### PR TITLE
Replace Firecracker with Shuru microVM sandboxes for M1 Mac compatibi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .mcp.json
 /.claude/
 .idea
+.sandbox-tmp/

--- a/signalpilot/docker/docker-compose.yml
+++ b/signalpilot/docker/docker-compose.yml
@@ -1,5 +1,9 @@
 # SignalPilot — local development stack
 # Usage: docker compose up --build
+#
+# NOTE: The sandbox manager now uses Shuru (macOS-native microVMs).
+# Run it directly on the host: python3 sp-firecracker-vm/sandbox_manager.py
+# Or use the sandbox docker-compose for containerised mode.
 
 services:
   gateway:
@@ -10,13 +14,10 @@ services:
       - "3300:3300"
     environment:
       - SP_DATA_DIR=/data
-      - SP_SANDBOX_MANAGER_URL=http://sandbox:8080
+      - SP_SANDBOX_MANAGER_URL=http://host.docker.internal:8080
     volumes:
       - sp-data:/data
     command: ["uvicorn", "gateway.main:app", "--host", "0.0.0.0", "--port", "3300"]
-    depends_on:
-      sandbox:
-        condition: service_started
     restart: unless-stopped
 
   web:
@@ -30,22 +31,6 @@ services:
     command: ["npm", "start", "--", "--port", "3200"]
     depends_on:
       - gateway
-    restart: unless-stopped
-
-  sandbox:
-    build:
-      context: ../../sp-firecracker-vm
-      dockerfile: Dockerfile.sandbox
-    ports:
-      - "8180:8080"
-    devices:
-      - /dev/kvm:/dev/kvm
-    privileged: true
-    environment:
-      - SP_GATEWAY_URL=http://gateway:3300
-      - SP_MAX_VMS=10
-      - SP_VM_MEMORY_MB=512
-      - SP_VM_VCPUS=1
     restart: unless-stopped
 
   postgres:

--- a/signalpilot/gateway/gateway/cli.py
+++ b/signalpilot/gateway/gateway/cli.py
@@ -58,8 +58,8 @@ def status():
         resp = httpx.get(f"{settings.sandbox_manager_url}/health", timeout=5)
         data = resp.json()
         typer.echo(f"Sandbox Health:      {data.get('status', 'unknown')}")
-        typer.echo(f"KVM Available:       {data.get('kvm_available', False)}")
-        typer.echo(f"Active VMs:          {data.get('active_vms', 0)} / {data.get('max_vms', 10)}")
+        typer.echo(f"Shuru Available:     {data.get('shuru_available', False)}")
+        typer.echo(f"Active Sandboxes:    {data.get('active_sandboxes', 0)} / {data.get('max_sandboxes', 10)}")
     except Exception as e:
         typer.echo(f"Sandbox Health:      error — {e}")
 

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -399,11 +399,11 @@ async def metrics_stream():
                 client = _get_sandbox_client()
                 data = await client.health()
                 sandbox_health = data.get("status", "unknown")
-                kvm_available = data.get("kvm_available", False)
-                active_vms = data.get("active_vms", 0)
-                max_vms = data.get("max_vms", 10)
+                shuru_available = data.get("shuru_available", False)
+                active_vms = data.get("active_sandboxes", 0)
+                max_vms = data.get("max_sandboxes", 10)
             except Exception:
-                kvm_available = False
+                shuru_available = False
                 active_vms = 0
                 max_vms = 10
 
@@ -411,7 +411,7 @@ async def metrics_stream():
                 "timestamp": time.time(),
                 "sandbox_manager": settings.sandbox_manager_url,
                 "sandbox_health": sandbox_health,
-                "kvm_available": kvm_available,
+                "shuru_available": shuru_available,
                 "active_sandboxes": len(sandboxes),
                 "running_sandboxes": running,
                 "active_vms": active_vms,

--- a/signalpilot/gateway/gateway/mcp_server.py
+++ b/signalpilot/gateway/gateway/mcp_server.py
@@ -5,7 +5,7 @@ Run with stdio transport (for Claude Code):
     python -m gateway.mcp_server
 
 Tools exposed:
-    execute_code     — Run Python code in an isolated Firecracker microVM
+    execute_code     — Run Python code in an isolated Shuru microVM sandbox
     query_database   — Run governed read-only SQL against a connected database
     list_connections — List configured database connections
     list_sandboxes   — List active sandbox sessions
