### PR TITLE
fix: add missing imports in agent main.py causing 502 on parallel endpoints

### DIFF
--- a/self-improve/agent/main.py
+++ b/self-improve/agent/main.py
@@ -25,10 +25,12 @@ Module layout:
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 import uvicorn
 
 from agent import db, endpoints
+from agent.run_manager import RunManager
 
 
 class ParallelStartRequest(BaseModel):
@@ -45,7 +47,9 @@ class ParallelSignalRequest(BaseModel):
     payload: str | None = None
 
 
-@asynccontextmanager
+_run_manager = RunManager()
+
+
 def _is_worker() -> bool:
     """Check if this process is running inside a worker container (not the orchestrator)."""
     try:
@@ -55,6 +59,7 @@ def _is_worker() -> bool:
         return False
 
 
+@asynccontextmanager
 async def lifespan(app: FastAPI):
     db_path = os.environ.get("DB_PATH", "/data/improve.db")
     await db.init_db(db_path)


### PR DESCRIPTION
## Summary
- Added missing imports (`BaseModel`, `HTTPException`, `RunManager`) and instantiated `_run_manager` in `self-improve/agent/main.py`
- Moved `@asynccontextmanager` decorator from `_is_worker()` to `lifespan()` where it belongs
- Fixes 502 Bad Gateway on `POST /api/parallel/start` and `GET /api/parallel/status`

## Test plan
- [x] Rebuilt agent container — starts without errors
- [ ] Verify `POST /api/parallel/start` returns 200
- [ ] Verify `GET /api/parallel/status` returns slot data

🤖 Generated with [Claude Code](https://claude.com/claude-code)