### PR TITLE
fix: parallel workers killing each other on startup

### DIFF
--- a/self-improve/agent/run_manager.py
+++ b/self-improve/agent/run_manager.py
@@ -255,6 +255,7 @@ class RunManager:
         env_flags: list[str] = [
             "-e", "GIT_TERMINAL_PROMPT=0",
             "-e", "DB_PATH=/data/improve.db",
+            "-e", "WORKER_MODE=1",
         ]
         if safe_creds.get("claude_token"):
             env_flags += ["-e", f"CLAUDE_CODE_OAUTH_TOKEN={safe_creds['claude_token']}"]
@@ -270,6 +271,7 @@ class RunManager:
         docker_args = (
             ["run", "-d",
              "--name", container_name,
+             "--hostname", container_name,
              "--network", env["network"],
              "--restart", "no",
              "--add-host", "host.docker.internal:host-gateway"]

--- a/self-improve/docker-compose.yml
+++ b/self-improve/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       MASTER_KEY_PATH: /data/master.key
       AGENT_API_URL: http://agent:8500
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:3400/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:3401/health || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/self-improve/monitor-entrypoint.sh
+++ b/self-improve/monitor-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Ensure shared data volume is writable by all containers (agent runs as non-root)
+chmod -R a+rw /data 2>/dev/null || true
+
 # Start FastAPI backend on port 3401
 uvicorn monitor.app:app --host 0.0.0.0 --port 3401 &
 FASTAPI_PID=$!


### PR DESCRIPTION
## Summary
- **Worker self-destruction**: Workers ran `cleanup_orphans()` on startup because `_is_worker()` always returned false — Docker sets hostname to container ID, not container name. Fixed by adding `--hostname` and `WORKER_MODE=1` env var to worker containers.
- **Monitor healthcheck**: Was hitting `/health` on port 3400 (nginx → Next.js 404) instead of port 3401 (FastAPI). Monitor appeared unhealthy despite working fine.
- **Shared volume permissions**: Monitor (root) created `improve.db`, agent (`agentuser`) couldn't write to it. Added `chmod -R a+rw /data` to monitor entrypoint.

## Test plan
- [ ] `docker compose build && docker compose up -d` — all 3 containers healthy
- [ ] Trigger a parallel run — worker container stays alive and completes
- [ ] Restart stack — orphan cleanup doesn't kill active workers
- [ ] Verify monitor healthcheck shows healthy within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)