### PR TITLE
Fix stats bar showing zeros during active runs

### DIFF
--- a/self-improve/monitor-web/app/page.tsx
+++ b/self-improve/monitor-web/app/page.tsx
@@ -428,7 +428,7 @@ export default function MonitorPage() {
         {/* Center - Event feed */}
         <main className="flex-1 flex flex-col min-h-0 min-w-0">
           <EventFeed events={allEvents} />
-          <StatsBar run={selectedRun} connected={connected} />
+          <StatsBar run={selectedRun} connected={connected} events={allEvents} />
         </main>
 
         {/* Right sidebar - WorkTree */}

--- a/self-improve/monitor-web/components/stats/StatsBar.tsx
+++ b/self-improve/monitor-web/components/stats/StatsBar.tsx
@@ -1,13 +1,33 @@
 "use client";
 
+import { useMemo } from "react";
 import { motion } from "framer-motion";
-import type { Run } from "@/lib/types";
+import type { Run, FeedEvent } from "@/lib/types";
 
 function formatTokens(n: number | null): string {
   if (!n) return "0";
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${Math.floor(n / 1_000)}k`;
   return n.toString();
+}
+
+const ACTIVE_STATUSES = new Set(["running", "paused", "rate_limited"]);
+
+function computeLiveStats(events: FeedEvent[]) {
+  let toolCount = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  for (const e of events) {
+    if (e._kind === "tool" && e.data.phase === "pre") {
+      toolCount++;
+    } else if (e._kind === "usage") {
+      inputTokens = e.data.total_input_tokens || 0;
+      outputTokens = e.data.total_output_tokens || 0;
+    }
+  }
+
+  return { toolCount, inputTokens, outputTokens };
 }
 
 function Stat({
@@ -35,10 +55,15 @@ function Stat({
 export function StatsBar({
   run,
   connected,
+  events = [],
 }: {
   run: Run | null;
   connected: boolean;
+  events?: FeedEvent[];
 }) {
+  const isActive = run != null && ACTIVE_STATUSES.has(run.status);
+  const live = useMemo(() => computeLiveStats(events), [events]);
+
   if (!run) {
     return (
       <div className="h-8 flex items-center px-4 border-t border-[#1a1a1a] bg-[#050505]">
@@ -60,7 +85,7 @@ export function StatsBar({
           </svg>
         }
         label="Tools"
-        value={String(run.total_tool_calls || 0)}
+        value={String(isActive ? live.toolCount : (run.total_tool_calls || 0))}
       />
       <Stat
         icon={
@@ -70,7 +95,7 @@ export function StatsBar({
           </svg>
         }
         label="Cost"
-        value={`$${(run.total_cost_usd || 0).toFixed(2)}`}
+        value={isActive && !run.total_cost_usd ? "—" : `$${(run.total_cost_usd || 0).toFixed(2)}`}
         accent="text-[#00ff88]"
       />
       <Stat
@@ -80,7 +105,10 @@ export function StatsBar({
           </svg>
         }
         label="In/Out"
-        value={`${formatTokens(run.total_input_tokens)} / ${formatTokens(run.total_output_tokens)}`}
+        value={isActive
+          ? `${formatTokens(live.inputTokens)} / ${formatTokens(live.outputTokens)}`
+          : `${formatTokens(run.total_input_tokens)} / ${formatTokens(run.total_output_tokens)}`
+        }
       />
       {run.pr_url && (
         <a


### PR DESCRIPTION
## Summary
- StatsBar was reading `total_tool_calls`, `total_cost_usd`, and token counts from the database `Run` record, which only gets populated when `finish_run()` is called at the end of a run
- Now computes tools count and token totals from live SSE events during active runs (running/paused/rate_limited)
- Falls back to database values for completed runs
- Cost shows "—" during active runs since it's only computed server-side at run end

## Test plan
- [ ] Start a new run and verify bottom bar Tools and In/Out update in real-time
- [ ] Select a completed run and verify Tools, Cost, and In/Out show correct DB values
- [ ] Verify PR link still renders for runs with PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)