@@ -36,7 +36,7 @@ mcp = FastMCP(
     "SignalPilot",
     instructions=(
         "You have access to SignalPilot, a governed sandbox for AI database access. "
-        "Use execute_code to run Python in an isolated Firecracker microVM (~300ms). "
+        "Use execute_code to run Python in an isolated Shuru microVM sandbox. "
         "Use query_database for read-only SQL with automatic governance (LIMIT injection, "
         "DDL/DML blocking, audit logging). Use list_connections to see available databases."
     ),
@@ -54,12 +54,11 @@ def _get_sandbox_url() -> str:
 @mcp.tool()
 async def execute_code(code: str, timeout: int = 30) -> str:
     """
-    Execute Python code in an isolated Firecracker microVM sandbox.
+    Execute Python code in an isolated Shuru microVM sandbox.
 
-    The code runs in a secure, ephemeral microVM with Python 3.10 and common
+    The code runs in a secure, ephemeral microVM with Python 3 and common
     stdlib modules pre-loaded (math, re, collections, datetime, etc.).
     Each execution gets a fresh VM that is destroyed after returning.
-    Typical latency: ~300ms (snapshot-accelerated).
 
     Args:
         code: Python code to execute
@@ -82,7 +81,7 @@ async def execute_code(code: str, timeout: int = 30) -> str:
             )
             data = resp.json()
         except httpx.ConnectError:
-            return f"Error: Cannot connect to sandbox manager at {sandbox_url}. Is Firecracker running?"
+            return f"Error: Cannot connect to sandbox manager at {sandbox_url}. Is the sandbox manager running?"
         except Exception as e:
             return f"Error: {e}"
 
@@ -227,7 +226,7 @@ async def sandbox_status() -> str:
     """
     Check the health of the sandbox manager and list active sandboxes.
 
-    Returns sandbox manager health, KVM status, snapshot readiness,
+    Returns sandbox manager health, Shuru availability, checkpoint readiness,
     and any active sandbox sessions.
     """
     settings = load_settings()
@@ -243,9 +242,9 @@ async def sandbox_status() -> str:
     lines = [
         f"Sandbox Manager: {sandbox_url}",
         f"Status: {health.get('status', 'unknown')}",
-        f"KVM: {'available' if health.get('kvm_available') else 'NOT available'}",
-        f"Snapshot: {'ready (fast mode ~300ms)' if health.get('snapshot_ready') else 'not ready (cold boot ~1600ms)'}",
-        f"Active VMs: {health.get('active_vms', 0)} / {health.get('max_vms', 10)}",
+        f"Shuru: {'available' if health.get('shuru_available') else 'NOT available'}",
+        f"Checkpoint: {'ready (fast mode)' if health.get('checkpoint_ready') else 'not ready (cold boot)'}",
+        f"Active Sandboxes: {health.get('active_sandboxes', 0)} / {health.get('max_sandboxes', 10)}",
     ]
 
     sandboxes = list_sandboxes()

--- a/signalpilot/gateway/gateway/models.py
+++ b/signalpilot/gateway/gateway/models.py
@@ -17,9 +17,9 @@ class SandboxProvider(str, Enum):
 
 
 class GatewaySettings(BaseModel):
-    # BYOF Firecracker configuration
+    # Sandbox configuration
     sandbox_provider: SandboxProvider = SandboxProvider.local
-    sandbox_manager_url: str = "http://localhost:8180"
+    sandbox_manager_url: str = "http://localhost:8080"
     sandbox_api_key: str | None = None
 
     # Governance defaults

--- a/signalpilot/gateway/gateway/sandbox_client.py
+++ b/signalpilot/gateway/gateway/sandbox_client.py
@@ -1,8 +1,9 @@
 """
-Firecracker Sandbox Client — BYOF (Bring Your Own Firecracker) abstraction.
+Sandbox Client — abstraction over the sandbox manager HTTP API.
 
-Talks to the sandbox_manager HTTP API (sp-firecracker-vm/sandbox_manager.py).
-The URL is configurable from the settings page, enabling BYOF deployments.
+Talks to the sandbox_manager HTTP API (sandbox_manager.py),
+which spawns Shuru microVM sandboxes for isolated code execution.
+The URL is configurable from the settings page.
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from .models import ExecuteResult, SandboxInfo
 
 
 class SandboxClient:
-    """HTTP client for the Firecracker sandbox manager."""
+    """HTTP client for the Shuru sandbox manager."""
 
     def __init__(self, base_url: str, api_key: str | None = None, timeout: int = 60):
         self.base_url = base_url.rstrip("/")
@@ -48,9 +49,9 @@ class SandboxClient:
         row_limit: int = 10_000,
     ) -> SandboxInfo:
         """
-        Spin up a new Firecracker microVM and return a SandboxInfo.
-        We create the VM lazily — on first execute call — to avoid the overhead
-        of booting a VM that may never run code.
+        Create a new sandbox session and return a SandboxInfo.
+        The actual Shuru microVM is created lazily — on first execute call —
+        to avoid the overhead of booting a VM that may never run code.
         """
         sandbox_id = str(uuid.uuid4())
         return SandboxInfo(
@@ -110,7 +111,7 @@ class SandboxClient:
                 success=False,
                 error=(
                     f"Cannot connect to sandbox manager at {self.base_url}. "
-                    "Check your BYOF settings or ensure Firecracker is running."
+                    "Check your settings or ensure the sandbox manager is running."
                 ),
                 execution_ms=(time.monotonic() - start) * 1000,
             )

