### PR TITLE
Add gVisor sandbox backend with auto-detection for macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ docker compose up -d
 
 | Container | Image | Port | Purpose |
 |-----------|-------|------|---------|
-| `docker-sandbox-1` | Custom | 8180 | Firecracker microVM manager: isolated code execution with KVM |
+| `sandbox` | `Dockerfile.gvisor` | 8080 | gVisor sandbox (default, no KVM needed, ~230ms) |
+| `sandbox-firecracker` | `Dockerfile` | 8080 | Firecracker microVMs (Linux/KVM only, ~200ms) |
 
 ### Testing (`testing/docker-compose.yml`)
 
@@ -210,22 +211,33 @@ Without a duration lock, it's single-shot: one round, then done.
 
 ### `sp-firecracker-vm/` -- Sandbox Manager
 
+Auto-detecting sandbox with two backends behind one API:
+- **Linux (KVM available):** Firecracker microVMs — separate guest kernel per sandbox, snapshot-accelerated (~200ms)
+- **macOS / no KVM:** gVisor (Google's user-space kernel) — syscall interception via Sentry (~230ms)
+
+Detection is automatic: if `/dev/kvm` exists → Firecracker, otherwise → gVisor. The gateway and LLM see the same `POST /execute` API regardless of backend.
+
 ```
 sp-firecracker-vm/
-  sandbox_manager.py        # FastAPI orchestrator: create/execute/kill microVMs
+  sandbox_manager.py        # HTTP API: /health, /execute, /vms — delegates to executor
+  executor_base.py          # Abstract executor interface
+  executor_firecracker.py   # Firecracker backend (Linux/KVM)
+  executor_gvisor.py        # gVisor backend (macOS/anywhere)
+  Dockerfile                # Firecracker image (requires --device /dev/kvm)
+  Dockerfile.gvisor         # gVisor image (works everywhere, no KVM needed)
+  Dockerfile.sandbox        # Self-contained Firecracker (downloads kernel + builds rootfs)
+  Dockerfile.rootfs         # Python + data science rootfs builder
   rootfs/
-    sandbox_agent.py        # In-VM agent: receives + executes code
-    sandbox_init.py         # VM boot init process
+    sandbox_agent.py        # In-VM agent: receives + executes code (vsock mode)
+    sandbox_init.py         # VM boot init process (serial mode)
   scripts/
     build-rootfs.sh         # Build ext4 root filesystem image
     setup-linux.sh          # Linux host prerequisites
-    setup-macos.sh          # macOS setup (via Lima)
+    setup-macos.sh          # macOS setup + backend auto-detection
     setup-network.sh        # Bridge networking for VMs
   test/boot-vm.py           # VM boot test
-  Dockerfile                # Sandbox manager image
-  Dockerfile.sandbox        # Orchestrator (used by main compose)
-  Dockerfile.rootfs         # Root filesystem builder
-  signalpilot-sandbox.yml   # VM resource spec
+  signalpilot-sandbox.yml   # Sandbox configuration (local/cloud/container modes)
+  docker-compose.yml        # Profiles: default (gVisor), firecracker (KVM)
   windows-instructions.md   # WSL2/KVM setup guide
 ```
 

--- a/self-improve/Dockerfile.agent
+++ b/self-improve/Dockerfile.agent
@@ -35,6 +35,7 @@ RUN npx playwright install-deps chromium
 WORKDIR /app
 
 COPY agent/pyproject.toml /app/agent/pyproject.toml
+COPY agent/__init__.py /app/agent/__init__.py
 RUN pip install --no-cache-dir /app/agent/
 
 COPY agent/ /app/agent/

--- a/self-improve/Dockerfile.agent
+++ b/self-improve/Dockerfile.agent
@@ -32,16 +32,10 @@ RUN npm install -g @anthropic-ai/claude-code @playwright/mcp
 # Install Playwright browser system deps (as root for apt packages)
 RUN npx playwright install-deps chromium
 
-# Install Python dependencies
-RUN pip install --no-cache-dir \
-    claude-agent-sdk \
-    asyncpg==0.30.* \
-    httpx==0.28.* \
-    python-dotenv \
-    fastapi==0.115.* \
-    uvicorn[standard]==0.34.*
-
 WORKDIR /app
+
+COPY agent/pyproject.toml /app/agent/pyproject.toml
+RUN pip install --no-cache-dir /app/agent/
 
 COPY agent/ /app/agent/
 COPY playwright-mcp.sh /usr/local/bin/playwright-mcp

--- a/self-improve/Dockerfile.monitor
+++ b/self-improve/Dockerfile.monitor
@@ -20,6 +20,7 @@ WORKDIR /app
 
 # Python deps for the API backend
 COPY monitor/pyproject.toml /app/monitor/pyproject.toml
+COPY monitor/__init__.py /app/monitor/__init__.py
 RUN pip install --no-cache-dir /app/monitor/
 
 # Copy the FastAPI backend

--- a/self-improve/Dockerfile.monitor
+++ b/self-improve/Dockerfile.monitor
@@ -19,12 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && \
 WORKDIR /app
 
 # Python deps for the API backend
-RUN pip install --no-cache-dir \
-    fastapi==0.115.* \
-    uvicorn[standard]==0.34.* \
-    asyncpg==0.30.* \
-    pydantic==2.* \
-    httpx==0.28.*
+COPY monitor/pyproject.toml /app/monitor/pyproject.toml
+RUN pip install --no-cache-dir /app/monitor/
 
 # Copy the FastAPI backend
 COPY monitor/ /app/monitor/

--- a/self-improve/agent/pyproject.toml
+++ b/self-improve/agent/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "signalpilot-agent"
+version = "0.1.0"
+description = "SignalPilot self-improvement agent — CEO/Worker loop powered by Claude Agent SDK"
+requires-python = ">=3.12"
+dependencies = [
+    "claude-agent-sdk",
+    "asyncpg>=0.30.0",
+    "httpx>=0.28.0",
+    "python-dotenv",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/self-improve/monitor/pyproject.toml
+++ b/self-improve/monitor/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "signalpilot-monitor"
+version = "0.1.0"
+description = "SignalPilot monitor — FastAPI backend for agent run tracking and control"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "asyncpg>=0.30.0",
+    "pydantic>=2.0.0",
+    "httpx>=0.28.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/sp-firecracker-vm/Dockerfile
+++ b/sp-firecracker-vm/Dockerfile
@@ -48,15 +48,17 @@ COPY kernel/vmlinux.bin /opt/signalpilot/kernel/
 # Copy rootfs (Python sandbox environment as ext4 image)
 COPY rootfs/sandbox-rootfs.ext4 /opt/signalpilot/rootfs/
 
+# Install Python deps for sandbox manager
+COPY pyproject.toml /opt/signalpilot/
+RUN pip3 install --no-cache-dir /opt/signalpilot/
+
 # Copy sandbox manager
 COPY sandbox_manager.py /opt/signalpilot/
+COPY executor_base.py /opt/signalpilot/
+COPY executor_firecracker.py /opt/signalpilot/
+COPY executor_gvisor.py /opt/signalpilot/
 COPY scripts/setup-network.sh /opt/signalpilot/scripts/
 RUN chmod +x /opt/signalpilot/scripts/setup-network.sh
-
-# Install Python deps for sandbox manager
-RUN pip3 install --no-cache-dir \
-    aiohttp \
-    requests-unixsocket
 
 EXPOSE 8080
 

--- a/sp-firecracker-vm/Dockerfile.gvisor
+++ b/sp-firecracker-vm/Dockerfile.gvisor
@@ -25,12 +25,13 @@ RUN ARCH=$(uname -m) && \
 
 RUN mkdir -p /opt/signalpilot
 
+COPY pyproject.toml /opt/signalpilot/
+RUN pip install --no-cache-dir /opt/signalpilot/
+
 COPY executor_base.py /opt/signalpilot/
 COPY executor_gvisor.py /opt/signalpilot/
 COPY executor_firecracker.py /opt/signalpilot/
 COPY sandbox_manager.py /opt/signalpilot/
-
-RUN pip install --no-cache-dir aiohttp
 
 WORKDIR /opt/signalpilot
 

--- a/sp-firecracker-vm/Dockerfile.gvisor
+++ b/sp-firecracker-vm/Dockerfile.gvisor
@@ -1,0 +1,42 @@
+# SignalPilot Sandbox — gVisor backend (no KVM required)
+# Works on macOS (Apple Silicon), Linux, and CI environments.
+#
+# BUILD:
+#   docker build -f Dockerfile.gvisor -t signalpilot-sandbox-gvisor .
+#
+# RUN:
+#   docker run --privileged -p 8080:8080 signalpilot-sandbox-gvisor
+
+FROM python:3.12-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System deps (curl for healthcheck)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install gVisor (runsc) — auto-detect architecture
+RUN ARCH=$(uname -m) && \
+    curl -fsSL "https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}/runsc" \
+    -o /usr/local/bin/runsc && \
+    chmod +x /usr/local/bin/runsc
+
+RUN mkdir -p /opt/signalpilot
+
+COPY executor_base.py /opt/signalpilot/
+COPY executor_gvisor.py /opt/signalpilot/
+COPY executor_firecracker.py /opt/signalpilot/
+COPY sandbox_manager.py /opt/signalpilot/
+
+RUN pip install --no-cache-dir aiohttp
+
+WORKDIR /opt/signalpilot
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=3s \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["python3", "sandbox_manager.py"]

--- a/sp-firecracker-vm/Dockerfile.gvisor
+++ b/sp-firecracker-vm/Dockerfile.gvisor
@@ -5,11 +5,12 @@
 #   docker build -f Dockerfile.gvisor -t signalpilot-sandbox-gvisor .
 #
 # RUN:
-#   docker run --privileged -p 8080:8080 signalpilot-sandbox-gvisor
+#   docker run --cap-add SYS_PTRACE --cap-add SYS_ADMIN -p 8080:8080 signalpilot-sandbox-gvisor
 
 FROM python:3.12-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV GVISOR_VERSION=20260323.0
 
 # System deps (curl for healthcheck)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,9 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install gVisor (runsc) — auto-detect architecture
+# Install gVisor (runsc) — pinned version, auto-detect architecture
 RUN ARCH=$(uname -m) && \
-    curl -fsSL "https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}/runsc" \
+    curl -fsSL "https://storage.googleapis.com/gvisor/releases/release/${GVISOR_VERSION}/${ARCH}/runsc" \
     -o /usr/local/bin/runsc && \
     chmod +x /usr/local/bin/runsc
 

--- a/sp-firecracker-vm/docker-compose.yml
+++ b/sp-firecracker-vm/docker-compose.yml
@@ -1,19 +1,33 @@
-# SignalPilot Firecracker Sandbox — Local Mode
-#
-# Prerequisites:
-#   Linux:   /dev/kvm available (modprobe kvm)
-#   Win11:   .wslconfig → nestedVirtualization=true, restart WSL + Docker
-#   macOS:   Docker Desktop nested virtualization enabled
+# SignalPilot Sandbox — auto-detecting backend
 #
 # Usage:
-#   docker-compose up -d
+#   docker compose up -d
 #
-# The sandbox manager listens on :8080 for run_analysis requests from
-# the SignalPilot gateway. Each request spins up a Firecracker microVM,
-# executes Python code, and returns results.
+# On Linux with /dev/kvm:  Firecracker microVMs (snapshot-accelerated)
+# On macOS / no KVM:       gVisor user-space kernel sandbox
+#
+# Both serve the same API on :8080. The gateway doesn't need to know
+# which backend is running.
 
 services:
+  # ── gVisor backend (default, works everywhere) ──────────────────────
   sandbox:
+    build:
+      context: .
+      dockerfile: Dockerfile.gvisor
+    ports:
+      - "8080:8080"
+    privileged: true    # runsc needs ptrace + mount capabilities
+    environment:
+      - SP_MAX_VMS=10
+      - SP_VM_MEMORY_MB=512
+      - SP_VM_TIMEOUT_SEC=300
+      - SP_LOG_LEVEL=info
+    profiles: ["gvisor", "default"]
+    restart: unless-stopped
+
+  # ── Firecracker backend (Linux with KVM only) ──────────────────────
+  sandbox-firecracker:
     build:
       context: .
       dockerfile: Dockerfile
@@ -22,8 +36,8 @@ services:
     devices:
       - "/dev/kvm:/dev/kvm"
     cap_add:
-      - NET_ADMIN      # TAP device creation for VM networking
-      - SYS_ADMIN      # jailer needs this for cgroup management
+      - NET_ADMIN
+      - SYS_ADMIN
     environment:
       - SP_GATEWAY_URL=http://host.docker.internal:3100
       - SP_MAX_VMS=10
@@ -33,6 +47,7 @@ services:
       - SP_LOG_LEVEL=info
     volumes:
       - sandbox-overlays:/opt/signalpilot/overlays
+    profiles: ["firecracker"]
     restart: unless-stopped
 
 volumes:

--- a/sp-firecracker-vm/docker-compose.yml
+++ b/sp-firecracker-vm/docker-compose.yml
@@ -17,7 +17,11 @@ services:
       dockerfile: Dockerfile.gvisor
     ports:
       - "8080:8080"
-    privileged: true    # runsc needs ptrace + mount capabilities
+    cap_add:
+      - SYS_PTRACE      # runsc ptrace sandbox processes
+      - SYS_ADMIN        # runsc mount overlay filesystem
+    security_opt:
+      - apparmor:unconfined
     environment:
       - SP_MAX_VMS=10
       - SP_VM_MEMORY_MB=512

--- a/sp-firecracker-vm/executor_base.py
+++ b/sp-firecracker-vm/executor_base.py
@@ -8,9 +8,6 @@ sandbox manager can swap backends without changing the HTTP layer.
 import abc
 
 
-RESULT_KEYS = ("success", "output", "error", "exit_code", "vm_id", "execution_ms")
-
-
 class ExecutorBase(abc.ABC):
     """Contract every sandbox executor must fulfill."""
 

--- a/sp-firecracker-vm/executor_base.py
+++ b/sp-firecracker-vm/executor_base.py
@@ -1,0 +1,49 @@
+"""
+Abstract base for sandbox executors.
+
+All executors (Firecracker, gVisor) implement this interface so the
+sandbox manager can swap backends without changing the HTTP layer.
+"""
+
+import abc
+
+
+RESULT_KEYS = ("success", "output", "error", "exit_code", "vm_id", "execution_ms")
+
+
+class ExecutorBase(abc.ABC):
+    """Contract every sandbox executor must fulfill."""
+
+    @abc.abstractmethod
+    async def start(self) -> None:
+        """One-time initialization (snapshot creation, image pull, etc.)."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def execute(self, code: str, timeout: int) -> dict:
+        """Run untrusted code and return a result dict.
+
+        Required keys in the returned dict:
+            success      (bool)  — True if exit_code == 0
+            output       (str)   — captured stdout
+            error        (str|None) — captured stderr or error message
+            exit_code    (int)   — process exit code
+            vm_id        (str)   — unique execution identifier
+            execution_ms (float) — wall-clock time in milliseconds
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def health(self) -> dict:
+        """Return a JSON-serialisable health status dict."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def cleanup_vm(self, vm_id: str) -> None:
+        """Force-kill and clean up a specific execution."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def list_vms(self) -> list[dict]:
+        """Return list of currently active executions."""
+        raise NotImplementedError

--- a/sp-firecracker-vm/executor_firecracker.py
+++ b/sp-firecracker-vm/executor_firecracker.py
@@ -1,0 +1,462 @@
+"""
+Firecracker executor — snapshot-accelerated microVM execution.
+
+Used on Linux hosts where /dev/kvm is available. Boots a template VM once,
+snapshots it with Python pre-loaded, then restores from snapshot for each
+execution (~200ms vs ~1600ms cold boot).
+"""
+
+import asyncio
+import http.client
+import json
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import time
+import uuid
+
+from executor_base import ExecutorBase
+
+log = logging.getLogger("executor.firecracker")
+
+# ─── Paths ───────────────────────────────────────────────────────────────────
+
+KERNEL_PATH = "/opt/signalpilot/kernel/vmlinux.bin"
+BASE_ROOTFS_PATH = "/opt/signalpilot/rootfs/sandbox-rootfs.ext4"
+OVERLAYS_DIR = "/opt/signalpilot/overlays"
+SOCKETS_DIR = "/opt/signalpilot/sockets"
+SNAPSHOT_DIR = "/opt/signalpilot/snapshot"
+SNAP_FILE = os.path.join(SNAPSHOT_DIR, "vm.snap")
+MEM_FILE = os.path.join(SNAPSHOT_DIR, "vm.mem")
+
+
+# ─── Firecracker Unix-socket API helpers ─────────────────────────────────────
+
+class _UnixHTTPConnection(http.client.HTTPConnection):
+    """HTTP over a Unix domain socket (Firecracker API)."""
+
+    def __init__(self, socket_path: str):
+        super().__init__("localhost")
+        self._socket_path = socket_path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self._socket_path)
+
+
+def _fc_request(conn: _UnixHTTPConnection, method: str, path: str, body: dict) -> tuple[bool, str]:
+    """Send a PUT/PATCH to the Firecracker API. Returns (ok, response_body)."""
+    data = json.dumps(body)
+    conn.request(method, path, body=data, headers={"Content-Type": "application/json"})
+    resp = conn.getresponse()
+    resp_body = resp.read().decode()
+    if resp.status >= 300:
+        log.error("Firecracker API error: %s %s → %s %s", method, path, resp.status, resp_body)
+        return False, resp_body
+    return True, resp_body
+
+
+def _fc_put(conn, path, body):
+    return _fc_request(conn, "PUT", path, body)
+
+
+def _fc_patch(conn, path, body):
+    return _fc_request(conn, "PATCH", path, body)
+
+
+def _wait_for_socket(path: str, timeout: float = 5.0) -> bool:
+    """Block until a Unix socket file appears on disk."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+# ─── Executor ────────────────────────────────────────────────────────────────
+
+class FirecrackerExecutor(ExecutorBase):
+    """Firecracker microVM executor with snapshot acceleration."""
+
+    def __init__(self, max_vms: int, vm_memory_mb: int, vm_vcpus: int, vm_timeout_sec: int):
+        self._max_vms = max_vms
+        self._vm_memory_mb = vm_memory_mb
+        self._vm_vcpus = vm_vcpus
+        self._vm_timeout_sec = vm_timeout_sec
+        self._active_vms: dict[str, dict] = {}
+        self._snapshot_ready = False
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Create dirs and build snapshot."""
+        for d in (SNAPSHOT_DIR, OVERLAYS_DIR, SOCKETS_DIR):
+            os.makedirs(d, exist_ok=True)
+        self._create_snapshot()
+
+    def health(self) -> dict:
+        return {
+            "backend": "firecracker",
+            "kvm_available": os.path.exists("/dev/kvm"),
+            "snapshot_ready": self._snapshot_ready,
+            "active_vms": len(self._active_vms),
+            "max_vms": self._max_vms,
+        }
+
+    def cleanup_vm(self, vm_id: str) -> None:
+        vm = self._active_vms.pop(vm_id, None)
+        if vm is None:
+            return
+        proc = vm.get("process")
+        if proc and proc.poll() is None:
+            proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+        for key in ("socket_path", "overlay_path"):
+            path = vm.get(key)
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+        log.info("VM %s cleaned up", vm_id)
+
+    def list_vms(self) -> list[dict]:
+        now = time.time()
+        return [{"vm_id": k, "uptime_sec": now - v["started_at"]} for k, v in self._active_vms.items()]
+
+    # ── Snapshot creation (runs once at startup) ──────────────────────────
+
+    def _create_snapshot(self) -> None:
+        """Boot a template VM, wait for Python readiness, snapshot it."""
+        if os.path.exists(SNAP_FILE) and os.path.exists(MEM_FILE):
+            log.info("Existing snapshot found, reusing")
+            self._snapshot_ready = True
+            return
+
+        log.info("Creating template VM for snapshot...")
+        sock_path = os.path.join(SOCKETS_DIR, "template.sock")
+        log_path = "/tmp/fc_template.log"
+
+        for f in (sock_path, log_path):
+            if os.path.exists(f):
+                os.remove(f)
+        open(log_path, "w").close()
+
+        proc = subprocess.Popen(
+            ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path, "--level", "Info"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+
+        if not _wait_for_socket(sock_path):
+            log.error("Template Firecracker socket never appeared")
+            proc.kill()
+            return
+
+        conn = _UnixHTTPConnection(sock_path)
+
+        _fc_put(conn, "/boot-source", {
+            "kernel_image_path": KERNEL_PATH,
+            "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/init",
+        })
+        _fc_put(conn, "/drives/rootfs", {
+            "drive_id": "rootfs", "path_on_host": BASE_ROOTFS_PATH,
+            "is_root_device": True, "is_read_only": False,
+        })
+        _fc_put(conn, "/machine-config", {"vcpu_count": self._vm_vcpus, "mem_size_mib": self._vm_memory_mb})
+
+        start = time.monotonic()
+        ok, _ = _fc_put(conn, "/actions", {"action_type": "InstanceStart"})
+        if not ok:
+            log.error("Failed to boot template VM")
+            proc.kill()
+            return
+
+        log.info("Template VM booted in %.0fms, waiting for Python readiness...", (time.monotonic() - start) * 1000)
+
+        ready = self._wait_for_ready_marker(proc, timeout_sec=30)
+        if not ready:
+            log.error("Template VM never became ready")
+            proc.kill()
+            return
+
+        log.info("Template Python ready in %.0fms — creating snapshot", (time.monotonic() - start) * 1000)
+
+        ok, _ = _fc_patch(conn, "/vm", {"state": "Paused"})
+        if not ok:
+            log.error("Failed to pause template VM")
+            proc.kill()
+            return
+
+        ok, _ = _fc_put(conn, "/snapshot/create", {
+            "snapshot_type": "Full", "snapshot_path": SNAP_FILE, "mem_file_path": MEM_FILE,
+        })
+        if not ok:
+            log.error("Failed to create snapshot")
+            proc.kill()
+            return
+
+        log.info("Snapshot created: state=%.0fKB mem=%.1fMB",
+                 os.path.getsize(SNAP_FILE) / 1024, os.path.getsize(MEM_FILE) / (1024 * 1024))
+
+        proc.kill()
+        proc.wait()
+        if os.path.exists(sock_path):
+            os.remove(sock_path)
+
+        self._snapshot_ready = True
+        log.info("Snapshot ready — all subsequent executions will use restore")
+
+    def _wait_for_ready_marker(self, proc: subprocess.Popen, timeout_sec: int) -> bool:
+        """Read VM stdout until ===SP_READY=== appears."""
+        deadline = time.monotonic() + timeout_sec
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            if line.decode("utf-8", errors="replace").strip() == "===SP_READY===":
+                return True
+        return False
+
+    # ── Execution ────────────────────────────────────────────────────────
+
+    async def execute(self, code: str, timeout: int) -> dict:
+        if self._snapshot_ready:
+            return await self._execute_snapshot(code, timeout)
+        return await self._execute_cold(code, timeout)
+
+    async def _execute_snapshot(self, code: str, timeout: int) -> dict:
+        """Restore VM from snapshot, send code via serial, return result."""
+        if len(self._active_vms) >= self._max_vms:
+            raise RuntimeError(f"Max concurrent VMs ({self._max_vms}) reached")
+
+        vm_id = str(uuid.uuid4())[:8]
+        sock_path = os.path.join(SOCKETS_DIR, f"{vm_id}.sock")
+        log_path = f"/tmp/fc_{vm_id}.log"
+        overlay_path = os.path.join(OVERLAYS_DIR, f"{vm_id}.ext4")
+
+        shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
+        for f in (sock_path, log_path):
+            if os.path.exists(f):
+                os.remove(f)
+        open(log_path, "w").close()
+
+        start_time = time.monotonic()
+
+        proc = subprocess.Popen(
+            ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path,
+             "--level", "Info", "--id", vm_id],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        self._active_vms[vm_id] = {
+            "process": proc, "socket_path": sock_path,
+            "overlay_path": overlay_path, "started_at": time.time(),
+        }
+
+        try:
+            if not _wait_for_socket(sock_path):
+                raise RuntimeError("Firecracker socket never appeared")
+
+            conn = _UnixHTTPConnection(sock_path)
+
+            ok, err = _fc_put(conn, "/snapshot/load", {
+                "snapshot_path": SNAP_FILE,
+                "mem_backend": {"backend_path": MEM_FILE, "backend_type": "File"},
+                "enable_diff_snapshots": False,
+            })
+            if not ok:
+                raise RuntimeError(f"Snapshot load failed: {err}")
+
+            restore_ms = (time.monotonic() - start_time) * 1000
+
+            ok, err = _fc_patch(conn, "/vm", {"state": "Resumed"})
+            if not ok:
+                raise RuntimeError(f"Resume failed: {err}")
+
+            log.info("VM %s restored in %.0fms", vm_id, restore_ms)
+
+            payload = code + "\n===SP_CODE_END===\n"
+            try:
+                proc.stdin.write(payload.encode())
+                proc.stdin.flush()
+                proc.stdin.close()
+            except (BrokenPipeError, OSError):
+                pass
+
+            raw = await self._collect_output(proc, timeout)
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            return self._parse_serial_result(raw, vm_id, restore_ms, elapsed_ms)
+        finally:
+            self.cleanup_vm(vm_id)
+
+    async def _execute_cold(self, code: str, timeout: int) -> dict:
+        """Boot a fresh VM, inject code via rootfs, return result."""
+        if len(self._active_vms) >= self._max_vms:
+            raise RuntimeError(f"Max concurrent VMs ({self._max_vms}) reached")
+
+        vm_id = str(uuid.uuid4())[:8]
+        sock_path = os.path.join(SOCKETS_DIR, f"{vm_id}.sock")
+        log_path = f"/tmp/fc_{vm_id}.log"
+        overlay_path = os.path.join(OVERLAYS_DIR, f"{vm_id}.ext4")
+        start_time = time.monotonic()
+
+        shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
+        self._inject_code_into_rootfs(overlay_path, code)
+
+        open(log_path, "w").close()
+        proc = subprocess.Popen(
+            ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path,
+             "--level", "Info", "--id", vm_id],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        self._active_vms[vm_id] = {
+            "process": proc, "socket_path": sock_path,
+            "overlay_path": overlay_path, "started_at": time.time(),
+        }
+
+        try:
+            if not _wait_for_socket(sock_path):
+                raise RuntimeError("Firecracker socket never appeared")
+
+            conn = _UnixHTTPConnection(sock_path)
+            _fc_put(conn, "/boot-source", {
+                "kernel_image_path": KERNEL_PATH,
+                "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/init",
+            })
+            _fc_put(conn, "/drives/rootfs", {
+                "drive_id": "rootfs", "path_on_host": overlay_path,
+                "is_root_device": True, "is_read_only": False,
+            })
+            _fc_put(conn, "/machine-config", {"vcpu_count": self._vm_vcpus, "mem_size_mib": self._vm_memory_mb})
+
+            boot_start = time.monotonic()
+            _fc_put(conn, "/actions", {"action_type": "InstanceStart"})
+            boot_ms = (time.monotonic() - boot_start) * 1000
+
+            await self._wait_for_exit(proc, timeout)
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+
+            result = self._read_result_from_rootfs(overlay_path)
+            result["vm_id"] = vm_id
+            result["boot_ms"] = boot_ms
+            result["execution_ms"] = elapsed_ms
+            return result
+        finally:
+            self.cleanup_vm(vm_id)
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    async def _collect_output(self, proc: subprocess.Popen, timeout: int) -> str:
+        """Read all stdout from a Firecracker process."""
+        loop = asyncio.get_event_loop()
+
+        def _read():
+            try:
+                stdout_bytes = proc.stdout.read()
+                proc.wait(timeout=timeout)
+                return stdout_bytes.decode("utf-8", errors="replace")
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                return (proc.stdout.read() or b"").decode("utf-8", errors="replace")
+
+        try:
+            return await asyncio.wait_for(loop.run_in_executor(None, _read), timeout=timeout + 2)
+        except asyncio.TimeoutError:
+            return ""
+
+    def _parse_serial_result(self, raw: str, vm_id: str, restore_ms: float, elapsed_ms: float) -> dict:
+        """Extract JSON result from serial console output."""
+        raw_clean = raw.replace("\r\n", "\n")
+        if "===SP_RESULT_START===" in raw_clean and "===SP_RESULT_END===" in raw_clean:
+            result_json = raw_clean.split("===SP_RESULT_START===\n", 1)[1].split("\n===SP_RESULT_END===", 1)[0].strip()
+            try:
+                result = json.loads(result_json)
+                result["vm_id"] = vm_id
+                result["restore_ms"] = restore_ms
+                result["execution_ms"] = elapsed_ms
+                return result
+            except json.JSONDecodeError:
+                pass
+
+        return {
+            "success": False, "output": "", "error": "Execution timed out or produced no result",
+            "exit_code": -1, "vm_id": vm_id, "restore_ms": restore_ms, "execution_ms": elapsed_ms,
+        }
+
+    def _inject_code_into_rootfs(self, overlay_path: str, code: str) -> None:
+        """Mount rootfs overlay, write code + init script, unmount."""
+        mount_dir = f"/tmp/mount_{uuid.uuid4().hex[:8]}"
+        os.makedirs(mount_dir, exist_ok=True)
+        try:
+            subprocess.run(["mount", "-o", "loop", overlay_path, mount_dir], check=True, capture_output=True)
+            os.makedirs(os.path.join(mount_dir, "tmp", "output"), exist_ok=True)
+            with open(os.path.join(mount_dir, "tmp", "user_code.py"), "w") as f:
+                f.write(code)
+            init_script = (
+                "#!/bin/sh\n"
+                "mount -t proc proc /proc 2>/dev/null\n"
+                "mount -t sysfs sysfs /sys 2>/dev/null\n"
+                "mount -t devtmpfs devtmpfs /dev 2>/dev/null\n"
+                "/usr/bin/python3 /tmp/user_code.py > /tmp/output/stdout.txt 2> /tmp/output/stderr.txt\n"
+                "echo $? > /tmp/output/exit_code.txt\n"
+                "sync\n"
+                "/bin/busybox reboot -f\n"
+            )
+            init_path = os.path.join(mount_dir, "init")
+            with open(init_path, "w") as f:
+                f.write(init_script)
+            os.chmod(init_path, 0o755)
+        finally:
+            subprocess.run(["umount", mount_dir], check=False, capture_output=True)
+            try:
+                os.rmdir(mount_dir)
+            except OSError:
+                pass
+
+    def _read_result_from_rootfs(self, overlay_path: str) -> dict:
+        """Mount overlay read-only and extract execution results."""
+        mount_dir = f"/tmp/read_{uuid.uuid4().hex[:8]}"
+        os.makedirs(mount_dir, exist_ok=True)
+        stdout = stderr = ""
+        exit_code = -1
+        try:
+            subprocess.run(["mount", "-o", "loop,ro", overlay_path, mount_dir], check=True, capture_output=True)
+            out_dir = os.path.join(mount_dir, "tmp", "output")
+            for name, target in (("stdout.txt", "stdout"), ("stderr.txt", "stderr"), ("exit_code.txt", "exit_code")):
+                path = os.path.join(out_dir, name)
+                if not os.path.exists(path):
+                    continue
+                val = open(path).read()
+                if target == "stdout":
+                    stdout = val.rstrip()
+                elif target == "stderr":
+                    stderr = val.rstrip()
+                elif target == "exit_code":
+                    try:
+                        exit_code = int(val.strip())
+                    except ValueError:
+                        pass
+        finally:
+            subprocess.run(["umount", mount_dir], check=False, capture_output=True)
+            try:
+                os.rmdir(mount_dir)
+            except OSError:
+                pass
+
+        return {"success": exit_code == 0, "output": stdout, "error": stderr or None, "exit_code": exit_code}
+
+    async def _wait_for_exit(self, proc: subprocess.Popen, timeout: int) -> None:
+        """Wait for Firecracker process to exit within timeout."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                return
+            await asyncio.sleep(0.1)
+        proc.kill()
+        proc.wait()

--- a/sp-firecracker-vm/executor_firecracker.py
+++ b/sp-firecracker-vm/executor_firecracker.py
@@ -11,6 +11,7 @@ import http.client
 import json
 import logging
 import os
+import pathlib
 import shutil
 import socket
 import subprocess
@@ -146,7 +147,7 @@ class FirecrackerExecutor(ExecutorBase):
         for f in (sock_path, log_path):
             if os.path.exists(f):
                 os.remove(f)
-        open(log_path, "w").close()
+        pathlib.Path(log_path).touch()
 
         proc = subprocess.Popen(
             ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path, "--level", "Info"],
@@ -244,7 +245,7 @@ class FirecrackerExecutor(ExecutorBase):
         for f in (sock_path, log_path):
             if os.path.exists(f):
                 os.remove(f)
-        open(log_path, "w").close()
+        pathlib.Path(log_path).touch()
 
         start_time = time.monotonic()
 
@@ -308,7 +309,7 @@ class FirecrackerExecutor(ExecutorBase):
         shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
         self._inject_code_into_rootfs(overlay_path, code)
 
-        open(log_path, "w").close()
+        pathlib.Path(log_path).touch()
         proc = subprocess.Popen(
             ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path,
              "--level", "Info", "--id", vm_id],
@@ -353,7 +354,7 @@ class FirecrackerExecutor(ExecutorBase):
 
     async def _collect_output(self, proc: subprocess.Popen, timeout: int) -> str:
         """Read all stdout from a Firecracker process."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def _read():
             try:

--- a/sp-firecracker-vm/executor_gvisor.py
+++ b/sp-firecracker-vm/executor_gvisor.py
@@ -24,7 +24,10 @@ log = logging.getLogger("executor.gvisor")
 RUNSC_PATH = "/usr/local/bin/runsc"
 PYTHON_PATH = os.getenv("SP_PYTHON_PATH", "/usr/local/bin/python3")
 
-# Matches the result format from rootfs/sandbox_init.py
+# Wrapper that executes user code and captures output as JSON.
+# User code is injected via json.dumps() which escapes all special chars,
+# then exec()'d inside gVisor's sandboxed kernel — no host access even if
+# the escaping were bypassed.
 _WRAPPER_TEMPLATE = '''
 import io, json, sys, traceback
 
@@ -61,17 +64,28 @@ print(result)
 class GVisorExecutor(ExecutorBase):
     """gVisor sandbox executor using runsc standalone mode."""
 
-    def __init__(self, max_sandboxes: int, memory_limit_mb: int, timeout_sec: int):
+    def __init__(self, max_sandboxes: int, timeout_sec: int):
         self._max_sandboxes = max_sandboxes
-        self._memory_limit_mb = memory_limit_mb
         self._timeout_sec = timeout_sec
         self._active: dict[str, dict] = {}
 
     async def start(self) -> None:
-        """Verify runsc binary is available."""
+        """Verify runsc binary is available and clean orphan temp dirs."""
         if not os.path.exists(RUNSC_PATH):
             raise RuntimeError(f"gVisor binary not found at {RUNSC_PATH}")
+        self._cleanup_orphan_temps()
         log.info("gVisor executor ready (runsc at %s)", RUNSC_PATH)
+
+    def _cleanup_orphan_temps(self) -> None:
+        """Remove leftover /tmp/sp_gvisor_* dirs from prior crashes."""
+        import glob
+        for path in glob.glob("/tmp/sp_gvisor_*"):
+            try:
+                for f in os.listdir(path):
+                    os.remove(os.path.join(path, f))
+                os.rmdir(path)
+            except OSError:
+                pass
 
     def health(self) -> dict:
         return {

--- a/sp-firecracker-vm/executor_gvisor.py
+++ b/sp-firecracker-vm/executor_gvisor.py
@@ -1,0 +1,175 @@
+"""
+gVisor executor — user-space kernel sandbox via runsc.
+
+Used on hosts without /dev/kvm (macOS Docker Desktop, CI, etc.).
+Runs untrusted code inside a gVisor sandbox using `runsc do`, which
+intercepts all syscalls through a user-space kernel (Sentry). No VM
+boot required — startup is near-instant (~50ms).
+
+gVisor is downloaded once at container build time (Dockerfile.gvisor).
+"""
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+
+from executor_base import ExecutorBase
+
+log = logging.getLogger("executor.gvisor")
+
+RUNSC_PATH = "/usr/local/bin/runsc"
+PYTHON_PATH = os.getenv("SP_PYTHON_PATH", "/usr/local/bin/python3")
+
+# Matches the result format from rootfs/sandbox_init.py
+_WRAPPER_TEMPLATE = '''
+import io, json, sys, traceback
+
+code = {code_json}
+
+stdout_buf = io.StringIO()
+stderr_buf = io.StringIO()
+old_out, old_err = sys.stdout, sys.stderr
+exit_code = 0
+
+try:
+    sys.stdout = stdout_buf
+    sys.stderr = stderr_buf
+    exec(compile(code, "<sandbox>", "exec"), {{"__builtins__": __builtins__}})
+except SystemExit as e:
+    exit_code = e.code if isinstance(e.code, int) else 1
+except Exception:
+    exit_code = 1
+    traceback.print_exc(file=stderr_buf)
+finally:
+    sys.stdout = old_out
+    sys.stderr = old_err
+
+result = json.dumps({{
+    "success": exit_code == 0,
+    "output": stdout_buf.getvalue(),
+    "error": stderr_buf.getvalue() or None,
+    "exit_code": exit_code,
+}})
+print(result)
+'''
+
+
+class GVisorExecutor(ExecutorBase):
+    """gVisor sandbox executor using runsc standalone mode."""
+
+    def __init__(self, max_sandboxes: int, memory_limit_mb: int, timeout_sec: int):
+        self._max_sandboxes = max_sandboxes
+        self._memory_limit_mb = memory_limit_mb
+        self._timeout_sec = timeout_sec
+        self._active: dict[str, dict] = {}
+
+    async def start(self) -> None:
+        """Verify runsc binary is available."""
+        if not os.path.exists(RUNSC_PATH):
+            raise RuntimeError(f"gVisor binary not found at {RUNSC_PATH}")
+        log.info("gVisor executor ready (runsc at %s)", RUNSC_PATH)
+
+    def health(self) -> dict:
+        return {
+            "backend": "gvisor",
+            "runsc_available": os.path.exists(RUNSC_PATH),
+            "active_sandboxes": len(self._active),
+            "max_sandboxes": self._max_sandboxes,
+        }
+
+    def cleanup_vm(self, vm_id: str) -> None:
+        entry = self._active.pop(vm_id, None)
+        if entry is None:
+            return
+        proc = entry.get("process")
+        if proc and proc.returncode is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+        log.info("Sandbox %s cleaned up", vm_id)
+
+    def list_vms(self) -> list[dict]:
+        now = time.time()
+        return [{"vm_id": k, "uptime_sec": now - v["started_at"]} for k, v in self._active.items()]
+
+    async def execute(self, code: str, timeout: int) -> dict:
+        """Run code inside a gVisor sandbox via `runsc do`."""
+        if len(self._active) >= self._max_sandboxes:
+            raise RuntimeError(f"Max concurrent sandboxes ({self._max_sandboxes}) reached")
+
+        vm_id = str(uuid.uuid4())[:8]
+        start_time = time.monotonic()
+
+        wrapper_code = _WRAPPER_TEMPLATE.format(code_json=json.dumps(code))
+
+        tmp_dir = tempfile.mkdtemp(prefix=f"sp_gvisor_{vm_id}_")
+        script_path = os.path.join(tmp_dir, "run.py")
+        with open(script_path, "w") as f:
+            f.write(wrapper_code)
+
+        cmd = [
+            RUNSC_PATH,
+            "-ignore-cgroups",
+            "do",
+            "-quiet",
+            "--",
+            PYTHON_PATH, script_path,
+        ]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            self._active[vm_id] = {"process": proc, "started_at": time.time(), "tmp_dir": tmp_dir}
+
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return self._timeout_result(vm_id, start_time)
+
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            return self._parse_result(stdout_bytes, stderr_bytes, vm_id, elapsed_ms)
+        finally:
+            self._active.pop(vm_id, None)
+            self._cleanup_tmp(tmp_dir)
+
+    def _parse_result(self, stdout_bytes: bytes, stderr_bytes: bytes, vm_id: str, elapsed_ms: float) -> dict:
+        """Parse JSON result from the wrapper script's stdout."""
+        stdout = stdout_bytes.decode("utf-8", errors="replace").strip()
+        stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+
+        try:
+            result = json.loads(stdout)
+            result["vm_id"] = vm_id
+            result["execution_ms"] = elapsed_ms
+            return result
+        except (json.JSONDecodeError, KeyError):
+            return {
+                "success": False, "output": stdout, "error": stderr or "Failed to parse result",
+                "exit_code": -1, "vm_id": vm_id, "execution_ms": elapsed_ms,
+            }
+
+    def _timeout_result(self, vm_id: str, start_time: float) -> dict:
+        """Build a result dict for a timed-out execution."""
+        return {
+            "success": False, "output": "", "error": "Execution timed out",
+            "exit_code": -1, "vm_id": vm_id, "execution_ms": (time.monotonic() - start_time) * 1000,
+        }
+
+    def _cleanup_tmp(self, tmp_dir: str) -> None:
+        """Remove the temporary script directory."""
+        try:
+            for f in os.listdir(tmp_dir):
+                os.remove(os.path.join(tmp_dir, f))
+            os.rmdir(tmp_dir)
+        except OSError:
+            pass

--- a/sp-firecracker-vm/executor_gvisor.py
+++ b/sp-firecracker-vm/executor_gvisor.py
@@ -50,8 +50,8 @@ finally:
 
 result = json.dumps({{
     "success": exit_code == 0,
-    "output": stdout_buf.getvalue(),
-    "error": stderr_buf.getvalue() or None,
+    "output": stdout_buf.getvalue().rstrip("\\n"),
+    "error": stderr_buf.getvalue().rstrip("\\n") or None,
     "exit_code": exit_code,
 }})
 print(result)

--- a/sp-firecracker-vm/pyproject.toml
+++ b/sp-firecracker-vm/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "signalpilot-sandbox"
+version = "0.1.0"
+description = "SignalPilot sandbox manager — Firecracker (Linux) and gVisor (macOS) code execution"
+requires-python = ">=3.12"
+dependencies = [
+    "aiohttp>=3.9.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/sp-firecracker-vm/sandbox_manager.py
+++ b/sp-firecracker-vm/sandbox_manager.py
@@ -1,494 +1,61 @@
 """
-SignalPilot Sandbox Manager — Snapshot-accelerated Firecracker execution
+SignalPilot Sandbox Manager — unified HTTP API for code execution.
 
-Performance model:
-  Cold boot:  ~1600ms (kernel + Python startup + exec + shutdown)
-  Snapshot:   ~200ms  (restore + exec + shutdown)
+Auto-detects the best available backend:
+  - /dev/kvm present → Firecracker microVMs (snapshot-accelerated, ~200ms)
+  - No /dev/kvm      → gVisor sandbox (user-space kernel, ~50ms)
 
-At startup, we boot a template VM, wait for Python to fully load,
-snapshot it, then kill the template. Every subsequent execution restores
-from the snapshot — skipping kernel boot and Python interpreter startup.
-
-Communication: serial console (stdin/stdout of the Firecracker process).
-The VM's init (sandbox_init.py) reads code from stdin, executes, writes
-JSON result to stdout, then reboots.
+Both backends implement ExecutorBase, so the HTTP layer is identical
+regardless of which backend is active.
 """
 
 import asyncio
-import json
 import logging
 import os
-import shutil
-import subprocess
-import time
-import uuid
 
 from aiohttp import web
 
+from executor_base import ExecutorBase
+
 # ─── Configuration ───────────────────────────────────────────────────────────
 
-GATEWAY_URL = os.getenv("SP_GATEWAY_URL", "http://host.docker.internal:3100")
 MAX_VMS = int(os.getenv("SP_MAX_VMS", "10"))
 VM_MEMORY_MB = int(os.getenv("SP_VM_MEMORY_MB", "512"))
 VM_VCPUS = int(os.getenv("SP_VM_VCPUS", "1"))
 VM_TIMEOUT_SEC = int(os.getenv("SP_VM_TIMEOUT_SEC", "300"))
 LOG_LEVEL = os.getenv("SP_LOG_LEVEL", "info").upper()
 
-KERNEL_PATH = "/opt/signalpilot/kernel/vmlinux.bin"
-BASE_ROOTFS_PATH = "/opt/signalpilot/rootfs/sandbox-rootfs.ext4"
-OVERLAYS_DIR = "/opt/signalpilot/overlays"
-SOCKETS_DIR = "/opt/signalpilot/sockets"
-SNAPSHOT_DIR = "/opt/signalpilot/snapshot"
-
 logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 log = logging.getLogger("sandbox_manager")
 
-active_vms: dict[str, dict] = {}
 
-# Snapshot state
-snapshot_ready = False
-SNAP_FILE = os.path.join(SNAPSHOT_DIR, "vm.snap")
-MEM_FILE = os.path.join(SNAPSHOT_DIR, "vm.mem")
+# ─── Backend detection ───────────────────────────────────────────────────────
 
-# ─── Firecracker API helpers ─────────────────────────────────────────────────
+def _detect_executor() -> ExecutorBase:
+    """Pick the best executor for this environment."""
+    if os.path.exists("/dev/kvm"):
+        from executor_firecracker import FirecrackerExecutor
+        log.info("KVM detected — using Firecracker backend")
+        return FirecrackerExecutor(MAX_VMS, VM_MEMORY_MB, VM_VCPUS, VM_TIMEOUT_SEC)
 
-import http.client
-import socket
+    from executor_gvisor import GVisorExecutor
+    log.info("No KVM — using gVisor backend")
+    return GVisorExecutor(MAX_VMS, VM_MEMORY_MB, VM_TIMEOUT_SEC)
 
 
-class UnixHTTPConnection(http.client.HTTPConnection):
-    def __init__(self, socket_path):
-        super().__init__("localhost")
-        self.socket_path = socket_path
+# ─── HTTP handlers ───────────────────────────────────────────────────────────
 
-    def connect(self):
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.sock.connect(self.socket_path)
+async def handle_health(request: web.Request) -> web.Response:
+    executor: ExecutorBase = request.app["executor"]
+    status = executor.health()
+    status["status"] = "healthy"
+    return web.json_response(status)
 
 
-def fc_put(conn, path, body):
-    data = json.dumps(body)
-    conn.request("PUT", path, body=data, headers={"Content-Type": "application/json"})
-    resp = conn.getresponse()
-    resp_body = resp.read().decode()
-    if resp.status >= 300:
-        log.error(f"Firecracker API error: PUT {path} → {resp.status} {resp_body}")
-        return False, resp_body
-    return True, resp_body
-
-
-def fc_patch(conn, path, body):
-    data = json.dumps(body)
-    conn.request("PATCH", path, body=data, headers={"Content-Type": "application/json"})
-    resp = conn.getresponse()
-    resp_body = resp.read().decode()
-    if resp.status >= 300:
-        log.error(f"Firecracker API error: PATCH {path} → {resp.status} {resp_body}")
-        return False, resp_body
-    return True, resp_body
-
-
-def wait_for_socket(path, timeout=5.0):
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if os.path.exists(path):
-            return True
-        time.sleep(0.02)
-    return False
-
-
-# ─── Snapshot creation (runs once at startup) ────────────────────────────────
-
-def create_snapshot():
-    """Boot a template VM, wait for Python readiness, snapshot it."""
-    global snapshot_ready
-
-    os.makedirs(SNAPSHOT_DIR, exist_ok=True)
-    os.makedirs(OVERLAYS_DIR, exist_ok=True)
-    os.makedirs(SOCKETS_DIR, exist_ok=True)
-
-    # If snapshot already exists, reuse it
-    if os.path.exists(SNAP_FILE) and os.path.exists(MEM_FILE):
-        log.info("Existing snapshot found, reusing")
-        snapshot_ready = True
-        return
-
-    log.info("Creating template VM for snapshot...")
-    sock_path = os.path.join(SOCKETS_DIR, "template.sock")
-    log_path = "/tmp/fc_template.log"
-
-    # Clean up
-    for f in [sock_path, log_path]:
-        if os.path.exists(f):
-            os.remove(f)
-    open(log_path, "w").close()
-
-    # Start Firecracker
-    proc = subprocess.Popen(
-        ["/usr/local/bin/firecracker",
-         "--api-sock", sock_path,
-         "--log-path", log_path,
-         "--level", "Info"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    if not wait_for_socket(sock_path):
-        log.error("Template Firecracker socket never appeared")
-        proc.kill()
-        return
-
-    conn = UnixHTTPConnection(sock_path)
-
-    # Configure and boot
-    fc_put(conn, "/boot-source", {
-        "kernel_image_path": KERNEL_PATH,
-        "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/init",
-    })
-    fc_put(conn, "/drives/rootfs", {
-        "drive_id": "rootfs",
-        "path_on_host": BASE_ROOTFS_PATH,
-        "is_root_device": True,
-        "is_read_only": False,
-    })
-    fc_put(conn, "/machine-config", {
-        "vcpu_count": VM_VCPUS,
-        "mem_size_mib": VM_MEMORY_MB,
-    })
-
-    start = time.monotonic()
-    ok, _ = fc_put(conn, "/actions", {"action_type": "InstanceStart"})
-    if not ok:
-        log.error("Failed to boot template VM")
-        proc.kill()
-        return
-
-    boot_ms = (time.monotonic() - start) * 1000
-    log.info(f"Template VM booted in {boot_ms:.0f}ms, waiting for Python readiness...")
-
-    # Read stdout until we see READY marker
-    # This means Python has started and pre-imported all modules
-    deadline = time.monotonic() + 30
-    ready = False
-    while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            break
-        text = line.decode("utf-8", errors="replace").strip()
-        if text == "===SP_READY===":
-            ready = True
-            break
-
-    if not ready:
-        log.error("Template VM never became ready")
-        proc.kill()
-        return
-
-    ready_ms = (time.monotonic() - start) * 1000
-    log.info(f"Template Python ready in {ready_ms:.0f}ms — creating snapshot")
-
-    # Pause VM
-    ok, _ = fc_patch(conn, "/vm", {"state": "Paused"})
-    if not ok:
-        log.error("Failed to pause template VM")
-        proc.kill()
-        return
-
-    # Create snapshot
-    ok, _ = fc_put(conn, "/snapshot/create", {
-        "snapshot_type": "Full",
-        "snapshot_path": SNAP_FILE,
-        "mem_file_path": MEM_FILE,
-    })
-    if not ok:
-        log.error("Failed to create snapshot")
-        proc.kill()
-        return
-
-    snap_size = os.path.getsize(SNAP_FILE) / 1024
-    mem_size = os.path.getsize(MEM_FILE) / (1024 * 1024)
-    log.info(f"Snapshot created: state={snap_size:.0f}KB mem={mem_size:.1f}MB")
-
-    # Kill template
-    proc.kill()
-    proc.wait()
-    if os.path.exists(sock_path):
-        os.remove(sock_path)
-
-    snapshot_ready = True
-    log.info("Snapshot ready — all subsequent executions will use restore")
-
-
-# ─── Execution (restore from snapshot) ───────────────────────────────────────
-
-def cleanup_vm(vm_id: str):
-    vm = active_vms.pop(vm_id, None)
-    if vm is None:
-        return
-    proc = vm.get("process")
-    if proc and proc.poll() is None:
-        proc.kill()
-        try:
-            proc.wait(timeout=5)
-        except Exception:
-            pass
-    for key in ("socket_path", "overlay_path"):
-        path = vm.get(key)
-        if path and os.path.exists(path):
-            try:
-                os.remove(path)
-            except OSError:
-                pass
-    log.info(f"VM {vm_id} cleaned up")
-
-
-async def execute_code_snapshot(code: str, timeout: int = 30) -> dict:
-    """Restore VM from snapshot, send code via serial, return result."""
-    if len(active_vms) >= MAX_VMS:
-        raise RuntimeError(f"Max concurrent VMs ({MAX_VMS}) reached")
-
-    vm_id = str(uuid.uuid4())[:8]
-    sock_path = os.path.join(SOCKETS_DIR, f"{vm_id}.sock")
-    log_path = f"/tmp/fc_{vm_id}.log"
-
-    # Copy the base rootfs as overlay (snapshot restore needs its own drive copy)
-    overlay_path = os.path.join(OVERLAYS_DIR, f"{vm_id}.ext4")
-    shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
-
-    # Clean up old socket/log
-    for f in [sock_path, log_path]:
-        if os.path.exists(f):
-            os.remove(f)
-    open(log_path, "w").close()
-
-    start_time = time.monotonic()
-
-    # Start Firecracker (no boot — we'll load a snapshot)
-    proc = subprocess.Popen(
-        ["/usr/local/bin/firecracker",
-         "--api-sock", sock_path,
-         "--log-path", log_path,
-         "--level", "Info",
-         "--id", vm_id],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    active_vms[vm_id] = {
-        "process": proc,
-        "socket_path": sock_path,
-        "overlay_path": overlay_path,
-        "started_at": time.time(),
-    }
-
-    try:
-        if not wait_for_socket(sock_path):
-            raise RuntimeError("Firecracker socket never appeared")
-
-        conn = UnixHTTPConnection(sock_path)
-
-        # Load snapshot
-        ok, err = fc_put(conn, "/snapshot/load", {
-            "snapshot_path": SNAP_FILE,
-            "mem_backend": {
-                "backend_path": MEM_FILE,
-                "backend_type": "File",
-            },
-            "enable_diff_snapshots": False,
-        })
-        if not ok:
-            raise RuntimeError(f"Snapshot load failed: {err}")
-
-        restore_ms = (time.monotonic() - start_time) * 1000
-
-        # Resume VM — Python resumes reading from stdin
-        ok, err = fc_patch(conn, "/vm", {"state": "Resumed"})
-        if not ok:
-            raise RuntimeError(f"Resume failed: {err}")
-
-        resume_ms = (time.monotonic() - start_time) * 1000
-        log.info(f"VM {vm_id} restored in {restore_ms:.0f}ms, resumed at {resume_ms:.0f}ms")
-
-        # Send code via stdin (serial console), then close stdin
-        payload = code + "\n===SP_CODE_END===\n"
-        try:
-            proc.stdin.write(payload.encode())
-            proc.stdin.flush()
-            proc.stdin.close()
-        except (BrokenPipeError, OSError):
-            pass  # VM may have exited already
-
-        # Wait for process to exit and collect all stdout
-        loop = asyncio.get_event_loop()
-        result_json = None
-
-        def collect_output():
-            try:
-                stdout_bytes = proc.stdout.read()
-                proc.wait(timeout=timeout)
-                return stdout_bytes.decode("utf-8", errors="replace")
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-                return (proc.stdout.read() or b"").decode("utf-8", errors="replace")
-
-        try:
-            raw = await asyncio.wait_for(
-                loop.run_in_executor(None, collect_output),
-                timeout=timeout + 2,
-            )
-            # Parse result markers from serial output (serial uses \r\n)
-            raw_clean = raw.replace("\r\n", "\n")
-            if "===SP_RESULT_START===" in raw_clean and "===SP_RESULT_END===" in raw_clean:
-                result_json = raw_clean.split("===SP_RESULT_START===\n", 1)[1].split("\n===SP_RESULT_END===", 1)[0].strip()
-        except asyncio.TimeoutError:
-            pass
-
-        elapsed_ms = (time.monotonic() - start_time) * 1000
-
-        if result_json:
-            try:
-                result = json.loads(result_json)
-                result["vm_id"] = vm_id
-                result["restore_ms"] = restore_ms
-                result["execution_ms"] = elapsed_ms
-                return result
-            except json.JSONDecodeError:
-                pass
-
-        return {
-            "success": False,
-            "output": "",
-            "error": "Execution timed out or produced no result",
-            "exit_code": -1,
-            "vm_id": vm_id,
-            "restore_ms": restore_ms,
-            "execution_ms": elapsed_ms,
-        }
-
-    finally:
-        cleanup_vm(vm_id)
-
-
-# ─── Fallback: cold boot execution (used if snapshot not available) ──────────
-
-async def execute_code_cold(code: str, session_token: str, timeout: int = 30) -> dict:
-    """Boot a fresh VM, inject code via rootfs, return result."""
-    if len(active_vms) >= MAX_VMS:
-        raise RuntimeError(f"Max concurrent VMs ({MAX_VMS}) reached")
-
-    vm_id = str(uuid.uuid4())[:8]
-    sock_path = os.path.join(SOCKETS_DIR, f"{vm_id}.sock")
-    log_path = f"/tmp/fc_{vm_id}.log"
-    overlay_path = os.path.join(OVERLAYS_DIR, f"{vm_id}.ext4")
-
-    start_time = time.monotonic()
-
-    # Copy rootfs and inject code
-    shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
-    mount_dir = f"/tmp/mount_{vm_id}"
-    os.makedirs(mount_dir, exist_ok=True)
-    try:
-        subprocess.run(["mount", "-o", "loop", overlay_path, mount_dir], check=True, capture_output=True)
-        os.makedirs(os.path.join(mount_dir, "tmp", "output"), exist_ok=True)
-        with open(os.path.join(mount_dir, "tmp", "user_code.py"), "w") as f:
-            f.write(code)
-        init_script = """#!/bin/sh
-mount -t proc proc /proc 2>/dev/null
-mount -t sysfs sysfs /sys 2>/dev/null
-mount -t devtmpfs devtmpfs /dev 2>/dev/null
-/usr/bin/python3 /tmp/user_code.py > /tmp/output/stdout.txt 2> /tmp/output/stderr.txt
-echo $? > /tmp/output/exit_code.txt
-sync
-/bin/busybox reboot -f
-"""
-        with open(os.path.join(mount_dir, "init"), "w") as f:
-            f.write(init_script)
-        os.chmod(os.path.join(mount_dir, "init"), 0o755)
-    finally:
-        subprocess.run(["umount", mount_dir], check=False, capture_output=True)
-        try:
-            os.rmdir(mount_dir)
-        except OSError:
-            pass
-
-    open(log_path, "w").close()
-    proc = subprocess.Popen(
-        ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path, "--level", "Info", "--id", vm_id],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-    )
-    active_vms[vm_id] = {"process": proc, "socket_path": sock_path, "overlay_path": overlay_path, "started_at": time.time()}
-
-    try:
-        if not wait_for_socket(sock_path):
-            raise RuntimeError("Firecracker socket never appeared")
-        conn = UnixHTTPConnection(sock_path)
-        fc_put(conn, "/boot-source", {"kernel_image_path": KERNEL_PATH, "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/init"})
-        fc_put(conn, "/drives/rootfs", {"drive_id": "rootfs", "path_on_host": overlay_path, "is_root_device": True, "is_read_only": False})
-        fc_put(conn, "/machine-config", {"vcpu_count": VM_VCPUS, "mem_size_mib": VM_MEMORY_MB})
-        boot_start = time.monotonic()
-        fc_put(conn, "/actions", {"action_type": "InstanceStart"})
-        boot_ms = (time.monotonic() - boot_start) * 1000
-
-        # Wait for exit
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                break
-            await asyncio.sleep(0.1)
-        else:
-            proc.kill()
-            proc.wait()
-
-        elapsed_ms = (time.monotonic() - start_time) * 1000
-
-        # Ensure process is dead
-        if proc.poll() is None:
-            proc.kill()
-            proc.wait()
-
-        # Read output from overlay
-        mount_dir = f"/tmp/read_{vm_id}"
-        os.makedirs(mount_dir, exist_ok=True)
-        stdout = stderr = ""
-        exit_code = -1
-        try:
-            subprocess.run(["mount", "-o", "loop", overlay_path, mount_dir], check=True, capture_output=True)
-            for name, target in [("stdout.txt", "stdout"), ("stderr.txt", "stderr"), ("exit_code.txt", "exit_code")]:
-                path = os.path.join(mount_dir, "tmp", "output", name)
-                if os.path.exists(path):
-                    val = open(path).read()
-                    if target == "stdout": stdout = val.rstrip()
-                    elif target == "stderr": stderr = val.rstrip()
-                    elif target == "exit_code":
-                        try: exit_code = int(val.strip())
-                        except ValueError: pass
-        finally:
-            subprocess.run(["umount", mount_dir], check=False, capture_output=True)
-            try: os.rmdir(mount_dir)
-            except OSError: pass
-
-        return {"success": exit_code == 0, "output": stdout, "error": stderr or None, "exit_code": exit_code, "vm_id": vm_id, "boot_ms": boot_ms, "execution_ms": elapsed_ms}
-    finally:
-        cleanup_vm(vm_id)
-
-
-# ─── HTTP API ────────────────────────────────────────────────────────────────
-
-async def handle_health(request):
-    return web.json_response({
-        "status": "healthy" if os.path.exists("/dev/kvm") else "degraded",
-        "kvm_available": os.path.exists("/dev/kvm"),
-        "active_vms": len(active_vms),
-        "max_vms": MAX_VMS,
-        "snapshot_ready": snapshot_ready,
-    })
-
-
-async def handle_execute(request):
+async def handle_execute(request: web.Request) -> web.Response:
+    executor: ExecutorBase = request.app["executor"]
     body = await request.json()
+
     code = body.get("code")
     if not code:
         return web.json_response({"error": "code is required"}, status=400)
@@ -496,10 +63,7 @@ async def handle_execute(request):
     timeout = body.get("timeout", VM_TIMEOUT_SEC)
 
     try:
-        if snapshot_ready:
-            result = await execute_code_snapshot(code, timeout=timeout)
-        else:
-            result = await execute_code_cold(code, body.get("session_token", ""), timeout=timeout)
+        result = await executor.execute(code, timeout=timeout)
         return web.json_response(result)
     except RuntimeError as e:
         return web.json_response({"error": str(e)}, status=503)
@@ -508,58 +72,56 @@ async def handle_execute(request):
         return web.json_response({"error": str(e)}, status=500)
 
 
-async def handle_kill(request):
+async def handle_kill(request: web.Request) -> web.Response:
+    executor: ExecutorBase = request.app["executor"]
     vm_id = request.match_info["vm_id"]
-    cleanup_vm(vm_id)
+    executor.cleanup_vm(vm_id)
     return web.json_response({"status": "killed", "vm_id": vm_id})
 
 
-async def handle_status(request):
-    vms = [{"vm_id": k, "uptime_sec": time.time() - v["started_at"]} for k, v in active_vms.items()]
-    return web.json_response({"active_vms": vms})
+async def handle_status(request: web.Request) -> web.Response:
+    executor: ExecutorBase = request.app["executor"]
+    return web.json_response({"active_vms": executor.list_vms()})
 
 
-async def cleanup_expired_vms():
+# ─── App lifecycle ───────────────────────────────────────────────────────────
+
+async def _cleanup_expired(app: web.Application) -> None:
+    """Periodically kill VMs that exceed the timeout."""
+    executor: ExecutorBase = app["executor"]
     while True:
-        now = time.time()
-        for vm_id in [k for k, v in active_vms.items() if now - v["started_at"] > VM_TIMEOUT_SEC]:
-            log.warning(f"VM {vm_id} expired, killing")
-            cleanup_vm(vm_id)
+        for vm in executor.list_vms():
+            if vm["uptime_sec"] > VM_TIMEOUT_SEC:
+                log.warning("VM %s expired, killing", vm["vm_id"])
+                executor.cleanup_vm(vm["vm_id"])
         await asyncio.sleep(10)
 
 
-async def on_startup(app):
-    app["cleanup_task"] = asyncio.create_task(cleanup_expired_vms())
+async def on_startup(app: web.Application) -> None:
+    executor = _detect_executor()
+    await executor.start()
+    app["executor"] = executor
+    app["cleanup_task"] = asyncio.create_task(_cleanup_expired(app))
 
 
-async def on_shutdown(app):
+async def on_shutdown(app: web.Application) -> None:
     app["cleanup_task"].cancel()
-    for vm_id in list(active_vms.keys()):
-        cleanup_vm(vm_id)
+    executor: ExecutorBase = app["executor"]
+    for vm in executor.list_vms():
+        executor.cleanup_vm(vm["vm_id"])
 
 
-def main():
-    if not os.path.exists("/dev/kvm"):
-        log.warning("Starting in degraded mode (no KVM)")
-
-    os.makedirs(OVERLAYS_DIR, exist_ok=True)
-    os.makedirs(SOCKETS_DIR, exist_ok=True)
-
-    # Create snapshot at startup
-    try:
-        create_snapshot()
-    except Exception:
-        log.exception("Snapshot creation failed — falling back to cold boot")
-
+def main() -> None:
     app = web.Application()
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)
+
     app.router.add_get("/health", handle_health)
     app.router.add_post("/execute", handle_execute)
     app.router.add_delete("/vm/{vm_id}", handle_kill)
     app.router.add_get("/vms", handle_status)
 
-    log.info(f"Sandbox manager starting on :8080 (max {MAX_VMS} VMs, snapshot={'yes' if snapshot_ready else 'no'})")
+    log.info("Sandbox manager starting on :8080")
     web.run_app(app, host="0.0.0.0", port=8080)
 
 

--- a/sp-firecracker-vm/sandbox_manager.py
+++ b/sp-firecracker-vm/sandbox_manager.py
@@ -40,7 +40,7 @@ def _detect_executor() -> ExecutorBase:
 
     from executor_gvisor import GVisorExecutor
     log.info("No KVM — using gVisor backend")
-    return GVisorExecutor(MAX_VMS, VM_MEMORY_MB, VM_TIMEOUT_SEC)
+    return GVisorExecutor(MAX_VMS, VM_TIMEOUT_SEC)
 
 
 # ─── HTTP handlers ───────────────────────────────────────────────────────────

--- a/sp-firecracker-vm/scripts/setup-macos.sh
+++ b/sp-firecracker-vm/scripts/setup-macos.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# SignalPilot Firecracker Setup — macOS
+# SignalPilot Sandbox Setup — macOS
 #
-# Checks prerequisites for running Firecracker inside Docker on macOS.
-# macOS support depends on Docker Desktop's nested virtualization
-# which is available on Apple Silicon (M1+) with recent Docker Desktop versions.
+# Auto-detects the best sandbox backend:
+#   - /dev/kvm available → Firecracker microVMs
+#   - No /dev/kvm        → gVisor (user-space kernel, no KVM needed)
 #
 # Usage:
 #   chmod +x setup-macos.sh && ./setup-macos.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 echo ""
 echo "========================================"
-echo "  SignalPilot Firecracker Setup (macOS)  "
+echo "  SignalPilot Sandbox Setup (macOS)      "
 echo "========================================"
 echo ""
 
@@ -23,7 +23,7 @@ MACOS_MAJOR=$(echo "$MACOS_VERSION" | cut -d. -f1)
 echo "[OK] macOS ${MACOS_VERSION}"
 
 if [ "$MACOS_MAJOR" -lt 13 ]; then
-    echo "[FAIL] macOS 13 (Ventura) or later required for nested virtualization."
+    echo "[FAIL] macOS 13 (Ventura) or later required."
     exit 1
 fi
 
@@ -31,10 +31,9 @@ fi
 
 ARCH=$(uname -m)
 if [ "$ARCH" = "arm64" ]; then
-    echo "[OK] Apple Silicon ($ARCH) — nested virtualization supported"
+    echo "[OK] Apple Silicon ($ARCH)"
 elif [ "$ARCH" = "x86_64" ]; then
-    echo "[WARN] Intel Mac ($ARCH) — nested virtualization may work but is less tested"
-    echo "       Intel Macs are EOL. Consider container fallback mode."
+    echo "[OK] Intel Mac ($ARCH)"
 else
     echo "[FAIL] Unknown architecture: $ARCH"
     exit 1
@@ -50,27 +49,35 @@ else
     exit 1
 fi
 
-# ─── Step 4: Check for KVM inside Docker ────────────────────────────────────
+# ─── Step 4: Detect backend ─────────────────────────────────────────────────
 
 echo "[...] Checking /dev/kvm inside Docker..."
 KVM_CHECK=$(docker run --rm --device /dev/kvm alpine ls /dev/kvm 2>&1 || true)
 
+BACKEND="gvisor"
 if echo "$KVM_CHECK" | grep -q "/dev/kvm"; then
-    echo "[OK] /dev/kvm available inside Docker — Firecracker ready!"
+    BACKEND="firecracker"
+    echo "[OK] /dev/kvm available — will use Firecracker"
 else
-    echo "[WARN] /dev/kvm not available inside Docker."
-    echo ""
-    echo "  To enable on Apple Silicon:"
-    echo "    1. Open Docker Desktop → Settings → General"
-    echo "    2. Enable 'Use Virtualization framework'"
-    echo "    3. Enable 'Use Rosetta for x86_64/amd64 emulation' (if needed)"
-    echo "    4. Settings → Resources → Advanced"
-    echo "    5. Check for nested virtualization option"
-    echo "    6. Restart Docker Desktop"
-    echo ""
-    echo "  If nested virtualization is not available in your Docker Desktop version:"
-    echo "    SignalPilot will automatically fall back to container sandbox mode."
-    echo "    Run: sp serve --sandbox-mode=container"
+    echo "[OK] No /dev/kvm — will use gVisor (user-space kernel sandbox)"
+fi
+
+# ─── Step 5: Verify gVisor binary availability ──────────────────────────────
+
+if [ "$BACKEND" = "gvisor" ]; then
+    echo "[...] Testing gVisor (runsc) on ${ARCH}..."
+    GVISOR_CHECK=$(docker run --rm python:3.12-slim sh -c \
+        "apt-get update -qq && apt-get install -qq -y curl >/dev/null 2>&1 && \
+         curl -fsSL https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}/runsc -o /tmp/runsc && \
+         chmod +x /tmp/runsc && /tmp/runsc --version 2>&1" 2>&1 || true)
+
+    if echo "$GVISOR_CHECK" | grep -q "runsc version"; then
+        echo "[OK] gVisor works on ${ARCH}"
+    else
+        echo "[FAIL] gVisor not available for ${ARCH}."
+        echo "       Output: $GVISOR_CHECK"
+        exit 1
+    fi
 fi
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
@@ -81,14 +88,16 @@ echo "  Setup Summary"
 echo "========================================"
 echo ""
 
-if echo "$KVM_CHECK" | grep -q "/dev/kvm"; then
-    echo "Ready! Run:"
-    echo "  docker run --device /dev/kvm signalpilot-sandbox"
+if [ "$BACKEND" = "firecracker" ]; then
+    echo "Backend: Firecracker (microVM, ~200ms snapshot restore)"
+    echo ""
+    echo "Run:"
+    echo "  docker compose --profile firecracker up -d"
 else
-    echo "Firecracker not available. Options:"
-    echo "  1. Update Docker Desktop and enable nested virtualization"
-    echo "  2. Use container sandbox mode: sp serve --sandbox-mode=container"
-    echo "  3. Use SignalPilot Cloud: sp login"
+    echo "Backend: gVisor (user-space kernel, ~50ms startup)"
+    echo ""
+    echo "Run:"
+    echo "  docker compose up -d"
 fi
 
 echo ""

--- a/sp-firecracker-vm/signalpilot-sandbox.yml
+++ b/sp-firecracker-vm/signalpilot-sandbox.yml
@@ -7,7 +7,7 @@ sandbox:
   # "local"     — Auto-detect: Firecracker (Linux/KVM) or gVisor (macOS/no KVM)
   # "cloud"     — Firecracker on SignalPilot infrastructure (requires sp login)
   # "container" — Basic Docker containers (works everywhere, weakest isolation)
-  mode: local   # recommended: auto-detects best backend
+  mode: container  # default: safest cross-platform option (change to "local" for auto-detect)
 
   local:
     # Shared settings (apply to both Firecracker and gVisor)

--- a/sp-firecracker-vm/signalpilot-sandbox.yml
+++ b/sp-firecracker-vm/signalpilot-sandbox.yml
@@ -4,31 +4,34 @@
 # The run_analysis tool behaves identically regardless of mode.
 
 sandbox:
-  # "local"     — Firecracker microVMs on your machine (requires KVM)
+  # "local"     — Auto-detect: Firecracker (Linux/KVM) or gVisor (macOS/no KVM)
   # "cloud"     — Firecracker on SignalPilot infrastructure (requires sp login)
-  # "container" — Hardened Docker containers (works everywhere, weaker isolation)
-  mode: container  # default: safest cross-platform option
+  # "container" — Basic Docker containers (works everywhere, weakest isolation)
+  mode: local   # recommended: auto-detects best backend
 
   local:
-    # Firecracker settings (only used when mode: local)
+    # Shared settings (apply to both Firecracker and gVisor)
     max_vms: 10
+    vm_timeout_sec: 300
+
+    # Firecracker-specific (only when /dev/kvm available)
     vm_memory_mb: 512
     vm_vcpus: 1
-    vm_timeout_sec: 300
-    # Network: VMs can ONLY reach the gateway. No internet.
     network_policy: gateway-only
 
+    # gVisor-specific (used on macOS / no KVM)
+    # runsc intercepts all syscalls via user-space kernel (Sentry)
+    # No network access, read-only rootfs, memory-limited
+    gvisor_memory_limit: 512m
+
   cloud:
-    # SignalPilot Cloud settings (only used when mode: cloud)
-    # Run `sp login` to authenticate
-    region: auto          # auto-selects closest region
-    vm_size: standard     # standard (1 vCPU/512MB) or heavy (4 vCPU/4GB)
+    region: auto
+    vm_size: standard
     vm_timeout_sec: 300
 
   container:
-    # Docker container settings (only used when mode: container)
     memory_limit: 512m
     cpu_limit: 1
-    network: gateway-only   # container can only reach SP gateway
-    read_only_rootfs: true  # tmpfs for scratch space
+    network: gateway-only
+    read_only_rootfs: true
     seccomp_profile: default


### PR DESCRIPTION
## Summary

Firecracker requires /dev/kvm which is unavailable on macOS Docker Desktop. This adds a gVisor (runsc) backend that provides user-space kernel isolation without KVM. The sandbox manager auto-detects at startup: KVM present uses Firecracker, otherwise falls back to gVisor.

Both backends implement the same ExecutorBase interface and serve identical API responses, so the gateway and LLM are unaware of which backend runs.

Tested on Apple Silicon: health, code execution, error handling, timeouts all pass via gVisor with ~200ms execution time.

## Benchmark: gVisor vs Shuru (Apple Silicon M1)

Heavy workload (`import math` + `sqrt(i)` for 10k iterations):

| | gVisor (PR #16) | Shuru (PR #17) |
|---|---|---|
| Run 1 | 247ms | 644ms |
| Run 2 | 220ms | 626ms |
| Run 3 | 224ms | 634ms |
| Run 4 | 243ms | 642ms |
| Run 5 | 222ms | 621ms |
| **Avg** | **231ms** | **633ms** |

gVisor is ~2.8x faster with lower variance. Both provide real sandbox isolation (gVisor = Google's user-space kernel, Shuru = Apple Virtualization.framework microVM).

## Test plan

- [x] Health endpoint returns `{"backend": "gvisor", "status": "healthy"}`
- [x] Code execution: `print(42)` → `{"success": true, "output": "42"}`
- [x] Error handling: `1/0` → `{"success": false, "error": "ZeroDivisionError..."}`
- [x] Timeout: long-running code killed after deadline
- [x] Gateway connects to sandbox on port 8180 and reports `sandbox_status: healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)