### PR TITLE
feat: tunnel manager UI + fix remote API routing

### DIFF
--- a/self-improve/docker-compose.yml
+++ b/self-improve/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       start_period: 20s
     volumes:
       - improve-db:/data
+      - /var/run/docker.sock:/var/run/docker.sock
 
   tunnel:
     image: cloudflare/cloudflared:latest

--- a/self-improve/monitor-web/app/page.tsx
+++ b/self-improve/monitor-web/app/page.tsx
@@ -42,6 +42,7 @@ import { OnboardingModal } from "@/components/onboarding/OnboardingModal";
 import { ParallelRunsView } from "@/components/parallel/ParallelRunsView";
 import { MobileTab } from "@/components/mobile/MobileTab";
 import { MobileControlSheet } from "@/components/mobile/MobileControlSheet";
+import { TunnelPopover } from "@/components/ui/TunnelPopover";
 import { useMobile } from "@/hooks/useMobile";
 
 export default function MonitorPage() {
@@ -418,6 +419,9 @@ export default function MonitorPage() {
           style={!agentIdle && agentReachable ? { boxShadow: "0 0 4px rgba(0,255,136,0.3)" } : undefined}
         />
 
+        {/* Tunnel manager */}
+        <TunnelPopover />
+
         {/* Run status */}
         {selectedRun && <StatusBadge status={selectedRun.status as RunStatus} size="md" />}
 
@@ -534,6 +538,11 @@ export default function MonitorPage() {
             Event Feed
           </button>
         </div>
+
+        <div className="w-px h-4 bg-[#1a1a1a]" />
+
+        {/* Tunnel manager */}
+        <TunnelPopover />
 
         <div className="w-px h-4 bg-[#1a1a1a]" />
 

--- a/self-improve/monitor-web/app/settings/page.tsx
+++ b/self-improve/monitor-web/app/settings/page.tsx
@@ -55,7 +55,7 @@ const FIELDS: FieldConfig[] = [
 
 function getApiBase(): string {
   if (typeof window === "undefined") return "http://localhost:3401";
-  return `${window.location.protocol}//${window.location.hostname}:3401`;
+  return "";
 }
 
 export default function SettingsPage() {

--- a/self-improve/monitor-web/components/parallel/ParallelRunsPanel.tsx
+++ b/self-improve/monitor-web/components/parallel/ParallelRunsPanel.tsx
@@ -83,7 +83,7 @@ export function ParallelRunsPanel({
     const key = slot.run_id;
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:3401"}/api/parallel/runs/${key}/health`,
+        `/api/parallel/runs/${key}/health`,
       );
       setHealthMap((prev) => ({ ...prev, [key]: res.ok ? "ok" : "degraded" }));
     } catch {

--- a/self-improve/monitor-web/components/ui/TunnelPopover.tsx
+++ b/self-improve/monitor-web/components/ui/TunnelPopover.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useTunnel } from "@/hooks/useTunnel";
+import { Button } from "./Button";
+
+export function TunnelPopover() {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { status, url, loading, start, stop } = useTunnel();
+
+  const isRunning = status === "running";
+  const isStopped = status === "exited" || status === "not_found";
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleCopy = async () => {
+    if (!url) return;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const statusColor = isRunning
+    ? "bg-[#00ff88]"
+    : isStopped
+      ? "bg-[#ff4444]/60"
+      : "bg-[#ffaa00]";
+
+  const statusLabel = isRunning
+    ? "Running"
+    : status === "exited"
+      ? "Stopped"
+      : status === "not_found"
+        ? "Not Found"
+        : status === "restarting"
+          ? "Restarting"
+          : "Error";
+
+  return (
+    <div ref={ref} className="relative">
+      {/* Trigger */}
+      <button
+        onClick={() => setOpen(!open)}
+        className="relative p-1.5 rounded hover:bg-white/[0.04] text-[#888] hover:text-[#ccc] transition-colors"
+        title="Mobile Access"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
+          <line x1="12" y1="18" x2="12.01" y2="18" />
+        </svg>
+        {/* Active indicator dot */}
+        {isRunning && (
+          <span className="absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-[#00ff88]" />
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.15 }}
+            className="absolute top-full right-0 mt-1 z-50 w-[280px] bg-[#0a0a0a] border border-[#1a1a1a] rounded-lg shadow-xl shadow-black/50 overflow-hidden"
+          >
+            {/* Header */}
+            <div className="px-3 py-2 border-b border-[#1a1a1a]">
+              <span className="text-[9px] uppercase tracking-[0.1em] text-[#666] font-semibold">
+                Mobile Access
+              </span>
+            </div>
+
+            <div className="p-3 space-y-3">
+              {/* Status */}
+              <div className="flex items-center gap-2">
+                <span className={`h-1.5 w-1.5 rounded-full ${statusColor}`} />
+                <span className="text-[11px] text-[#ccc] font-medium">
+                  {statusLabel}
+                </span>
+              </div>
+
+              {/* URL */}
+              {isRunning && url && (
+                <div className="flex items-center gap-1.5">
+                  <div className="flex-1 min-w-0 px-2 py-1.5 bg-white/[0.03] border border-[#1a1a1a] rounded text-[10px] text-[#88ccff] font-mono truncate">
+                    {url}
+                  </div>
+                  <button
+                    onClick={handleCopy}
+                    className="shrink-0 p-1.5 rounded hover:bg-white/[0.04] text-[#888] hover:text-[#ccc] transition-colors"
+                    title="Copy URL"
+                  >
+                    {copied ? (
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#00ff88"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    ) : (
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <rect x="9" y="9" width="13" height="13" rx="2" />
+                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              )}
+
+              {isRunning && !url && (
+                <p className="text-[10px] text-[#666]">
+                  Waiting for tunnel URL...
+                </p>
+              )}
+
+              {isRunning && url && (
+                <p className="text-[10px] text-[#666] leading-relaxed">
+                  Open this URL on your phone to access the monitor remotely.
+                </p>
+              )}
+
+              {/* Toggle */}
+              <Button
+                variant={isRunning ? "danger" : "success"}
+                size="sm"
+                onClick={isRunning ? stop : start}
+                disabled={loading}
+                icon={
+                  isRunning ? (
+                    <svg
+                      width="10"
+                      height="10"
+                      viewBox="0 0 10 10"
+                      fill="currentColor"
+                    >
+                      <rect x="2" y="2" width="6" height="6" rx="1" />
+                    </svg>
+                  ) : (
+                    <svg
+                      width="10"
+                      height="10"
+                      viewBox="0 0 10 10"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    >
+                      <polygon points="3 2 8 5 3 8" />
+                    </svg>
+                  )
+                }
+              >
+                {loading
+                  ? "..."
+                  : isRunning
+                    ? "Stop Tunnel"
+                    : "Start Tunnel"}
+              </Button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/self-improve/monitor-web/hooks/useParallelRuns.ts
+++ b/self-improve/monitor-web/hooks/useParallelRuns.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { ParallelRunSlot, ParallelStatus } from "@/lib/types";
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3401";
+const API = "";
 
 const SAFE_ID = /^[\w-]+$/;
 

--- a/self-improve/monitor-web/hooks/useTunnel.ts
+++ b/self-improve/monitor-web/hooks/useTunnel.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  fetchTunnelStatus,
+  startTunnel as apiStart,
+  stopTunnel as apiStop,
+} from "@/lib/api";
+import type { TunnelStatus } from "@/lib/api";
+
+const POLL_INTERVAL = 10_000;
+const RAPID_POLLS = [1000, 3000, 5000];
+
+export function useTunnel() {
+  const [status, setStatus] = useState<TunnelStatus["status"]>("not_found");
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const rapidTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const refresh = useCallback(async () => {
+    const data = await fetchTunnelStatus();
+    setStatus(data.status);
+    setUrl(data.url);
+  }, []);
+
+  // Rapid-poll after an action to catch URL propagation
+  const rapidRefresh = useCallback(() => {
+    rapidTimers.current.forEach(clearTimeout);
+    rapidTimers.current = RAPID_POLLS.map((ms) =>
+      setTimeout(() => refresh(), ms),
+    );
+  }, [refresh]);
+
+  const start = useCallback(async () => {
+    setLoading(true);
+    try {
+      await apiStart();
+      setStatus("running");
+      rapidRefresh();
+    } finally {
+      setLoading(false);
+    }
+  }, [rapidRefresh]);
+
+  const stop = useCallback(async () => {
+    setLoading(true);
+    try {
+      await apiStop();
+      setStatus("exited");
+      setUrl(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Poll on interval
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, POLL_INTERVAL);
+    return () => {
+      clearInterval(id);
+      rapidTimers.current.forEach(clearTimeout);
+    };
+  }, [refresh]);
+
+  return { status, url, loading, start, stop, refresh };
+}

--- a/self-improve/monitor-web/lib/api.ts
+++ b/self-improve/monitor-web/lib/api.ts
@@ -137,6 +137,40 @@ export async function fetchRunDiff(runId: string): Promise<DiffStats> {
   }
 }
 
+// ── Tunnel ───────────────────────────────────────────────────────────────────
+
+export interface TunnelStatus {
+  status: "running" | "exited" | "not_found" | "restarting" | "error";
+  url: string | null;
+  container_id?: string;
+}
+
+export async function fetchTunnelStatus(): Promise<TunnelStatus> {
+  try {
+    const res = await fetch(`${getApiBase()}/api/tunnel/status`);
+    if (!res.ok) return { status: "error", url: null };
+    return res.json();
+  } catch {
+    return { status: "error", url: null };
+  }
+}
+
+export async function startTunnel(): Promise<{ ok: boolean }> {
+  const res = await fetch(`${getApiBase()}/api/tunnel/start`, {
+    method: "POST",
+  });
+  return res.json();
+}
+
+export async function stopTunnel(): Promise<{ ok: boolean }> {
+  const res = await fetch(`${getApiBase()}/api/tunnel/stop`, {
+    method: "POST",
+  });
+  return res.json();
+}
+
+// ── Branches ─────────────────────────────────────────────────────────────────
+
 export async function fetchBranches(repo?: string): Promise<string[]> {
   try {
     const params = repo ? `?repo=${encodeURIComponent(repo)}` : "";

--- a/self-improve/monitor/app.py
+++ b/self-improve/monitor/app.py
@@ -10,6 +10,7 @@ Provides:
 import asyncio
 import json
 import os
+import re
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -971,3 +972,70 @@ async def remove_repo(repo_slug: str):
     )
     await conn.commit()
     return {"ok": True, "remaining": repos}
+
+
+# ── Tunnel management ────────────────────────────────────────────────────────
+
+import docker  # noqa: E402
+
+_docker_client: docker.DockerClient | None = None
+TUNNEL_CONTAINER = "improve-tunnel"
+TUNNEL_URL_RE = re.compile(r"https://[a-zA-Z0-9-]+\.trycloudflare\.com")
+
+
+def _get_docker() -> docker.DockerClient:
+    global _docker_client
+    if _docker_client is None:
+        _docker_client = docker.from_env()
+    return _docker_client
+
+
+def _parse_tunnel_url(container) -> str | None:
+    try:
+        logs = container.logs(tail=50).decode("utf-8", errors="replace")
+        matches = TUNNEL_URL_RE.findall(logs)
+        return matches[-1] if matches else None
+    except Exception:
+        return None
+
+
+@app.get("/api/tunnel/status")
+async def tunnel_status():
+    try:
+        container = _get_docker().containers.get(TUNNEL_CONTAINER)
+        url = _parse_tunnel_url(container) if container.status == "running" else None
+        return {
+            "status": container.status,
+            "url": url,
+            "container_id": container.short_id,
+        }
+    except docker.errors.NotFound:
+        return {"status": "not_found", "url": None}
+    except docker.errors.APIError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+
+@app.post("/api/tunnel/start")
+async def tunnel_start():
+    try:
+        container = _get_docker().containers.get(TUNNEL_CONTAINER)
+        if container.status == "running":
+            return {"ok": True, "message": "already running"}
+        container.start()
+        return {"ok": True}
+    except docker.errors.NotFound:
+        raise HTTPException(status_code=404, detail="Tunnel container not found")
+    except docker.errors.APIError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+
+@app.post("/api/tunnel/stop")
+async def tunnel_stop():
+    try:
+        container = _get_docker().containers.get(TUNNEL_CONTAINER)
+        container.stop(timeout=5)
+        return {"ok": True}
+    except docker.errors.NotFound:
+        raise HTTPException(status_code=404, detail="Tunnel container not found")
+    except docker.errors.APIError as e:
+        raise HTTPException(status_code=502, detail=str(e))

--- a/self-improve/monitor/pyproject.toml
+++ b/self-improve/monitor/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "cryptography>=43.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.28.0",
+    "docker>=7.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary
- Add a tunnel manager button (smartphone icon) to the monitor header with a popover showing tunnel status, copyable public URL, and start/stop controls
- Mount Docker socket on monitor container so the backend can manage the `improve-tunnel` cloudflared container
- Fix client-side API calls in `useParallelRuns`, `ParallelRunsPanel`, and settings page that hardcoded `localhost:3401`, breaking bot controls when accessed remotely through the Cloudflare tunnel

## Test plan
- [ ] Open monitor locally at `localhost:3400` — tunnel icon visible in header, popover shows status + URL
- [ ] Open the tunnel URL on mobile — UI loads, events feed works
- [ ] Launch a bot from the tunnel URL — should work now (was broken before due to hardcoded localhost)
- [ ] Start/stop tunnel from the popover
- [ ] Settings page works through tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)