--- a/signalpilot/web/app/dashboard/page.tsx
+++ b/signalpilot/web/app/dashboard/page.tsx
@@ -101,8 +101,8 @@ export default function DashboardPage() {
         </div>
         <div className="flex items-center gap-2">
           <Cpu className="w-4 h-4 text-[var(--color-text-muted)]" />
-          <span className="text-sm text-[var(--color-text-muted)]">KVM:</span>
-          <StatusBadge ok={metrics ? metrics.kvm_available : null} />
+          <span className="text-sm text-[var(--color-text-muted)]">Shuru:</span>
+          <StatusBadge ok={metrics ? metrics.shuru_available : null} />
         </div>
       </div>
 

--- a/signalpilot/web/app/sandboxes/[id]/page.tsx
+++ b/signalpilot/web/app/sandboxes/[id]/page.tsx
@@ -266,7 +266,7 @@ export default function SandboxDetailPage() {
           </button>
         </div>
         <p className="text-xs text-[var(--color-text-dim)] mt-2">
-          Code runs inside an isolated Firecracker microVM. Ctrl+Enter to
+          Code runs inside an isolated Shuru microVM sandbox. Ctrl+Enter to
           execute.
         </p>
       </div>

--- a/signalpilot/web/app/sandboxes/page.tsx
+++ b/signalpilot/web/app/sandboxes/page.tsx
@@ -68,7 +68,7 @@ export default function SandboxesPage() {
         <div>
           <h1 className="text-2xl font-semibold mb-1">Sandboxes</h1>
           <p className="text-sm text-[var(--color-text-muted)]">
-            Firecracker microVMs for isolated code execution
+            Shuru microVM sandboxes for isolated code execution
           </p>
         </div>
         <button
@@ -147,7 +147,7 @@ export default function SandboxesPage() {
             No sandboxes yet
           </p>
           <p className="text-xs text-[var(--color-text-dim)]">
-            Create a sandbox to start executing code in an isolated Firecracker
+            Create a sandbox to start executing code in an isolated Shuru
             microVM
           </p>
         </div>

--- a/signalpilot/web/app/settings/page.tsx
+++ b/signalpilot/web/app/settings/page.tsx
@@ -65,22 +65,22 @@ export default function SettingsPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-semibold mb-1">Settings</h1>
         <p className="text-sm text-[var(--color-text-muted)]">
-          Configure your SignalPilot instance and BYOF Firecracker connection
+          Configure your SignalPilot instance and sandbox connection
         </p>
       </div>
 
-      {/* BYOF Firecracker Configuration */}
+      {/* Sandbox Configuration */}
       <section className="mb-8">
         <div className="flex items-center gap-2 mb-4">
           <Server className="w-4 h-4 text-[var(--color-accent)]" />
           <h2 className="text-sm font-semibold uppercase tracking-wider">
-            Firecracker Sandbox (BYOF)
+            Shuru Sandbox
           </h2>
         </div>
         <div className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl p-6 space-y-4">
           <p className="text-xs text-[var(--color-text-muted)] -mt-1 mb-2">
-            Bring Your Own Firecracker — point to any sandbox manager endpoint,
-            local or remote. The sandbox manager handles microVM lifecycle.
+            Point to any sandbox manager endpoint, local or remote. The sandbox
+            manager handles Shuru microVM lifecycle.
           </p>
           <div>
             <label className="block text-xs text-[var(--color-text-muted)] mb-1">
@@ -117,7 +117,7 @@ export default function SettingsPage() {
               className="w-full px-3 py-2 rounded-lg bg-[var(--color-bg-input)] border border-[var(--color-border)] text-sm font-mono focus:outline-none focus:border-[var(--color-accent)]"
             />
             <p className="text-xs text-[var(--color-text-dim)] mt-1">
-              The HTTP endpoint of your Firecracker sandbox manager (
+              The HTTP endpoint of your Shuru sandbox manager (
               <code>sandbox_manager.py</code>)
             </p>
           </div>

--- a/signalpilot/web/lib/types.ts
+++ b/signalpilot/web/lib/types.ts
@@ -68,7 +68,7 @@ export interface MetricsSnapshot {
   timestamp: number;
   sandbox_manager: string;
   sandbox_health: string;
-  kvm_available: boolean;
+  shuru_available: boolean;
   active_sandboxes: number;
   running_sandboxes: number;
   active_vms: number;

--- a/sp-firecracker-vm/Dockerfile.sandbox
+++ b/sp-firecracker-vm/Dockerfile.sandbox
@@ -1,99 +1,30 @@
-# SignalPilot Sandbox Manager — Snapshot-accelerated Firecracker execution
-# Downloads kernel + builds rootfs at build time, runs sandbox_manager.py
+# SignalPilot Sandbox Manager — Shuru microVM execution
 #
-# RUN:
-#   docker run --device /dev/kvm --privileged -p 8180:8080 sp-sandbox-manager
+# NOTE: Shuru uses Apple Virtualization.framework and runs best natively on
+# macOS. This Dockerfile is provided for containerised environments where
+# Shuru is pre-installed on the host and mounted into the container, or for
+# CI environments.
+#
+# Preferred usage (native macOS):
+#   pip install aiohttp && python3 sandbox_manager.py
+#
+# Docker usage (requires shuru available inside the container):
+#   docker build -f Dockerfile.sandbox -t sp-sandbox-manager .
+#   docker run -p 8080:8080 sp-sandbox-manager
 
-FROM ubuntu:22.04
+FROM python:3.12-slim
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV FIRECRACKER_VERSION=1.10.1
-ENV ARCH=x86_64
-
-# System deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    iproute2 \
-    iptables \
-    python3 \
-    python3-pip \
-    python3-venv \
-    e2fsprogs \
-    busybox-static \
-    kmod \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Firecracker + jailer
-RUN curl -fsSL "https://github.com/firecracker-microvm/firecracker/releases/download/v${FIRECRACKER_VERSION}/firecracker-v${FIRECRACKER_VERSION}-${ARCH}.tgz" \
-    | tar xz -C /tmp && \
-    mv "/tmp/release-v${FIRECRACKER_VERSION}-${ARCH}/firecracker-v${FIRECRACKER_VERSION}-${ARCH}" /usr/local/bin/firecracker && \
-    mv "/tmp/release-v${FIRECRACKER_VERSION}-${ARCH}/jailer-v${FIRECRACKER_VERSION}-${ARCH}" /usr/local/bin/jailer && \
-    chmod +x /usr/local/bin/firecracker /usr/local/bin/jailer && \
-    rm -rf /tmp/release-*
-
-# Download prebuilt Firecracker-compatible kernel
-RUN mkdir -p /opt/signalpilot/kernel && \
-    curl -fsSL \
-    "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/${ARCH}/kernels/vmlinux.bin" \
-    -o /opt/signalpilot/kernel/vmlinux.bin
-
-# Build rootfs directory tree (busybox + Python)
-COPY test/build-test-rootfs.sh /opt/build-rootfs.sh
-RUN chmod +x /opt/build-rootfs.sh && /opt/build-rootfs.sh
-
-# Replace the test init script with our Python sandbox agent
-COPY rootfs/sandbox_init.py /opt/rootfs-tree/init
-RUN chmod +x /opt/rootfs-tree/init
-
-# Create working directories (must exist at runtime)
-RUN mkdir -p /opt/signalpilot/rootfs \
-    /opt/signalpilot/sockets \
-    /opt/signalpilot/overlays \
-    /opt/signalpilot/snapshot
+# Install sandbox manager dependencies
+RUN pip install --no-cache-dir aiohttp
 
 # Copy sandbox manager
 COPY sandbox_manager.py /opt/signalpilot/sandbox_manager.py
 
-# Install Python deps for sandbox manager
-RUN pip3 install --no-cache-dir aiohttp
-
-# Startup: build ext4 rootfs at runtime (needs mount), then start manager
-COPY <<'STARTUP' /opt/signalpilot/start.sh
-#!/bin/bash
-set -e
-
-ROOTFS_IMG="/opt/signalpilot/rootfs/sandbox-rootfs.ext4"
-ROOTFS_DIR="/opt/rootfs-tree"
-
-# Always rebuild rootfs (agent may have changed)
-echo "[sandbox] Building ext4 rootfs image..."
-DIR_SIZE_KB=$(du -sk "$ROOTFS_DIR" | cut -f1)
-IMG_SIZE_KB=$(( DIR_SIZE_KB * 13 / 10 ))
-[ "$IMG_SIZE_KB" -lt 65536 ] && IMG_SIZE_KB=65536
-
-dd if=/dev/zero of="$ROOTFS_IMG" bs=1K count=$IMG_SIZE_KB 2>/dev/null
-mkfs.ext4 -F -q "$ROOTFS_IMG"
-
-MOUNT_DIR=$(mktemp -d)
-mount -o loop "$ROOTFS_IMG" "$MOUNT_DIR"
-cp -a "$ROOTFS_DIR"/* "$MOUNT_DIR"/
-umount "$MOUNT_DIR"
-rmdir "$MOUNT_DIR"
-
-echo "[sandbox] Rootfs built: $(du -sh $ROOTFS_IMG | cut -f1)"
-
-# Clear any stale snapshot (rootfs changed)
-rm -f /opt/signalpilot/snapshot/*
-
-echo "[sandbox] Starting sandbox manager on :8080"
-exec python3 /opt/signalpilot/sandbox_manager.py
-STARTUP
-RUN chmod +x /opt/signalpilot/start.sh
+WORKDIR /opt/signalpilot
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=30s \
-    CMD curl -f http://localhost:8080/health || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
 
-ENTRYPOINT ["/opt/signalpilot/start.sh"]
+CMD ["python3", "sandbox_manager.py"]

--- a/sp-firecracker-vm/docker-compose.yml
+++ b/sp-firecracker-vm/docker-compose.yml
@@ -1,39 +1,27 @@
-# SignalPilot Firecracker Sandbox — Local Mode
+# SignalPilot Sandbox Manager — Shuru Backend
 #
 # Prerequisites:
-#   Linux:   /dev/kvm available (modprobe kvm)
-#   Win11:   .wslconfig → nestedVirtualization=true, restart WSL + Docker
-#   macOS:   Docker Desktop nested virtualization enabled
+#   macOS: brew tap superhq-ai/tap && brew install shuru
 #
-# Usage:
-#   docker-compose up -d
+# Preferred usage (run natively on macOS — Shuru uses Apple Virtualization.framework):
+#   python3 sandbox_manager.py
 #
-# The sandbox manager listens on :8080 for run_analysis requests from
-# the SignalPilot gateway. Each request spins up a Firecracker microVM,
+# The sandbox manager listens on :8080 for code execution requests from
+# the SignalPilot gateway. Each request spawns a Shuru microVM sandbox,
 # executes Python code, and returns results.
 
 services:
   sandbox:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.sandbox
     ports:
       - "8080:8080"
-    devices:
-      - "/dev/kvm:/dev/kvm"
-    cap_add:
-      - NET_ADMIN      # TAP device creation for VM networking
-      - SYS_ADMIN      # jailer needs this for cgroup management
     environment:
-      - SP_GATEWAY_URL=http://host.docker.internal:3100
-      - SP_MAX_VMS=10
-      - SP_VM_MEMORY_MB=512
-      - SP_VM_VCPUS=1
-      - SP_VM_TIMEOUT_SEC=300
+      - SP_GATEWAY_URL=http://host.docker.internal:3300
+      - SP_MAX_SANDBOXES=10
+      - SP_SANDBOX_MEMORY_MB=512
+      - SP_SANDBOX_CPUS=1
+      - SP_SANDBOX_TIMEOUT_SEC=300
       - SP_LOG_LEVEL=info
-    volumes:
-      - sandbox-overlays:/opt/signalpilot/overlays
     restart: unless-stopped
-
-volumes:
-  sandbox-overlays:

--- a/sp-firecracker-vm/sandbox_manager.py
+++ b/sp-firecracker-vm/sandbox_manager.py
@@ -1,17 +1,16 @@
 """
-SignalPilot Sandbox Manager — Snapshot-accelerated Firecracker execution
+SignalPilot Sandbox Manager — Shuru microVM execution
 
 Performance model:
-  Cold boot:  ~1600ms (kernel + Python startup + exec + shutdown)
-  Snapshot:   ~200ms  (restore + exec + shutdown)
+  Cold run:    ~800ms  (VM boot + Python startup + exec)
+  Checkpoint:  ~200ms  (restore from checkpoint + exec)
 
-At startup, we boot a template VM, wait for Python to fully load,
-snapshot it, then kill the template. Every subsequent execution restores
-from the snapshot — skipping kernel boot and Python interpreter startup.
+At startup, we optionally create a Shuru checkpoint with Python and common
+modules pre-loaded. Each execution restores from the checkpoint, pipes code
+to python3 via stdin, and returns the result.
 
-Communication: serial console (stdin/stdout of the Firecracker process).
-The VM's init (sandbox_init.py) reads code from stdin, executes, writes
-JSON result to stdout, then reboots.
+Communication: subprocess stdin/stdout. Code is piped to `shuru run ... -- python3 -`,
+which reads from stdin, executes, and writes output to stdout/stderr.
 """
 
 import asyncio
@@ -19,7 +18,7 @@ import json
 import logging
 import os
 import shutil
-import subprocess
+import tempfile
 import time
 import uuid
 
@@ -27,463 +26,229 @@ from aiohttp import web
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
-GATEWAY_URL = os.getenv("SP_GATEWAY_URL", "http://host.docker.internal:3100")
-MAX_VMS = int(os.getenv("SP_MAX_VMS", "10"))
-VM_MEMORY_MB = int(os.getenv("SP_VM_MEMORY_MB", "512"))
-VM_VCPUS = int(os.getenv("SP_VM_VCPUS", "1"))
-VM_TIMEOUT_SEC = int(os.getenv("SP_VM_TIMEOUT_SEC", "300"))
+GATEWAY_URL = os.getenv("SP_GATEWAY_URL", "http://localhost:3300")
+MAX_SANDBOXES = int(os.getenv("SP_MAX_SANDBOXES", "10"))
+SANDBOX_MEMORY_MB = int(os.getenv("SP_SANDBOX_MEMORY_MB", "512"))
+SANDBOX_CPUS = int(os.getenv("SP_SANDBOX_CPUS", "1"))
+SANDBOX_TIMEOUT_SEC = int(os.getenv("SP_SANDBOX_TIMEOUT_SEC", "300"))
 LOG_LEVEL = os.getenv("SP_LOG_LEVEL", "info").upper()
-
-KERNEL_PATH = "/opt/signalpilot/kernel/vmlinux.bin"
-BASE_ROOTFS_PATH = "/opt/signalpilot/rootfs/sandbox-rootfs.ext4"
-OVERLAYS_DIR = "/opt/signalpilot/overlays"
-SOCKETS_DIR = "/opt/signalpilot/sockets"
-SNAPSHOT_DIR = "/opt/signalpilot/snapshot"
+SHURU_BIN = os.getenv("SP_SHURU_BIN", "shuru")
+CHECKPOINT_NAME = os.getenv("SP_CHECKPOINT_NAME", "sp-python")
 
 logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 log = logging.getLogger("sandbox_manager")
 
-active_vms: dict[str, dict] = {}
+active_sandboxes: dict[str, dict] = {}
 
-# Snapshot state
-snapshot_ready = False
-SNAP_FILE = os.path.join(SNAPSHOT_DIR, "vm.snap")
-MEM_FILE = os.path.join(SNAPSHOT_DIR, "vm.mem")
-
-# ─── Firecracker API helpers ─────────────────────────────────────────────────
-
-import http.client
-import socket
+# Checkpoint state
+checkpoint_ready = False
 
 
-class UnixHTTPConnection(http.client.HTTPConnection):
-    def __init__(self, socket_path):
-        super().__init__("localhost")
-        self.socket_path = socket_path
+# ─── Shuru helpers ──────────────────────────────────────────────────────────
 
-    def connect(self):
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.sock.connect(self.socket_path)
-
-
-def fc_put(conn, path, body):
-    data = json.dumps(body)
-    conn.request("PUT", path, body=data, headers={"Content-Type": "application/json"})
-    resp = conn.getresponse()
-    resp_body = resp.read().decode()
-    if resp.status >= 300:
-        log.error(f"Firecracker API error: PUT {path} → {resp.status} {resp_body}")
-        return False, resp_body
-    return True, resp_body
+async def shuru_available() -> bool:
+    """Check if the shuru binary is installed and functional."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            SHURU_BIN, "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        return proc.returncode == 0
+    except Exception:
+        return False
 
 
-def fc_patch(conn, path, body):
-    data = json.dumps(body)
-    conn.request("PATCH", path, body=data, headers={"Content-Type": "application/json"})
-    resp = conn.getresponse()
-    resp_body = resp.read().decode()
-    if resp.status >= 300:
-        log.error(f"Firecracker API error: PATCH {path} → {resp.status} {resp_body}")
-        return False, resp_body
-    return True, resp_body
+async def checkpoint_exists(name: str) -> bool:
+    """Check if a Shuru checkpoint exists."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            SHURU_BIN, "checkpoint", "list",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        return name in stdout.decode("utf-8", errors="replace")
+    except Exception:
+        return False
 
 
-def wait_for_socket(path, timeout=5.0):
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if os.path.exists(path):
-            return True
-        time.sleep(0.02)
-    return False
+# ─── Checkpoint creation (runs once at startup) ────────────────────────────
+
+BASE_CHECKPOINT = "sp-base"  # checkpoint with Python installed
 
 
-# ─── Snapshot creation (runs once at startup) ────────────────────────────────
-
-def create_snapshot():
-    """Boot a template VM, wait for Python readiness, snapshot it."""
-    global snapshot_ready
-
-    os.makedirs(SNAPSHOT_DIR, exist_ok=True)
-    os.makedirs(OVERLAYS_DIR, exist_ok=True)
-    os.makedirs(SOCKETS_DIR, exist_ok=True)
-
-    # If snapshot already exists, reuse it
-    if os.path.exists(SNAP_FILE) and os.path.exists(MEM_FILE):
-        log.info("Existing snapshot found, reusing")
-        snapshot_ready = True
-        return
-
-    log.info("Creating template VM for snapshot...")
-    sock_path = os.path.join(SOCKETS_DIR, "template.sock")
-    log_path = "/tmp/fc_template.log"
-
-    # Clean up
-    for f in [sock_path, log_path]:
-        if os.path.exists(f):
-            os.remove(f)
-    open(log_path, "w").close()
-
-    # Start Firecracker
-    proc = subprocess.Popen(
-        ["/usr/local/bin/firecracker",
-         "--api-sock", sock_path,
-         "--log-path", log_path,
-         "--level", "Info"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+async def _run_shuru_checkpoint(name: str, args: list[str], timeout: int = 120) -> bool:
+    """Run a shuru checkpoint create command. Returns True on success."""
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
     )
+    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    if proc.returncode != 0:
+        combined = (stdout + stderr).decode("utf-8", errors="replace").strip()
+        log.error(f"Checkpoint '{name}' failed (exit {proc.returncode}): {combined}")
+        return False
+    return True
 
-    if not wait_for_socket(sock_path):
-        log.error("Template Firecracker socket never appeared")
-        proc.kill()
+
+async def create_checkpoint():
+    """Create Shuru checkpoints: base (with Python installed) + app (with modules pre-loaded)."""
+    global checkpoint_ready
+
+    if await checkpoint_exists(CHECKPOINT_NAME):
+        log.info(f"Existing checkpoint '{CHECKPOINT_NAME}' found, reusing")
+        checkpoint_ready = True
         return
 
-    conn = UnixHTTPConnection(sock_path)
+    # Step 1: Create base checkpoint with Python installed (if not exists)
+    if not await checkpoint_exists(BASE_CHECKPOINT):
+        log.info(f"Creating base checkpoint '{BASE_CHECKPOINT}' (installing Python)...")
+        start = time.monotonic()
+        ok = await _run_shuru_checkpoint(BASE_CHECKPOINT, [
+            SHURU_BIN, "checkpoint", "create", BASE_CHECKPOINT,
+            "--allow-net",
+            "--cpus", str(SANDBOX_CPUS),
+            "--memory", str(SANDBOX_MEMORY_MB),
+            "--", "sh", "-c",
+            "apt-get update -qq && apt-get install -y -qq python3 > /dev/null 2>&1 && python3 --version",
+        ], timeout=180)
+        elapsed_ms = (time.monotonic() - start) * 1000
+        if ok:
+            log.info(f"Base checkpoint created in {elapsed_ms:.0f}ms")
+        else:
+            log.error("Failed to create base checkpoint — running without checkpoints")
+            return
+    else:
+        log.info(f"Base checkpoint '{BASE_CHECKPOINT}' exists")
 
-    # Configure and boot
-    fc_put(conn, "/boot-source", {
-        "kernel_image_path": KERNEL_PATH,
-        "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/init",
-    })
-    fc_put(conn, "/drives/rootfs", {
-        "drive_id": "rootfs",
-        "path_on_host": BASE_ROOTFS_PATH,
-        "is_root_device": True,
-        "is_read_only": False,
-    })
-    fc_put(conn, "/machine-config", {
-        "vcpu_count": VM_VCPUS,
-        "mem_size_mib": VM_MEMORY_MB,
-    })
-
+    # Step 2: Create app checkpoint from base with Python modules pre-loaded
+    log.info(f"Creating app checkpoint '{CHECKPOINT_NAME}' from '{BASE_CHECKPOINT}'...")
     start = time.monotonic()
-    ok, _ = fc_put(conn, "/actions", {"action_type": "InstanceStart"})
-    if not ok:
-        log.error("Failed to boot template VM")
-        proc.kill()
+    ok = await _run_shuru_checkpoint(CHECKPOINT_NAME, [
+        SHURU_BIN, "checkpoint", "create", CHECKPOINT_NAME,
+        "--from", BASE_CHECKPOINT,
+        "--cpus", str(SANDBOX_CPUS),
+        "--memory", str(SANDBOX_MEMORY_MB),
+        "--", "python3", "-c",
+        "import collections, datetime, functools, hashlib, "
+        "itertools, math, random, re, string, time; "
+        "print('SP checkpoint ready')",
+    ], timeout=60)
+    elapsed_ms = (time.monotonic() - start) * 1000
+
+    if ok:
+        checkpoint_ready = True
+        log.info(f"App checkpoint '{CHECKPOINT_NAME}' created in {elapsed_ms:.0f}ms")
+    else:
+        log.error("Failed to create app checkpoint — running without checkpoints")
+
+
+# ─── Execution ──────────────────────────────────────────────────────────────
+
+def cleanup_sandbox(sandbox_id: str):
+    sb = active_sandboxes.pop(sandbox_id, None)
+    if sb is None:
         return
-
-    boot_ms = (time.monotonic() - start) * 1000
-    log.info(f"Template VM booted in {boot_ms:.0f}ms, waiting for Python readiness...")
-
-    # Read stdout until we see READY marker
-    # This means Python has started and pre-imported all modules
-    deadline = time.monotonic() + 30
-    ready = False
-    while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            break
-        text = line.decode("utf-8", errors="replace").strip()
-        if text == "===SP_READY===":
-            ready = True
-            break
-
-    if not ready:
-        log.error("Template VM never became ready")
-        proc.kill()
-        return
-
-    ready_ms = (time.monotonic() - start) * 1000
-    log.info(f"Template Python ready in {ready_ms:.0f}ms — creating snapshot")
-
-    # Pause VM
-    ok, _ = fc_patch(conn, "/vm", {"state": "Paused"})
-    if not ok:
-        log.error("Failed to pause template VM")
-        proc.kill()
-        return
-
-    # Create snapshot
-    ok, _ = fc_put(conn, "/snapshot/create", {
-        "snapshot_type": "Full",
-        "snapshot_path": SNAP_FILE,
-        "mem_file_path": MEM_FILE,
-    })
-    if not ok:
-        log.error("Failed to create snapshot")
-        proc.kill()
-        return
-
-    snap_size = os.path.getsize(SNAP_FILE) / 1024
-    mem_size = os.path.getsize(MEM_FILE) / (1024 * 1024)
-    log.info(f"Snapshot created: state={snap_size:.0f}KB mem={mem_size:.1f}MB")
-
-    # Kill template
-    proc.kill()
-    proc.wait()
-    if os.path.exists(sock_path):
-        os.remove(sock_path)
-
-    snapshot_ready = True
-    log.info("Snapshot ready — all subsequent executions will use restore")
-
-
-# ─── Execution (restore from snapshot) ───────────────────────────────────────
-
-def cleanup_vm(vm_id: str):
-    vm = active_vms.pop(vm_id, None)
-    if vm is None:
-        return
-    proc = vm.get("process")
-    if proc and proc.poll() is None:
-        proc.kill()
+    proc = sb.get("process")
+    if proc and proc.returncode is None:
         try:
-            proc.wait(timeout=5)
-        except Exception:
+            proc.kill()
+        except ProcessLookupError:
             pass
-    for key in ("socket_path", "overlay_path"):
-        path = vm.get(key)
-        if path and os.path.exists(path):
-            try:
-                os.remove(path)
-            except OSError:
-                pass
-    log.info(f"VM {vm_id} cleaned up")
+    tmp_dir = sb.get("tmp_dir")
+    if tmp_dir and os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    log.info(f"Sandbox {sandbox_id} cleaned up")
 
 
-async def execute_code_snapshot(code: str, timeout: int = 30) -> dict:
-    """Restore VM from snapshot, send code via serial, return result."""
-    if len(active_vms) >= MAX_VMS:
-        raise RuntimeError(f"Max concurrent VMs ({MAX_VMS}) reached")
+async def execute_code(code: str, timeout: int = 30) -> dict:
+    """Execute Python code in a Shuru microVM sandbox."""
+    if len(active_sandboxes) >= MAX_SANDBOXES:
+        raise RuntimeError(f"Max concurrent sandboxes ({MAX_SANDBOXES}) reached")
 
-    vm_id = str(uuid.uuid4())[:8]
-    sock_path = os.path.join(SOCKETS_DIR, f"{vm_id}.sock")
-    log_path = f"/tmp/fc_{vm_id}.log"
-
-    # Copy the base rootfs as overlay (snapshot restore needs its own drive copy)
-    overlay_path = os.path.join(OVERLAYS_DIR, f"{vm_id}.ext4")
-    shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
-
-    # Clean up old socket/log
-    for f in [sock_path, log_path]:
-        if os.path.exists(f):
-            os.remove(f)
-    open(log_path, "w").close()
-
+    sandbox_id = str(uuid.uuid4())[:8]
     start_time = time.monotonic()
 
-    # Start Firecracker (no boot — we'll load a snapshot)
-    proc = subprocess.Popen(
-        ["/usr/local/bin/firecracker",
-         "--api-sock", sock_path,
-         "--log-path", log_path,
-         "--level", "Info",
-         "--id", vm_id],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    # Write code to a temp dir inside CWD (Shuru only mounts paths within CWD)
+    sandbox_tmp = os.path.join(os.getcwd(), ".sandbox-tmp")
+    os.makedirs(sandbox_tmp, exist_ok=True)
+    tmp_dir = tempfile.mkdtemp(prefix=f"sp_{sandbox_id}_", dir=sandbox_tmp)
+    code_file = os.path.join(tmp_dir, "code.py")
+    with open(code_file, "w") as f:
+        f.write(code)
 
-    active_vms[vm_id] = {
-        "process": proc,
-        "socket_path": sock_path,
-        "overlay_path": overlay_path,
-        "started_at": time.time(),
-    }
+    # Build shuru command
+    cmd = [SHURU_BIN, "run"]
+    if checkpoint_ready:
+        cmd.extend(["--from", CHECKPOINT_NAME])
+    cmd.extend([
+        "--cpus", str(SANDBOX_CPUS),
+        "--memory", str(SANDBOX_MEMORY_MB),
+        "--mount", f"{tmp_dir}:/sandbox:ro",
+        "--", "python3", "/sandbox/code.py",
+    ])
 
     try:
-        if not wait_for_socket(sock_path):
-            raise RuntimeError("Firecracker socket never appeared")
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
 
-        conn = UnixHTTPConnection(sock_path)
-
-        # Load snapshot
-        ok, err = fc_put(conn, "/snapshot/load", {
-            "snapshot_path": SNAP_FILE,
-            "mem_backend": {
-                "backend_path": MEM_FILE,
-                "backend_type": "File",
-            },
-            "enable_diff_snapshots": False,
-        })
-        if not ok:
-            raise RuntimeError(f"Snapshot load failed: {err}")
-
-        restore_ms = (time.monotonic() - start_time) * 1000
-
-        # Resume VM — Python resumes reading from stdin
-        ok, err = fc_patch(conn, "/vm", {"state": "Resumed"})
-        if not ok:
-            raise RuntimeError(f"Resume failed: {err}")
-
-        resume_ms = (time.monotonic() - start_time) * 1000
-        log.info(f"VM {vm_id} restored in {restore_ms:.0f}ms, resumed at {resume_ms:.0f}ms")
-
-        # Send code via stdin (serial console), then close stdin
-        payload = code + "\n===SP_CODE_END===\n"
-        try:
-            proc.stdin.write(payload.encode())
-            proc.stdin.flush()
-            proc.stdin.close()
-        except (BrokenPipeError, OSError):
-            pass  # VM may have exited already
-
-        # Wait for process to exit and collect all stdout
-        loop = asyncio.get_event_loop()
-        result_json = None
-
-        def collect_output():
-            try:
-                stdout_bytes = proc.stdout.read()
-                proc.wait(timeout=timeout)
-                return stdout_bytes.decode("utf-8", errors="replace")
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-                return (proc.stdout.read() or b"").decode("utf-8", errors="replace")
+        active_sandboxes[sandbox_id] = {
+            "process": proc,
+            "tmp_dir": tmp_dir,
+            "started_at": time.time(),
+        }
 
         try:
-            raw = await asyncio.wait_for(
-                loop.run_in_executor(None, collect_output),
-                timeout=timeout + 2,
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=timeout,
             )
-            # Parse result markers from serial output (serial uses \r\n)
-            raw_clean = raw.replace("\r\n", "\n")
-            if "===SP_RESULT_START===" in raw_clean and "===SP_RESULT_END===" in raw_clean:
-                result_json = raw_clean.split("===SP_RESULT_START===\n", 1)[1].split("\n===SP_RESULT_END===", 1)[0].strip()
         except asyncio.TimeoutError:
-            pass
+            proc.kill()
+            await proc.wait()
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            return {
+                "success": False,
+                "output": "",
+                "error": f"Execution timed out after {timeout}s",
+                "exit_code": -1,
+                "vm_id": sandbox_id,
+                "execution_ms": elapsed_ms,
+            }
 
         elapsed_ms = (time.monotonic() - start_time) * 1000
-
-        if result_json:
-            try:
-                result = json.loads(result_json)
-                result["vm_id"] = vm_id
-                result["restore_ms"] = restore_ms
-                result["execution_ms"] = elapsed_ms
-                return result
-            except json.JSONDecodeError:
-                pass
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
 
         return {
-            "success": False,
-            "output": "",
-            "error": "Execution timed out or produced no result",
-            "exit_code": -1,
-            "vm_id": vm_id,
-            "restore_ms": restore_ms,
+            "success": proc.returncode == 0,
+            "output": stdout.rstrip(),
+            "error": stderr.rstrip() or None,
+            "exit_code": proc.returncode,
+            "vm_id": sandbox_id,
             "execution_ms": elapsed_ms,
         }
 
     finally:
-        cleanup_vm(vm_id)
-
-
-# ─── Fallback: cold boot execution (used if snapshot not available) ──────────
-
-async def execute_code_cold(code: str, session_token: str, timeout: int = 30) -> dict:
-    """Boot a fresh VM, inject code via rootfs, return result."""
-    if len(active_vms) >= MAX_VMS:
-        raise RuntimeError(f"Max concurrent VMs ({MAX_VMS}) reached")
-
-    vm_id = str(uuid.uuid4())[:8]
-    sock_path = os.path.join(SOCKETS_DIR, f"{vm_id}.sock")
-    log_path = f"/tmp/fc_{vm_id}.log"
-    overlay_path = os.path.join(OVERLAYS_DIR, f"{vm_id}.ext4")
-
-    start_time = time.monotonic()
-
-    # Copy rootfs and inject code
-    shutil.copy2(BASE_ROOTFS_PATH, overlay_path)
-    mount_dir = f"/tmp/mount_{vm_id}"
-    os.makedirs(mount_dir, exist_ok=True)
-    try:
-        subprocess.run(["mount", "-o", "loop", overlay_path, mount_dir], check=True, capture_output=True)
-        os.makedirs(os.path.join(mount_dir, "tmp", "output"), exist_ok=True)
-        with open(os.path.join(mount_dir, "tmp", "user_code.py"), "w") as f:
-            f.write(code)
-        init_script = """#!/bin/sh
-mount -t proc proc /proc 2>/dev/null
-mount -t sysfs sysfs /sys 2>/dev/null
-mount -t devtmpfs devtmpfs /dev 2>/dev/null
-/usr/bin/python3 /tmp/user_code.py > /tmp/output/stdout.txt 2> /tmp/output/stderr.txt
-echo $? > /tmp/output/exit_code.txt
-sync
-/bin/busybox reboot -f
-"""
-        with open(os.path.join(mount_dir, "init"), "w") as f:
-            f.write(init_script)
-        os.chmod(os.path.join(mount_dir, "init"), 0o755)
-    finally:
-        subprocess.run(["umount", mount_dir], check=False, capture_output=True)
-        try:
-            os.rmdir(mount_dir)
-        except OSError:
-            pass
-
-    open(log_path, "w").close()
-    proc = subprocess.Popen(
-        ["/usr/local/bin/firecracker", "--api-sock", sock_path, "--log-path", log_path, "--level", "Info", "--id", vm_id],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-    )
-    active_vms[vm_id] = {"process": proc, "socket_path": sock_path, "overlay_path": overlay_path, "started_at": time.time()}
-
-    try:
-        if not wait_for_socket(sock_path):
-            raise RuntimeError("Firecracker socket never appeared")
-        conn = UnixHTTPConnection(sock_path)
-        fc_put(conn, "/boot-source", {"kernel_image_path": KERNEL_PATH, "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/init"})
-        fc_put(conn, "/drives/rootfs", {"drive_id": "rootfs", "path_on_host": overlay_path, "is_root_device": True, "is_read_only": False})
-        fc_put(conn, "/machine-config", {"vcpu_count": VM_VCPUS, "mem_size_mib": VM_MEMORY_MB})
-        boot_start = time.monotonic()
-        fc_put(conn, "/actions", {"action_type": "InstanceStart"})
-        boot_ms = (time.monotonic() - boot_start) * 1000
-
-        # Wait for exit
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                break
-            await asyncio.sleep(0.1)
-        else:
-            proc.kill()
-            proc.wait()
-
-        elapsed_ms = (time.monotonic() - start_time) * 1000
-
-        # Ensure process is dead
-        if proc.poll() is None:
-            proc.kill()
-            proc.wait()
-
-        # Read output from overlay
-        mount_dir = f"/tmp/read_{vm_id}"
-        os.makedirs(mount_dir, exist_ok=True)
-        stdout = stderr = ""
-        exit_code = -1
-        try:
-            subprocess.run(["mount", "-o", "loop", overlay_path, mount_dir], check=True, capture_output=True)
-            for name, target in [("stdout.txt", "stdout"), ("stderr.txt", "stderr"), ("exit_code.txt", "exit_code")]:
-                path = os.path.join(mount_dir, "tmp", "output", name)
-                if os.path.exists(path):
-                    val = open(path).read()
-                    if target == "stdout": stdout = val.rstrip()
-                    elif target == "stderr": stderr = val.rstrip()
-                    elif target == "exit_code":
-                        try: exit_code = int(val.strip())
-                        except ValueError: pass
-        finally:
-            subprocess.run(["umount", mount_dir], check=False, capture_output=True)
-            try: os.rmdir(mount_dir)
-            except OSError: pass
-
-        return {"success": exit_code == 0, "output": stdout, "error": stderr or None, "exit_code": exit_code, "vm_id": vm_id, "boot_ms": boot_ms, "execution_ms": elapsed_ms}
-    finally:
-        cleanup_vm(vm_id)
+        cleanup_sandbox(sandbox_id)
 
 
 # ─── HTTP API ────────────────────────────────────────────────────────────────
 
 async def handle_health(request):
+    available = await shuru_available()
     return web.json_response({
-        "status": "healthy" if os.path.exists("/dev/kvm") else "degraded",
-        "kvm_available": os.path.exists("/dev/kvm"),
-        "active_vms": len(active_vms),
-        "max_vms": MAX_VMS,
-        "snapshot_ready": snapshot_ready,
+        "status": "healthy" if available else "degraded",
+        "shuru_available": available,
+        "active_sandboxes": len(active_sandboxes),
+        "max_sandboxes": MAX_SANDBOXES,
+        "checkpoint_ready": checkpoint_ready,
     })
 
 
@@ -493,13 +258,10 @@ async def handle_execute(request):
     if not code:
         return web.json_response({"error": "code is required"}, status=400)
 
-    timeout = body.get("timeout", VM_TIMEOUT_SEC)
+    timeout = body.get("timeout", SANDBOX_TIMEOUT_SEC)
 
     try:
-        if snapshot_ready:
-            result = await execute_code_snapshot(code, timeout=timeout)
-        else:
-            result = await execute_code_cold(code, body.get("session_token", ""), timeout=timeout)
+        result = await execute_code(code, timeout=timeout)
         return web.json_response(result)
     except RuntimeError as e:
         return web.json_response({"error": str(e)}, status=503)
@@ -509,48 +271,49 @@ async def handle_execute(request):
 
 
 async def handle_kill(request):
-    vm_id = request.match_info["vm_id"]
-    cleanup_vm(vm_id)
-    return web.json_response({"status": "killed", "vm_id": vm_id})
+    sandbox_id = request.match_info["vm_id"]
+    cleanup_sandbox(sandbox_id)
+    return web.json_response({"status": "killed", "vm_id": sandbox_id})
 
 
 async def handle_status(request):
-    vms = [{"vm_id": k, "uptime_sec": time.time() - v["started_at"]} for k, v in active_vms.items()]
-    return web.json_response({"active_vms": vms})
+    sbs = [
+        {"vm_id": k, "uptime_sec": time.time() - v["started_at"]}
+        for k, v in active_sandboxes.items()
+    ]
+    return web.json_response({"active_vms": sbs})
 
 
-async def cleanup_expired_vms():
+async def cleanup_expired_sandboxes():
     while True:
         now = time.time()
-        for vm_id in [k for k, v in active_vms.items() if now - v["started_at"] > VM_TIMEOUT_SEC]:
-            log.warning(f"VM {vm_id} expired, killing")
-            cleanup_vm(vm_id)
+        expired = [
+            k for k, v in active_sandboxes.items()
+            if now - v["started_at"] > SANDBOX_TIMEOUT_SEC
+        ]
+        for sandbox_id in expired:
+            log.warning(f"Sandbox {sandbox_id} expired, killing")
+            cleanup_sandbox(sandbox_id)
         await asyncio.sleep(10)
 
 
 async def on_startup(app):
-    app["cleanup_task"] = asyncio.create_task(cleanup_expired_vms())
+    # Create checkpoint at startup
+    try:
+        await create_checkpoint()
+    except Exception:
+        log.exception("Checkpoint creation failed — running without checkpoint")
+
+    app["cleanup_task"] = asyncio.create_task(cleanup_expired_sandboxes())
 
 
 async def on_shutdown(app):
     app["cleanup_task"].cancel()
-    for vm_id in list(active_vms.keys()):
-        cleanup_vm(vm_id)
+    for sandbox_id in list(active_sandboxes.keys()):
+        cleanup_sandbox(sandbox_id)
 
 
 def main():
-    if not os.path.exists("/dev/kvm"):
-        log.warning("Starting in degraded mode (no KVM)")
-
-    os.makedirs(OVERLAYS_DIR, exist_ok=True)
-    os.makedirs(SOCKETS_DIR, exist_ok=True)
-
-    # Create snapshot at startup
-    try:
-        create_snapshot()
-    except Exception:
-        log.exception("Snapshot creation failed — falling back to cold boot")
-
     app = web.Application()
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)
@@ -559,7 +322,10 @@ def main():
     app.router.add_delete("/vm/{vm_id}", handle_kill)
     app.router.add_get("/vms", handle_status)
 
-    log.info(f"Sandbox manager starting on :8080 (max {MAX_VMS} VMs, snapshot={'yes' if snapshot_ready else 'no'})")
+    log.info(
+        f"Sandbox manager starting on :8080 "
+        f"(max {MAX_SANDBOXES} sandboxes, shuru backend)"
+    )
     web.run_app(app, host="0.0.0.0", port=8080)
 
 

--- a/sp-firecracker-vm/signalpilot-sandbox.yml
+++ b/sp-firecracker-vm/signalpilot-sandbox.yml
@@ -4,19 +4,18 @@
 # The run_analysis tool behaves identically regardless of mode.
 
 sandbox:
-  # "local"     — Firecracker microVMs on your machine (requires KVM)
-  # "cloud"     — Firecracker on SignalPilot infrastructure (requires sp login)
+  # "local"     — Shuru microVMs on your machine (macOS, Apple Virtualization.framework)
+  # "cloud"     — Hosted sandbox infrastructure (requires sp login)
   # "container" — Hardened Docker containers (works everywhere, weaker isolation)
-  mode: container  # default: safest cross-platform option
+  mode: local  # default: Shuru microVMs on macOS
 
   local:
-    # Firecracker settings (only used when mode: local)
-    max_vms: 10
-    vm_memory_mb: 512
-    vm_vcpus: 1
-    vm_timeout_sec: 300
-    # Network: VMs can ONLY reach the gateway. No internet.
-    network_policy: gateway-only
+    # Shuru settings (only used when mode: local)
+    max_sandboxes: 10
+    memory_mb: 512
+    cpus: 1
+    timeout_sec: 300
+    checkpoint: sp-python   # pre-loaded Python checkpoint for fast start
 
   cloud:
     # SignalPilot Cloud settings (only used when mode: cloud)


### PR DESCRIPTION
…lity

Firecracker requires KVM (Linux-only), making local development impossible on Apple Silicon Macs. Shuru uses Apple's Virtualization.framework natively, eliminating the need for Docker, KVM, or nested virtualization.

- Rewrite sandbox_manager.py to spawn Shuru VMs via subprocess
- Two-step checkpoint system: base (installs Python) + app (preloads modules)
- Update gateway, MCP server, CLI, and web UI references
- Remove Docker sandbox service from main compose (Shuru runs natively)
- Simplify Dockerfile.sandbox to just Python + aiohttp