### PR TITLE
Add Cloudflare tunnel management for remote access

### DIFF
--- a/self-improve/monitor-web/lib/api.ts
+++ b/self-improve/monitor-web/lib/api.ts
@@ -1,10 +1,16 @@
 import type { Run, ToolCall, AuditEvent } from "./types";
 
-// FastAPI backend runs on port 3401 (same host)
-// SSE and all API calls go directly to FastAPI, not through Next.js rewrite
+// FastAPI backend runs on port 3401.
+// On localhost: call port 3401 directly.
+// Via tunnel/remote: use relative URLs so Next.js rewrites proxy to the backend.
 function getApiBase(): string {
   if (typeof window === "undefined") return "http://localhost:3401";
-  return `${window.location.protocol}//${window.location.hostname}:3401`;
+  const host = window.location.hostname;
+  if (host === "localhost" || host === "127.0.0.1") {
+    return `${window.location.protocol}//${host}:3401`;
+  }
+  // Remote access — use relative URL, Next.js rewrite proxies to backend
+  return "";
 }
 
 export async function fetchRuns(): Promise<Run[]> {

--- a/self-improve/monitor-web/next.config.ts
+++ b/self-improve/monitor-web/next.config.ts
@@ -1,12 +1,15 @@
 import type { NextConfig } from "next";
 
+// Server-side rewrite target: Docker service name for container-to-container,
+// falls back to localhost for local dev outside Docker.
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.API_URL || "http://localhost:3401";
+
 const nextConfig: NextConfig = {
   async rewrites() {
-    const apiUrl = process.env.API_URL || "http://localhost:3401";
     return [
       {
         source: "/api/:path*",
-        destination: `${apiUrl}/api/:path*`,
+        destination: `${API_INTERNAL}/api/:path*`,
       },
     ];
   },

--- a/signalpilot/docker/Dockerfile.gateway
+++ b/signalpilot/docker/Dockerfile.gateway
@@ -2,6 +2,19 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Install cloudflared for tunnel management (auto-detect arch)
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
+      CF_ARCH="arm64"; \
+    else \
+      CF_ARCH="amd64"; \
+    fi && \
+    curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${CF_ARCH}" \
+      -o /usr/local/bin/cloudflared && \
+    chmod +x /usr/local/bin/cloudflared && \
+    apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
 # Copy source first so pip can find the package
 COPY pyproject.toml .
 COPY gateway/ gateway/

--- a/signalpilot/docker/docker-compose.yml
+++ b/signalpilot/docker/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     environment:
       - SP_DATA_DIR=/data
       - SP_SANDBOX_MANAGER_URL=http://sandbox:8080
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - sp-data:/data
     command: ["uvicorn", "gateway.main:app", "--host", "0.0.0.0", "--port", "3300"]

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -19,6 +19,13 @@ Endpoints:
 
   POST /api/query              governed SQL query (direct DB)
 
+  GET  /api/tunnels            list tunnels
+  POST /api/tunnels            create + start tunnel
+  GET  /api/tunnels/{id}       tunnel details
+  DELETE /api/tunnels/{id}     stop + delete tunnel
+  POST /api/tunnels/{id}/stop  stop without deleting
+  POST /api/tunnels/{id}/start (re)start a stopped tunnel
+
   GET  /api/audit              audit log
   GET  /api/metrics            SSE live metrics stream
 """
@@ -31,9 +38,9 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Query
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi import FastAPI, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .engine import inject_limit, validate_sql
 from .middleware import APIKeyAuthMiddleware, RateLimitMiddleware, SecurityHeadersMiddleware
@@ -43,25 +50,34 @@ from .models import (
     ExecuteRequest,
     GatewaySettings,
     SandboxCreate,
+    TunnelCreate,
+    TunnelInfo,
+    TunnelStatus,
 )
 from .connectors.pool_manager import pool_manager
 from .connectors.health_monitor import health_monitor
 from .connectors.schema_cache import schema_cache
 from .sandbox_client import SandboxClient
+from .tunnel_manager import TunnelManager
 from .store import (
     append_audit,
     create_connection,
     delete_connection,
     delete_sandbox,
+    delete_tunnel,
     get_connection,
     get_connection_string,
     get_sandbox,
+    get_tunnel,
     list_connections,
     list_sandboxes,
+    list_tunnels,
     load_settings,
+    load_tunnels,
     read_audit,
     save_settings,
     upsert_sandbox,
+    upsert_tunnel,
 )
 
 # ─── Error Sanitization (HIGH-06) ────────────────────────────────────────────
@@ -110,10 +126,18 @@ def _reset_sandbox_client():
     _sandbox_client = None
 
 
+# ─── Tunnel Manager ─────────────────────────────────────────────────────────
+
+_tunnel_manager = TunnelManager()
+
+
 # ─── App ─────────────────────────────────────────────────────────────────────
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Load persisted tunnels (all as stopped)
+    load_tunnels()
+
     # Start background pool cleanup task
     async def _pool_cleanup_loop():
         while True:
@@ -125,6 +149,7 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         cleanup_task.cancel()
+        await _tunnel_manager.stop_all()
         await pool_manager.close_all()
         if _sandbox_client:
             await _sandbox_client.close()
@@ -137,26 +162,58 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS — restrict to known origins instead of wildcard (CRIT-02 fix)
-_ALLOWED_ORIGINS = [
+# CORS — dynamic origin allowlist (CRIT-02 fix + tunnel support)
+import os as _os
+
+_ALLOWED_ORIGINS: set[str] = {
     "http://localhost:3200",
     "http://localhost:3000",
     "http://127.0.0.1:3200",
     "http://127.0.0.1:3000",
-]
-# Allow override via env var for production deployments
-import os as _os
+}
 _extra_origins = _os.getenv("SP_ALLOWED_ORIGINS", "")
 if _extra_origins:
-    _ALLOWED_ORIGINS.extend(o.strip() for o in _extra_origins.split(",") if o.strip())
+    _ALLOWED_ORIGINS.update(o.strip() for o in _extra_origins.split(",") if o.strip())
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_ALLOWED_ORIGINS,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization", "X-API-Key"],
-    allow_credentials=True,
-)
+_CORS_METHODS = "GET, POST, PUT, DELETE, OPTIONS"
+_CORS_HEADERS = "Content-Type, Authorization, X-API-Key"
+
+
+def add_tunnel_origin(url: str):
+    _ALLOWED_ORIGINS.add(url.rstrip("/"))
+
+
+def remove_tunnel_origin(url: str):
+    _ALLOWED_ORIGINS.discard(url.rstrip("/"))
+
+
+class DynamicCORSMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        origin = request.headers.get("origin", "")
+
+        # Handle preflight
+        if request.method == "OPTIONS" and origin in _ALLOWED_ORIGINS:
+            return Response(
+                status_code=204,
+                headers={
+                    "Access-Control-Allow-Origin": origin,
+                    "Access-Control-Allow-Methods": _CORS_METHODS,
+                    "Access-Control-Allow-Headers": _CORS_HEADERS,
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Max-Age": "600",
+                },
+            )
+
+        response = await call_next(request)
+
+        if origin in _ALLOWED_ORIGINS:
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+
+        return response
+
+
+app.add_middleware(DynamicCORSMiddleware)
 
 # Security middleware stack (order matters: outermost runs first)
 app.add_middleware(SecurityHeadersMiddleware)
@@ -861,3 +918,116 @@ async def metrics_stream():
             await asyncio.sleep(5)
 
     return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+# ─── Tunnels ────────────────────────────────────────────────────────────────
+
+@app.get("/api/tunnels")
+async def get_tunnels():
+    return list_tunnels()
+
+
+@app.post("/api/tunnels", status_code=201)
+async def create_tunnel_endpoint(req: TunnelCreate):
+    # Check for duplicate port
+    for t in list_tunnels():
+        if t.local_port == req.local_port and t.status in (TunnelStatus.running, TunnelStatus.starting):
+            raise HTTPException(status_code=409, detail=f"Port {req.local_port} is already tunneled")
+
+    tunnel = TunnelInfo(
+        id=str(uuid.uuid4()),
+        label=req.label or f"port-{req.local_port}",
+        local_port=req.local_port,
+        status=TunnelStatus.starting,
+        created_at=time.time(),
+    )
+    upsert_tunnel(tunnel)
+
+    tunnel = await _tunnel_manager.start_tunnel(tunnel)
+
+    # Add tunnel URL to CORS allowlist
+    if tunnel.public_url:
+        add_tunnel_origin(tunnel.public_url)
+
+    await append_audit(AuditEntry(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        event_type="tunnel",
+        metadata={
+            "action": "create",
+            "tunnel_id": tunnel.id,
+            "local_port": tunnel.local_port,
+            "public_url": tunnel.public_url,
+            "status": tunnel.status,
+        },
+    ))
+
+    return tunnel
+
+
+@app.get("/api/tunnels/{tunnel_id}")
+async def get_tunnel_detail(tunnel_id: str):
+    tunnel = get_tunnel(tunnel_id)
+    if not tunnel:
+        raise HTTPException(status_code=404, detail="Tunnel not found")
+    return tunnel
+
+
+@app.delete("/api/tunnels/{tunnel_id}", status_code=204)
+async def remove_tunnel(tunnel_id: str):
+    tunnel = get_tunnel(tunnel_id)
+    if not tunnel:
+        raise HTTPException(status_code=404, detail="Tunnel not found")
+
+    if tunnel.public_url:
+        remove_tunnel_origin(tunnel.public_url)
+
+    await _tunnel_manager.stop_tunnel(tunnel_id)
+    delete_tunnel(tunnel_id)
+
+    await append_audit(AuditEntry(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        event_type="tunnel",
+        metadata={"action": "delete", "tunnel_id": tunnel_id, "local_port": tunnel.local_port},
+    ))
+
+
+@app.post("/api/tunnels/{tunnel_id}/stop")
+async def stop_tunnel_endpoint(tunnel_id: str):
+    tunnel = get_tunnel(tunnel_id)
+    if not tunnel:
+        raise HTTPException(status_code=404, detail="Tunnel not found")
+
+    if tunnel.public_url:
+        remove_tunnel_origin(tunnel.public_url)
+
+    await _tunnel_manager.stop_tunnel(tunnel_id)
+    tunnel.status = TunnelStatus.stopped
+    tunnel.pid = None
+    tunnel.public_url = None
+    tunnel.started_at = None
+    upsert_tunnel(tunnel)
+    return tunnel
+
+
+@app.post("/api/tunnels/{tunnel_id}/start")
+async def start_tunnel_endpoint(tunnel_id: str):
+    tunnel = get_tunnel(tunnel_id)
+    if not tunnel:
+        raise HTTPException(status_code=404, detail="Tunnel not found")
+
+    if tunnel.status == TunnelStatus.running:
+        raise HTTPException(status_code=409, detail="Tunnel is already running")
+
+    # Check for duplicate port
+    for t in list_tunnels():
+        if t.id != tunnel_id and t.local_port == tunnel.local_port and t.status in (TunnelStatus.running, TunnelStatus.starting):
+            raise HTTPException(status_code=409, detail=f"Port {tunnel.local_port} is already tunneled by another tunnel")
+
+    tunnel = await _tunnel_manager.start_tunnel(tunnel)
+
+    if tunnel.public_url:
+        add_tunnel_origin(tunnel.public_url)
+
+    return tunnel

--- a/signalpilot/gateway/gateway/models.py
+++ b/signalpilot/gateway/gateway/models.py
@@ -129,6 +129,32 @@ class AuditEntry(BaseModel):
     metadata: dict[str, Any] = {}
 
 
+# ─── Tunnels ─────────────────────────────────────────────────────────────────
+
+class TunnelStatus(str, Enum):
+    starting = "starting"
+    running = "running"
+    stopped = "stopped"
+    error = "error"
+
+
+class TunnelCreate(BaseModel):
+    label: str = Field(default="", max_length=128)
+    local_port: int = Field(..., ge=1, le=65535)
+
+
+class TunnelInfo(BaseModel):
+    id: str
+    label: str = ""
+    local_port: int
+    public_url: str | None = None
+    status: TunnelStatus = TunnelStatus.stopped
+    error_message: str | None = None
+    created_at: float = Field(default_factory=time.time)
+    started_at: float | None = None
+    pid: int | None = None
+
+
 # ─── MCP ─────────────────────────────────────────────────────────────────────
 
 class MCPToolCall(BaseModel):

--- a/signalpilot/gateway/gateway/store.py
+++ b/signalpilot/gateway/gateway/store.py
@@ -24,6 +24,8 @@ from .models import (
     DBType,
     GatewaySettings,
     SandboxInfo,
+    TunnelInfo,
+    TunnelStatus,
 )
 
 DATA_DIR = Path(os.getenv("SP_DATA_DIR", str(Path.home() / ".signalpilot")))
@@ -31,6 +33,7 @@ CONNECTIONS_FILE = DATA_DIR / "connections.json"
 SANDBOXES_FILE = DATA_DIR / "sandboxes.json"
 SETTINGS_FILE = DATA_DIR / "settings.json"
 AUDIT_FILE = DATA_DIR / "audit.jsonl"
+TUNNELS_FILE = DATA_DIR / "tunnels.json"
 
 # In-memory vault for raw credentials (never written to disk in plain text)
 _credential_vault: dict[str, str] = {}
@@ -253,3 +256,50 @@ async def read_audit(
     # Most recent first
     entries.sort(key=lambda e: e.timestamp, reverse=True)
     return entries[offset : offset + limit]
+
+
+# ─── Tunnels ────────────────────────────────────────────────────────────────
+
+_tunnels: dict[str, TunnelInfo] = {}
+
+
+def load_tunnels():
+    """Load persisted tunnels from disk. All reset to stopped (no live process)."""
+    global _tunnels
+    data = _load_json(TUNNELS_FILE, {})
+    _tunnels = {}
+    for tid, raw in data.items():
+        t = TunnelInfo(**raw)
+        t.status = TunnelStatus.stopped
+        t.pid = None
+        t.public_url = None
+        t.started_at = None
+        t.error_message = None
+        _tunnels[tid] = t
+
+
+def list_tunnels() -> list[TunnelInfo]:
+    return list(_tunnels.values())
+
+
+def get_tunnel(tunnel_id: str) -> TunnelInfo | None:
+    return _tunnels.get(tunnel_id)
+
+
+def upsert_tunnel(tunnel: TunnelInfo):
+    _tunnels[tunnel.id] = tunnel
+    _persist_tunnels()
+
+
+def delete_tunnel(tunnel_id: str) -> bool:
+    if tunnel_id not in _tunnels:
+        return False
+    del _tunnels[tunnel_id]
+    _persist_tunnels()
+    return True
+
+
+def _persist_tunnels():
+    """Write tunnel configs to disk (runtime state like pid is included but reset on load)."""
+    data = {tid: t.model_dump() for tid, t in _tunnels.items()}
+    _save_json(TUNNELS_FILE, data)

--- a/signalpilot/gateway/gateway/tunnel_manager.py
+++ b/signalpilot/gateway/gateway/tunnel_manager.py
@@ -1,0 +1,225 @@
+"""
+Cloudflare quick-tunnel process manager.
+
+Spawns `cloudflared tunnel --url http://{host}:{port}` as child processes,
+parses the assigned public URL from stderr, and monitors process lifetime.
+
+Inside Docker, ports on other containers are reached by service name
+(e.g. web:3200 instead of localhost:3200).  The mapping is configured via
+the SP_TUNNEL_HOST_MAP env var:  "3200=web,8180=sandbox"
+The gateway's own port (3300) always resolves to localhost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import signal
+import time
+
+from .models import TunnelInfo, TunnelStatus
+from .store import upsert_tunnel
+
+logger = logging.getLogger(__name__)
+
+_URL_PATTERN = re.compile(r"(https://[a-zA-Z0-9-]+\.trycloudflare\.com)")
+
+# Graceful stop timeout before SIGKILL
+_STOP_TIMEOUT = 5
+
+# Port -> internal hostname mapping for Docker networking.
+# Services on the same docker-compose network use their service name.
+# Services on a different network (e.g. self-improve) use host.docker.internal
+# to reach the port exposed on the Docker host.
+# Override with SP_TUNNEL_HOST_MAP env var.
+_DEFAULT_HOST_MAP: dict[int, str] = {
+    3200: "web",                    # Next.js frontend (same network)
+    3400: "host.docker.internal",   # self-improve monitor web (different network)
+    3401: "host.docker.internal",   # self-improve monitor API (different network)
+    8180: "sandbox",                # firecracker sandbox manager (same network)
+}
+
+
+def _load_host_map() -> dict[int, str]:
+    """Build the port->host map from defaults + env override."""
+    host_map = dict(_DEFAULT_HOST_MAP)
+    raw = os.getenv("SP_TUNNEL_HOST_MAP", "")
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if "=" in entry:
+            port_str, host = entry.split("=", 1)
+            try:
+                host_map[int(port_str.strip())] = host.strip()
+            except ValueError:
+                pass
+    return host_map
+
+
+def resolve_tunnel_target(port: int) -> str:
+    """Return the internal URL that cloudflared should connect to for a given port."""
+    host_map = _load_host_map()
+    host = host_map.get(port, "localhost")
+    # For sandbox, the internal port is 8080 even though it's exposed as 8180
+    if port == 8180 and host != "localhost":
+        return f"http://{host}:8080"
+    return f"http://{host}:{port}"
+
+
+class TunnelManager:
+    """Manages cloudflared child processes."""
+
+    def __init__(self) -> None:
+        self._processes: dict[str, asyncio.subprocess.Process] = {}
+        self._monitors: dict[str, asyncio.Task[None]] = {}
+        self._stopping: set[str] = set()  # tunnels being intentionally stopped
+
+    @staticmethod
+    def cloudflared_available() -> bool:
+        return shutil.which("cloudflared") is not None
+
+    async def start_tunnel(self, tunnel: TunnelInfo) -> TunnelInfo:
+        """Spawn cloudflared and extract the public URL."""
+        if not self.cloudflared_available():
+            tunnel.status = TunnelStatus.error
+            tunnel.error_message = (
+                "cloudflared binary not found on PATH. "
+                "Install from https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+            )
+            upsert_tunnel(tunnel)
+            return tunnel
+
+        tunnel.status = TunnelStatus.starting
+        tunnel.error_message = None
+        upsert_tunnel(tunnel)
+
+        target_url = resolve_tunnel_target(tunnel.local_port)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "cloudflared", "tunnel", "--url", target_url,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError as e:
+            tunnel.status = TunnelStatus.error
+            tunnel.error_message = f"Failed to start cloudflared: {e}"
+            upsert_tunnel(tunnel)
+            return tunnel
+
+        self._processes[tunnel.id] = proc
+        tunnel.pid = proc.pid
+
+        # Parse URL from stderr (cloudflared prints it there)
+        public_url = await self._extract_url(proc, timeout=20)
+
+        if public_url:
+            tunnel.public_url = public_url
+            tunnel.status = TunnelStatus.running
+            tunnel.started_at = time.time()
+            logger.info("Tunnel %s started: %s -> %s", tunnel.id, public_url, target_url)
+        else:
+            tunnel.status = TunnelStatus.error
+            tunnel.error_message = "Timed out waiting for public URL from cloudflared"
+            await self._kill_process(tunnel.id)
+
+        upsert_tunnel(tunnel)
+
+        # Start background monitor if process is still alive
+        if tunnel.status == TunnelStatus.running:
+            task = asyncio.create_task(self._monitor_process(tunnel.id))
+            self._monitors[tunnel.id] = task
+
+        return tunnel
+
+    async def stop_tunnel(self, tunnel_id: str) -> bool:
+        """Stop a running tunnel process."""
+        self._stopping.add(tunnel_id)
+        try:
+            cancelled = await self._kill_process(tunnel_id)
+            # Cancel the monitor task
+            monitor = self._monitors.pop(tunnel_id, None)
+            if monitor and not monitor.done():
+                monitor.cancel()
+            return cancelled
+        finally:
+            self._stopping.discard(tunnel_id)
+
+    async def stop_all(self):
+        """Stop all running tunnels (called during gateway shutdown)."""
+        tunnel_ids = list(self._processes.keys())
+        for tid in tunnel_ids:
+            await self.stop_tunnel(tid)
+
+    async def _extract_url(self, proc: asyncio.subprocess.Process, timeout: float) -> str | None:
+        """Read stderr lines until we find the trycloudflare.com URL."""
+        assert proc.stderr is not None
+
+        async def _read_lines() -> str | None:
+            while True:
+                line = await proc.stderr.readline()  # type: ignore[union-attr]
+                if not line:
+                    return None
+                text = line.decode("utf-8", errors="replace")
+                match = _URL_PATTERN.search(text)
+                if match:
+                    return match.group(1)
+
+        try:
+            return await asyncio.wait_for(_read_lines(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def _kill_process(self, tunnel_id: str) -> bool:
+        proc = self._processes.pop(tunnel_id, None)
+        if proc is None or proc.returncode is not None:
+            return False
+
+        # Try graceful termination first
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            return False
+
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=_STOP_TIMEOUT)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+
+        return True
+
+    async def _monitor_process(self, tunnel_id: str):
+        """Watch for unexpected process exit."""
+        proc = self._processes.get(tunnel_id)
+        if proc is None:
+            return
+
+        try:
+            returncode = await proc.wait()
+        except asyncio.CancelledError:
+            return
+
+        # Process exited — clean up
+        self._processes.pop(tunnel_id, None)
+
+        # If we intentionally stopped it, the stop_tunnel method handles state
+        if tunnel_id in self._stopping:
+            return
+
+        from .store import get_tunnel
+        tunnel = get_tunnel(tunnel_id)
+        if tunnel is None:
+            return
+
+        tunnel.status = TunnelStatus.error
+        tunnel.error_message = f"cloudflared exited unexpectedly (code {returncode})"
+        tunnel.pid = None
+        tunnel.public_url = None
+        upsert_tunnel(tunnel)
+        logger.warning("Tunnel %s died with code %d", tunnel_id, returncode)

--- a/signalpilot/web/app/tunnels/page.tsx
+++ b/signalpilot/web/app/tunnels/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import {
+  Plus,
+  Trash2,
+  Loader2,
+  Play,
+  Square,
+  Copy,
+  Check,
+  ExternalLink,
+  Globe,
+} from "lucide-react";
+import {
+  getTunnels,
+  createTunnel,
+  deleteTunnel,
+  stopTunnel,
+  startTunnel,
+} from "@/lib/api";
+import type { TunnelInfo } from "@/lib/types";
+import { EmptyTerminal, EmptyState } from "@/components/ui/empty-states";
+import { PageHeader, TerminalBar } from "@/components/ui/page-header";
+import { StatusDot } from "@/components/ui/data-viz";
+import { useToast } from "@/components/ui/toast";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+const PORT_PRESETS = [
+  { port: 3200, label: "Web UI" },
+  { port: 3300, label: "Gateway API" },
+  { port: 3400, label: "Monitor" },
+  { port: 3401, label: "Monitor API" },
+];
+
+function formatUptime(startedAt: number | null): string {
+  if (!startedAt) return "--";
+  const sec = Math.floor((Date.now() / 1000) - startedAt);
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ${sec % 60}s`;
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+export default function TunnelsPage() {
+  const { toast } = useToast();
+  const [tunnels, setTunnels] = useState<TunnelInfo[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [stopping, setStopping] = useState<string | null>(null);
+  const [starting, setStarting] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TunnelInfo | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [form, setForm] = useState({ port: "3200", label: "", customPort: "" });
+
+  const refresh = useCallback(() => {
+    getTunnels().then(setTunnels).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const i = setInterval(refresh, 5000);
+    return () => clearInterval(i);
+  }, [refresh]);
+
+  const selectedPort = form.port === "custom" ? parseInt(form.customPort) || 0 : parseInt(form.port);
+
+  async function handleCreate() {
+    if (!selectedPort || selectedPort < 1 || selectedPort > 65535) {
+      toast("invalid port number", "error");
+      return;
+    }
+    setCreating(true);
+    try {
+      const t = await createTunnel({ local_port: selectedPort, label: form.label || undefined });
+      if (t.status === "error") {
+        toast(t.error_message || "tunnel failed to start", "error");
+      } else {
+        toast("tunnel created", "success");
+      }
+      setShowForm(false);
+      setForm({ port: "3200", label: "", customPort: "" });
+      refresh();
+    } catch (e) {
+      toast(String(e), "error");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleStop(id: string) {
+    setStopping(id);
+    try {
+      await stopTunnel(id);
+      toast("tunnel stopped", "info");
+      refresh();
+    } catch (e) {
+      toast(String(e), "error");
+    } finally {
+      setStopping(null);
+    }
+  }
+
+  async function handleStart(id: string) {
+    setStarting(id);
+    try {
+      const t = await startTunnel(id);
+      if (t.status === "error") {
+        toast(t.error_message || "tunnel failed to start", "error");
+      } else {
+        toast("tunnel started", "success");
+      }
+      refresh();
+    } catch (e) {
+      toast(String(e), "error");
+    } finally {
+      setStarting(null);
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget) return;
+    try {
+      await deleteTunnel(deleteTarget.id);
+      toast("tunnel deleted", "info");
+      refresh();
+    } catch (e) {
+      toast(String(e), "error");
+    }
+    setDeleteTarget(null);
+  }
+
+  function copyUrl(url: string) {
+    navigator.clipboard.writeText(url);
+    setCopied(url);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  const running = tunnels.filter((t) => t.status === "running").length;
+
+  return (
+    <div className="p-8 animate-fade-in">
+      <PageHeader
+        title="tunnels"
+        subtitle="networking"
+        description="expose local services to the internet via cloudflare quick tunnels"
+        actions={
+          <button
+            onClick={() => setShowForm(true)}
+            className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90"
+          >
+            <Plus className="w-3.5 h-3.5" /> new tunnel
+          </button>
+        }
+      />
+
+      <TerminalBar
+        path="tunnels --list"
+        status={<StatusDot status={running > 0 ? "healthy" : "unknown"} size={4} />}
+      >
+        <div className="flex items-center gap-6 text-xs">
+          <span className="text-[var(--color-text-dim)]">
+            total: <code className="text-[10px] text-[var(--color-text)]">{tunnels.length}</code>
+          </span>
+          <span className="text-[var(--color-text-dim)]">
+            active: <code className="text-[10px] text-[var(--color-success)]">{running}</code>
+          </span>
+        </div>
+      </TerminalBar>
+
+      {/* Create form */}
+      {showForm && (
+        <div className="mb-6 border border-[var(--color-border)] bg-[var(--color-bg-card)] animate-scale-in overflow-hidden">
+          <div className="px-6 py-3 border-b border-[var(--color-border)] flex items-center gap-2">
+            <Globe className="w-3.5 h-3.5 text-[var(--color-text-dim)]" strokeWidth={1.5} />
+            <span className="text-[10px] text-[var(--color-text-dim)] uppercase tracking-[0.15em]">new tunnel</span>
+          </div>
+          <div className="p-6">
+            <div className="grid grid-cols-3 gap-4 mb-5">
+              <div>
+                <label className="block text-[10px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">service</label>
+                <select
+                  value={form.port}
+                  onChange={(e) => setForm({ ...form, port: e.target.value })}
+                  className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)]"
+                >
+                  {PORT_PRESETS.map((p) => (
+                    <option key={p.port} value={String(p.port)}>
+                      {p.label} (:{p.port})
+                    </option>
+                  ))}
+                  <option value="custom">Custom port</option>
+                </select>
+              </div>
+              {form.port === "custom" && (
+                <div>
+                  <label className="block text-[10px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">port</label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={65535}
+                    placeholder="8080"
+                    value={form.customPort}
+                    onChange={(e) => setForm({ ...form, customPort: e.target.value })}
+                    className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tracking-wide"
+                  />
+                </div>
+              )}
+              <div>
+                <label className="block text-[10px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">label (optional)</label>
+                <input
+                  type="text"
+                  placeholder="my-tunnel"
+                  value={form.label}
+                  onChange={(e) => setForm({ ...form, label: e.target.value })}
+                  className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tracking-wide"
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleCreate}
+                disabled={creating || !selectedPort}
+                className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
+              >
+                {creating && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                create + start
+              </button>
+              <button
+                onClick={() => setShowForm(false)}
+                className="px-4 py-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors tracking-wider"
+              >
+                cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Tunnel list */}
+      {tunnels.length === 0 && !showForm ? (
+        <EmptyState
+          icon={EmptyTerminal}
+          title="no tunnels configured"
+          description="create a tunnel to expose a local service to the internet via cloudflare"
+          action={
+            <button
+              onClick={() => setShowForm(true)}
+              className="flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider"
+            >
+              <Plus className="w-3.5 h-3.5" /> create first tunnel
+            </button>
+          }
+        />
+      ) : (
+        <div className="space-y-2">
+          {tunnels.map((tunnel) => (
+            <div
+              key={tunnel.id}
+              className="bg-[var(--color-bg-card)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] transition-all card-accent-top"
+            >
+              <div className="flex items-center gap-4 p-4">
+                {/* Status */}
+                <div className="flex-shrink-0">
+                  <StatusDot
+                    status={
+                      tunnel.status === "running" ? "healthy" :
+                      tunnel.status === "starting" ? "warning" :
+                      tunnel.status === "error" ? "error" : "unknown"
+                    }
+                    size={5}
+                    pulse={tunnel.status === "running"}
+                  />
+                </div>
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-[var(--color-text)]">{tunnel.label}</span>
+                    <span className="text-[9px] px-1.5 py-0.5 border border-[var(--color-border)] text-[var(--color-text-dim)] tracking-wider">
+                      cf
+                    </span>
+                    <span className={`text-[10px] tracking-wider ${
+                      tunnel.status === "running" ? "text-[var(--color-success)]" :
+                      tunnel.status === "error" ? "text-[var(--color-error)]" :
+                      tunnel.status === "starting" ? "text-[var(--color-warning)]" :
+                      "text-[var(--color-text-dim)]"
+                    }`}>
+                      {tunnel.status}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-3 mt-1">
+                    <span className="text-[10px] text-[var(--color-text-dim)] tracking-wider tabular-nums">
+                      localhost:{tunnel.local_port}
+                    </span>
+                    {tunnel.public_url && (
+                      <>
+                        <span className="text-[10px] text-[var(--color-text-dim)]">&rarr;</span>
+                        <button
+                          onClick={() => copyUrl(tunnel.public_url!)}
+                          className="flex items-center gap-1.5 text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors tracking-wider group"
+                        >
+                          <span className="truncate max-w-[300px]">{tunnel.public_url}</span>
+                          {copied === tunnel.public_url ? (
+                            <Check className="w-3 h-3 text-[var(--color-success)] flex-shrink-0" />
+                          ) : (
+                            <Copy className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+                          )}
+                        </button>
+                        <a
+                          href={tunnel.public_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                      </>
+                    )}
+                  </div>
+
+                  {tunnel.error_message && (
+                    <p className="text-[10px] text-[var(--color-error)] mt-1 tracking-wider truncate max-w-lg">
+                      {tunnel.error_message}
+                    </p>
+                  )}
+
+                  {tunnel.status === "running" && tunnel.started_at && (
+                    <span className="text-[9px] text-[var(--color-text-dim)] mt-1 tracking-wider inline-block">
+                      uptime: {formatUptime(tunnel.started_at)}
+                    </span>
+                  )}
+                </div>
+
+                {/* Actions */}
+                <div className="flex items-center gap-1">
+                  {tunnel.status === "running" ? (
+                    <button
+                      onClick={() => handleStop(tunnel.id)}
+                      disabled={stopping === tunnel.id}
+                      className="flex items-center gap-1.5 px-2.5 py-1.5 text-[10px] text-[var(--color-text-dim)] hover:text-[var(--color-warning)] hover:bg-[var(--color-bg-hover)] transition-all tracking-wider"
+                    >
+                      {stopping === tunnel.id ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <Square className="w-3 h-3" strokeWidth={1.5} />
+                      )}
+                      stop
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handleStart(tunnel.id)}
+                      disabled={starting === tunnel.id || tunnel.status === "starting"}
+                      className="flex items-center gap-1.5 px-2.5 py-1.5 text-[10px] text-[var(--color-text-dim)] hover:text-[var(--color-success)] hover:bg-[var(--color-bg-hover)] transition-all tracking-wider"
+                    >
+                      {starting === tunnel.id || tunnel.status === "starting" ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <Play className="w-3 h-3" strokeWidth={1.5} />
+                      )}
+                      start
+                    </button>
+                  )}
+                  <button
+                    onClick={() => setDeleteTarget(tunnel)}
+                    className="p-1.5 text-[var(--color-text-dim)] hover:text-[var(--color-error)] hover:bg-[var(--color-error)]/5 transition-all"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="delete tunnel"
+        message={`Stop and remove tunnel "${deleteTarget?.label}" (port ${deleteTarget?.local_port})? The public URL will become inaccessible.`}
+        confirmLabel="delete"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -71,6 +71,15 @@ function NavIconAudit({ active }: { active: boolean }) {
     </svg>
   );
 }
+function NavIconTunnel({ active }: { active: boolean }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path d="M1 7H4M10 7H13" stroke="currentColor" strokeWidth="1" strokeLinecap="square" />
+      <rect x="4" y="3" width="6" height="8" rx="3" stroke="currentColor" strokeWidth="1" fill="none" />
+      {active && <circle cx="7" cy="7" r="1" fill="var(--color-success)" />}
+    </svg>
+  );
+}
 function NavIconSettings({ active }: { active: boolean }) {
   return (
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -89,8 +98,9 @@ const nav: { href: string; label: string; icon: NavIconComponent; shortcut: stri
   { href: "/sandboxes", label: "sandboxes", icon: NavIconSandbox, shortcut: "4" },
   { href: "/connections", label: "connections", icon: NavIconDatabase, shortcut: "5" },
   { href: "/health", label: "health", icon: NavIconHealth, shortcut: "6" },
-  { href: "/audit", label: "audit", icon: NavIconAudit, shortcut: "7" },
-  { href: "/settings", label: "settings", icon: NavIconSettings, shortcut: "8" },
+  { href: "/tunnels", label: "tunnels", icon: NavIconTunnel, shortcut: "7" },
+  { href: "/audit", label: "audit", icon: NavIconAudit, shortcut: "8" },
+  { href: "/settings", label: "settings", icon: NavIconSettings, shortcut: "9" },
 ];
 
 function SignalPilotLogo() {
@@ -165,11 +175,13 @@ export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const [activeSandboxes, setActiveSandboxes] = useState(0);
+  const [activeTunnels, setActiveTunnels] = useState(0);
   const [connHealth, setConnHealth] = useState<{ total: number; healthy: number }>({ total: 0, healthy: 0 });
 
   // Poll for active sandbox count and connection health
   const fetchCounts = useCallback(() => {
-    const url = typeof window !== "undefined" ? localStorage.getItem("sp_gateway_url") || "http://localhost:3300" : "";
+    const isRemote = typeof window !== "undefined" && window.location.hostname !== "localhost" && window.location.hostname !== "127.0.0.1";
+    const url = isRemote ? "" : (typeof window !== "undefined" ? localStorage.getItem("sp_gateway_url") || "http://localhost:3300" : "");
     const key = typeof window !== "undefined" ? localStorage.getItem("sp_api_key") : null;
     const headers: Record<string, string> = {};
     if (key) headers["Authorization"] = `Bearer ${key}`;
@@ -177,6 +189,12 @@ export default function Sidebar() {
       .then((r) => r.ok ? r.json() : [])
       .then((sandboxes: { status: string }[]) => {
         setActiveSandboxes(sandboxes.filter((s) => s.status === "running").length);
+      })
+      .catch(() => {});
+    fetch(`${url}/api/tunnels`, { headers })
+      .then((r) => r.ok ? r.json() : [])
+      .then((tunnels: { status: string }[]) => {
+        setActiveTunnels(tunnels.filter((t) => t.status === "running").length);
       })
       .catch(() => {});
     fetch(`${url}/api/health/connections`, { headers })
@@ -253,7 +271,7 @@ export default function Sidebar() {
       <nav className="flex-1 px-3 py-2 space-y-0.5">
         {nav.map(({ href, label, icon: Icon, shortcut }) => {
           const active = pathname.startsWith(href);
-          const badge = href === "/sandboxes" ? activeSandboxes : 0;
+          const badge = href === "/sandboxes" ? activeSandboxes : href === "/tunnels" ? activeTunnels : 0;
           return (
             <Link
               key={href}

--- a/signalpilot/web/lib/api.ts
+++ b/signalpilot/web/lib/api.ts
@@ -1,4 +1,18 @@
-const GATEWAY_URL = process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:3300";
+function getGatewayUrl(): string {
+  // Server-side (SSR): always use the env var or Docker internal URL
+  if (typeof window === "undefined") {
+    return process.env.NEXT_PUBLIC_GATEWAY_URL || "http://gateway:3300";
+  }
+  // Client-side on localhost: call gateway directly
+  const host = window.location.hostname;
+  if (host === "localhost" || host === "127.0.0.1") {
+    return process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:3300";
+  }
+  // Client-side via tunnel/remote: use relative URL so Next.js rewrites proxy to gateway
+  return "";
+}
+
+const GATEWAY_URL = getGatewayUrl();
 
 function getApiKey(): string | null {
   if (typeof window === "undefined") return null;
@@ -138,6 +152,15 @@ export const getSchemaCache = () =>
   request<{ cached_connections: number; total_entries: number; ttl_seconds: number }>("/api/schema-cache/stats");
 export const invalidateSchemaCache = (name?: string) =>
   request<{ invalidated: number }>(`/api/schema-cache/invalidate${name ? `?connection_name=${encodeURIComponent(name)}` : ""}`, { method: "POST" });
+
+// Tunnels
+export const getTunnels = () => request<import("./types").TunnelInfo[]>("/api/tunnels");
+export const createTunnel = (t: { local_port: number; label?: string }) =>
+  request<import("./types").TunnelInfo>("/api/tunnels", { method: "POST", body: JSON.stringify(t) });
+export const getTunnel = (id: string) => request<import("./types").TunnelInfo>(`/api/tunnels/${id}`);
+export const deleteTunnel = (id: string) => request<void>(`/api/tunnels/${id}`, { method: "DELETE" });
+export const stopTunnel = (id: string) => request<import("./types").TunnelInfo>(`/api/tunnels/${id}/stop`, { method: "POST" });
+export const startTunnel = (id: string) => request<import("./types").TunnelInfo>(`/api/tunnels/${id}/start`, { method: "POST" });
 
 // Metrics SSE
 export function subscribeMetrics(cb: (data: import("./types").MetricsSnapshot) => void): () => void {

--- a/signalpilot/web/lib/types.ts
+++ b/signalpilot/web/lib/types.ts
@@ -65,6 +65,18 @@ export interface AuditEntry {
   metadata: Record<string, unknown>;
 }
 
+export interface TunnelInfo {
+  id: string;
+  label: string;
+  local_port: number;
+  public_url: string | null;
+  status: "starting" | "running" | "stopped" | "error";
+  error_message: string | null;
+  created_at: number;
+  started_at: number | null;
+  pid: number | null;
+}
+
 export interface ConnectionHealthStats {
   connection_name: string;
   db_type: string;

--- a/signalpilot/web/next.config.ts
+++ b/signalpilot/web/next.config.ts
@@ -1,11 +1,20 @@
 import type { NextConfig } from "next";
 
+// Server-side gateway URL for rewrites (container-to-container).
+// Falls back to Docker service name since rewrites run on the Next.js server, not the browser.
+const GATEWAY_INTERNAL = process.env.SP_GATEWAY_INTERNAL_URL || "http://gateway:3300";
+
 const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
         source: "/gateway/:path*",
-        destination: `${process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:3300"}/:path*`,
+        destination: `${GATEWAY_INTERNAL}/:path*`,
+      },
+      // Proxy /api/* to gateway so tunnel access works without localhost
+      {
+        source: "/api/:path*",
+        destination: `${GATEWAY_INTERNAL}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- New **tunnels page** in the web UI (`/tunnels`) to create, start, stop, and delete Cloudflare quick tunnels
- Gateway spawns and manages `cloudflared` child processes with automatic public URL extraction
- `cloudflared` binary bundled in the gateway Docker image (multi-arch: amd64 + arm64)
- Dynamic CORS middleware automatically allows tunnel origins
- Both web UI (3200) and self-improve monitor (3400) detect remote access and proxy API calls through Next.js rewrites — no localhost dependency when accessed via tunnel

## Files changed
| Area | Files |
|------|-------|
| Backend | `tunnel_manager.py` (new), `models.py`, `store.py`, `main.py` |
| Docker | `Dockerfile.gateway`, `docker-compose.yml` |
| Web UI | `app/tunnels/page.tsx` (new), `sidebar.tsx`, `api.ts`, `types.ts`, `next.config.ts` |
| Monitor | `monitor-web/api.ts`, `monitor-web/next.config.ts` |

## Test plan
- [ ] `docker compose up --build` from `signalpilot/docker/`
- [ ] Navigate to `http://localhost:3200/tunnels`
- [ ] Create a tunnel for port 3200 → verify trycloudflare.com URL appears
- [ ] Open public URL in browser → verify web UI loads with data
- [ ] Create tunnel for port 3400 → verify monitor loads via tunnel
- [ ] Stop/delete tunnels → verify cleanup
- [ ] Verify localhost:3200 and localhost:3400 still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)