### PR TITLE
dbt agent: date hazard + non-determinism detection + JOIN/prompt optimization

### DIFF
--- a/benchmark/prompts/dbt_local_system.md
+++ b/benchmark/prompts/dbt_local_system.md
@@ -59,10 +59,9 @@ anything else. This single call tells you:
 - every model defined in the project (complete, stub, missing, orphan)
 - the exact yml-declared column contract for every model that needs work
 - the topologically-sorted build order for actionable models
-- source tables, macros, packages
-- any parse errors in the yml files themselves
+- source tables, macros, packages, and any yml parse errors
 
-Read the output carefully. The work order at the bottom is your plan.
+The work order at the bottom is your plan.
 
 If the output contains a "WARNING: Models use current_date" section, fix every
 flagged file before writing new SQL:
@@ -70,11 +69,14 @@ flagged file before writing new SQL:
 2. Find the column and table marked "USE THIS" in the output
 3. Replace `current_date`/`current_timestamp`/`now()` with
    `(SELECT MAX(<column>) FROM {{ ref('<table>') }})` using values from step 2
-4. Run `dbt run --select <model_name>` to verify.
+4. If the file is marked "PACKAGE MODEL": read it, create models/<name>.sql,
+   paste the full SQL, replace current_date with the subquery from step 3,
+   add `{{ config(materialized='table') }}` at top.
+5. Run `dbt run --select <model_name>` to verify each fix.
 
 If the output contains a "WARNING: Pre-shipped models use ROW_NUMBER" section,
-fix each flagged file:
-1. Find every ROW_NUMBER()/RANK()/DENSE_RANK() OVER (...)
+fix each flagged file (project: edit in-place; package: create override as above):
+1. Find every ROW_NUMBER()/RANK()/DENSE_RANK() OVER(...)
 2. Run `explore_table` or `SELECT COUNT(*), COUNT(DISTINCT <col>)` to check
    if ORDER BY columns are unique within each partition
 3. If not unique, append the primary key to the ORDER BY

--- a/benchmark/prompts/dbt_local_system.md
+++ b/benchmark/prompts/dbt_local_system.md
@@ -64,6 +64,22 @@ anything else. This single call tells you:
 
 Read the output carefully. The work order at the bottom is your plan.
 
+If the output contains a "WARNING: Models use current_date" section, fix every
+flagged file before writing new SQL:
+1. Call `mcp__signalpilot__get_date_boundaries connection_name="${instance_id}"`
+2. Find the column and table marked "USE THIS" in the output
+3. Replace `current_date`/`current_timestamp`/`now()` with
+   `(SELECT MAX(<column>) FROM {{ ref('<table>') }})` using values from step 2
+4. Run `dbt run --select <model_name>` to verify.
+
+If the output contains a "WARNING: Pre-shipped models use ROW_NUMBER" section,
+fix each flagged file:
+1. Find every ROW_NUMBER()/RANK()/DENSE_RANK() OVER (...)
+2. Run `explore_table` or `SELECT COUNT(*), COUNT(DISTINCT <col>)` to check
+   if ORDER BY columns are unique within each partition
+3. If not unique, append the primary key to the ORDER BY
+4. Run `dbt run --select <model_name>` to verify.
+
 Cross-check the result against the Task instruction above — if the task
 mentions a model or table that does NOT appear in the project map, the task
 wants you to create it from scratch. Add it to your build list.
@@ -93,6 +109,11 @@ For each missing model (in dependency order):
 - Use `{{ ref('model_name') }}` for other models, `{{ source('schema', 'table') }}` for raw tables
 - Use DuckDB syntax (no DATEADD, no ::date on non-ISO strings, INTERVAL '1' DAY not +1)
 - Add `{{ config(materialized='table') }}` at the top
+- Default to LEFT JOIN for all joins. Use INNER JOIN only when the task explicitly
+  says "only matching", "exclude", or filters non-matching rows. After writing any
+  model with JOINs, call `mcp__signalpilot__compare_join_types connection_name="${instance_id}"
+  left_table="<left>" right_table="<right>" join_keys="<keys>"` to verify no rows
+  are silently dropped.
 
 ### Step 4 — Run and fix
 Run: `${dbt_bin} run` (skip `dbt deps` unless `dbt_project_validate` told you to).

--- a/benchmark/skills/dbt-date-spines/SKILL.md
+++ b/benchmark/skills/dbt-date-spines/SKILL.md
@@ -23,6 +23,24 @@ Edit the model SQL directly. Replace `current_date`/`current_timestamp`/`now()` 
 
 Use the fact table with the most rows, or the one referenced in the task instruction.
 
+## Package Model Override
+
+If the flagged file is in `dbt_packages/` (marked "PACKAGE MODEL" in the warning):
+1. Read the full SQL from the package model file
+2. Create `models/<same_filename>.sql` — dbt prioritizes local models over package models
+3. Paste the entire package SQL into the new file and replace `current_date` with the data-driven endpoint
+4. Add `{{ config(materialized='table') }}` at the top
+
+Example: if `dbt_packages/shopify_source/models/stg_shopify__order.sql` uses `current_date`:
+```sql
+-- models/stg_shopify__order.sql  (local override — copy ENTIRE package SQL here)
+{{ config(materialized='table') }}
+-- Replace current_date with a data-driven endpoint:
+-- (SELECT MAX(order_date) FROM {{ ref('stg_orders') }})
+```
+
+Do NOT edit files inside `dbt_packages/` directly — `dbt deps` will overwrite your changes.
+
 ## Finding the Right Date
 
 Call `mcp__signalpilot__get_date_boundaries(connection_name="<id>")`.

--- a/benchmark/skills/dbt-date-spines/SKILL.md
+++ b/benchmark/skills/dbt-date-spines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: dbt-date-spines
+type: skill
+---
+
+# dbt Date Spine Hazard — Fixing current_date in Model Files
+
+## When This Applies
+- `dbt_project_map` reports "WARNING: Models use current_date"
+- `dbt run` produces far more rows than expected in a date-spine model
+
+These are pre-shipped model SQL files in `models/` — you have direct write access.
+For general date spine syntax, see `duckdb-sql` skill section 2.
+
+## Fix Pattern
+
+Edit the model SQL directly. Replace `current_date`/`current_timestamp`/`now()` with a data-driven endpoint — a subquery from the primary fact table:
+
+```sql
+-- Before:  ... CURRENT_DATE ...
+-- After:   ... (SELECT MAX(order_date) FROM {{ ref('stg_orders') }}) ...
+```
+
+Use the fact table with the most rows, or the one referenced in the task instruction.
+
+## Finding the Right Date
+
+Call `mcp__signalpilot__get_date_boundaries(connection_name="<id>")`.
+Use the primary fact table's max date (marked "USE THIS"). Never use the global max — dimension tables often have later dates.
+
+## Verification
+
+```
+dbt run --select <model_name>
+```
+```sql
+SELECT MIN(date_col), MAX(date_col), COUNT(*) FROM <model_name>
+```
+The spine's max date must match the source data's endpoint, not today's date.

--- a/benchmark/skills/dbt-workflow/SKILL.md
+++ b/benchmark/skills/dbt-workflow/SKILL.md
@@ -118,3 +118,16 @@ Over-exploration is the #1 cause of missing models. Follow this discipline:
 - **Last 25% of turns**: Fix errors, write non-priority models, run /dbt-verification.
 
 If halfway through your budget any priority model lacks a .sql file, STOP everything else and write it immediately — even a minimal version.
+
+## 13. Non-Deterministic Window Functions
+
+If `dbt_project_map` warns about ROW_NUMBER/RANK/DENSE_RANK in pre-shipped models, review each flagged file:
+1. Open the file and find every `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)` (or RANK/DENSE_RANK)
+2. Run `explore_table` or a COUNT DISTINCT query to verify whether the ORDER BY columns uniquely identify rows within each partition:
+   ```sql
+   SELECT COUNT(*), COUNT(DISTINCT <order_by_col>) FROM <table>;
+   ```
+3. If not unique, add a tiebreaker: append the table's primary key or a unique ID column to the ORDER BY
+4. Run `dbt run --select <model>` and verify row counts match expectations
+
+Common pattern: `ROW_NUMBER() OVER (ORDER BY patient_id)` — if patient_id repeats across rows, add a secondary sort like `ORDER BY patient_id, encounter_id`.

--- a/benchmark/skills_test.py
+++ b/benchmark/skills_test.py
@@ -57,7 +57,7 @@ GATEWAY_SRC = PROJECT_ROOT / "signalpilot" / "gateway"
 GATEWAY_URL = os.environ.get("SP_GATEWAY_URL", "http://localhost:3300")
 DBT_BIN = shutil.which("dbt") or str(Path.home() / ".local" / "bin" / "dbt")
 
-SKILL_NAMES = ["dbt-workflow", "dbt-verification", "dbt-debugging", "duckdb-sql"]
+SKILL_NAMES = ["dbt-workflow", "dbt-verification", "dbt-debugging", "duckdb-sql", "dbt-date-spines"]
 
 
 # ── Helpers (identical to run_dbt_local.py) ───────────────────
@@ -190,13 +190,14 @@ def build_skills_system_prompt(instruction: str, instance_id: str, dbt_bin: str)
     bootstrap = f"""\
 ## BOOTSTRAP — Execute these steps FIRST, before any task work
 
-You have 4 skills and a SignalPilot MCP server available. Load them all now.
+You have 5 skills and a SignalPilot MCP server available. Load them all now.
 
-### Step 1: Load all skills (call the Skill tool 4 times)
+### Step 1: Load all skills (call the Skill tool 5 times)
 - `Skill({{"skill": "dbt-workflow"}})`
 - `Skill({{"skill": "dbt-verification"}})`
 - `Skill({{"skill": "dbt-debugging"}})`
 - `Skill({{"skill": "duckdb-sql"}})`
+- `Skill({{"skill": "dbt-date-spines"}})`
 
 ### Step 2: Verify SignalPilot MCP connectivity
 - Call `ToolSearch({{"query": "select:mcp__signalpilot__dbt_project_map,mcp__signalpilot__dbt_project_validate,mcp__signalpilot__schema_link,mcp__signalpilot__query_database", "max_results": 5}})` to fetch the MCP tool schemas.
@@ -441,7 +442,7 @@ def main():
 
     # Evaluate
     print(f"\n{'=' * 60}")
-    print(f"Evaluating against gold standard...")
+    print("Evaluating against gold standard...")
     print(f"{'=' * 60}")
 
     try:
@@ -455,7 +456,7 @@ def main():
         print(f"\n  Evaluation error: {e}")
         traceback.print_exc()
         print(f"\n{'=' * 60}")
-        print(f"RESULT: ERROR")
+        print("RESULT: ERROR")
         print(f"{'=' * 60}")
 
 

--- a/signalpilot/gateway/gateway/dbt/formatters.py
+++ b/signalpilot/gateway/gateway/dbt/formatters.py
@@ -40,6 +40,23 @@ _ICON = {
 }
 
 
+def _date_hazard_lines(project: ProjectMap) -> list[str]:
+    """Render the date hazard warning section (if any)."""
+    if not project.date_hazards:
+        return []
+    lines = [
+        "## WARNING: Models use current_date (date spine hazard)",
+        "These model files use current_date/current_timestamp which will produce incorrect",
+        "row counts when run after the source data's date range. Edit them directly —",
+        "replace current_date with a subquery using MAX(date_col) from the source table.",
+        "Load the dbt-date-spines skill for the fix procedure.",
+    ]
+    for hazard in project.date_hazards:
+        lines.append(f"  - {hazard['file']} ({hazard['pattern']})")
+    lines.append("")
+    return lines
+
+
 def render_project_map(
     project_dir: str | Path,
     focus: str = "all",
@@ -175,6 +192,9 @@ def render_full(
         if len(project.parse_errors) > 20:
             lines.append(f"  (+{len(project.parse_errors) - 20} more)")
         lines.append("")
+
+    # Date hazard warning (if any model files use current_date)
+    lines.extend(_date_hazard_lines(project))
 
     # Footer — actionable next step hint
     lines.append(_footer(project))
@@ -323,6 +343,8 @@ def render_work_order(project: ProjectMap) -> str:
         for name, refs in sorted(project.unresolved_refs.items()):
             lines.append(f"   {name}: {', '.join(refs)}")
         lines.append("")
+
+    lines.extend(_date_hazard_lines(project))
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/signalpilot/gateway/gateway/dbt/formatters.py
+++ b/signalpilot/gateway/gateway/dbt/formatters.py
@@ -57,6 +57,20 @@ def _date_hazard_lines(project: ProjectMap) -> list[str]:
     return lines
 
 
+def _nondeterminism_lines(project: ProjectMap) -> list[str]:
+    """Render the non-determinism warning section (if any)."""
+    if not project.nondeterminism_warnings:
+        return []
+    lines = [
+        "## WARNING: Pre-shipped models use ROW_NUMBER (potential non-determinism)",
+        "ORDER BY may not be unique — add a tiebreaker (primary key) to each flagged file.",
+    ]
+    for warning in project.nondeterminism_warnings:
+        lines.append(f"  - {warning['file']}")
+    lines.append("")
+    return lines
+
+
 def render_project_map(
     project_dir: str | Path,
     focus: str = "all",
@@ -195,6 +209,9 @@ def render_full(
 
     # Date hazard warning (if any model files use current_date)
     lines.extend(_date_hazard_lines(project))
+
+    # Non-determinism warning (if any pre-shipped models use window ranking functions)
+    lines.extend(_nondeterminism_lines(project))
 
     # Footer — actionable next step hint
     lines.append(_footer(project))
@@ -345,6 +362,7 @@ def render_work_order(project: ProjectMap) -> str:
         lines.append("")
 
     lines.extend(_date_hazard_lines(project))
+    lines.extend(_nondeterminism_lines(project))
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/signalpilot/gateway/gateway/dbt/formatters.py
+++ b/signalpilot/gateway/gateway/dbt/formatters.py
@@ -47,12 +47,21 @@ def _date_hazard_lines(project: ProjectMap) -> list[str]:
     lines = [
         "## WARNING: Models use current_date (date spine hazard)",
         "These model files use current_date/current_timestamp which will produce incorrect",
-        "row counts when run after the source data's date range. Edit them directly —",
-        "replace current_date with a subquery using MAX(date_col) from the source table.",
+        "row counts when run after the source data's date range.",
         "Load the dbt-date-spines skill for the fix procedure.",
     ]
     for hazard in project.date_hazards:
-        lines.append(f"  - {hazard['file']} ({hazard['pattern']})")
+        if hazard.get("package"):
+            lines.append(
+                f"  - PACKAGE MODEL — copy to {hazard['override_path']} and fix there"
+                f" ({hazard['file']}, {hazard['pattern']})"
+            )
+        else:
+            lines.append(f"  - {hazard['file']} ({hazard['pattern']}) — edit directly")
+    lines.append(
+        "Action: edit project files in-place; for package files,"
+        " create a local override in models/ with the same filename."
+    )
     lines.append("")
     return lines
 
@@ -66,7 +75,17 @@ def _nondeterminism_lines(project: ProjectMap) -> list[str]:
         "ORDER BY may not be unique — add a tiebreaker (primary key) to each flagged file.",
     ]
     for warning in project.nondeterminism_warnings:
-        lines.append(f"  - {warning['file']}")
+        if warning.get("package"):
+            lines.append(
+                f"  - PACKAGE MODEL — copy to {warning['override_path']} and fix there"
+                f" ({warning['file']})"
+            )
+        else:
+            lines.append(f"  - {warning['file']} — edit directly")
+    lines.append(
+        "Action: edit project files in-place; for package files,"
+        " create a local override in models/ with the same filename."
+    )
     lines.append("")
     return lines
 

--- a/signalpilot/gateway/gateway/dbt/inventory.py
+++ b/signalpilot/gateway/gateway/dbt/inventory.py
@@ -95,6 +95,8 @@ def scan_project(project_dir: Path | str) -> ProjectMap:
     project_map.cycles = work_result["cycles"]
     project_map.unresolved_refs = work_result["unresolved"]
 
+    project_map.date_hazards = raw.get("date_hazards", [])
+
     return project_map
 
 

--- a/signalpilot/gateway/gateway/dbt/inventory.py
+++ b/signalpilot/gateway/gateway/dbt/inventory.py
@@ -96,6 +96,7 @@ def scan_project(project_dir: Path | str) -> ProjectMap:
     project_map.unresolved_refs = work_result["unresolved"]
 
     project_map.date_hazards = raw.get("date_hazards", [])
+    project_map.nondeterminism_warnings = raw.get("nondeterminism_warnings", [])
 
     return project_map
 

--- a/signalpilot/gateway/gateway/dbt/scanner.py
+++ b/signalpilot/gateway/gateway/dbt/scanner.py
@@ -75,6 +75,15 @@ _RE_DATE_HAZARD = re.compile(
     re.IGNORECASE,
 )
 
+# Non-determinism detection: window functions that may produce different results
+# across runs when the ORDER BY clause does not uniquely identify rows.
+# Flags ROW_NUMBER, RANK, and DENSE_RANK — all share the same non-determinism
+# problem when the ORDER BY is not unique within the partition.
+_RE_NONDETERMINISTIC_WINDOW = re.compile(
+    r"(ROW_NUMBER|RANK|DENSE_RANK)\s*\(\s*\)\s*OVER\s*\(",
+    re.IGNORECASE,
+)
+
 
 def _iter_files(root: Path, suffixes: tuple[str, ...]) -> Iterable[Path]:
     """Yield files under root whose suffix is in `suffixes`, skipping _SKIP_DIRS."""
@@ -450,6 +459,7 @@ def scan_filesystem(project_dir: Path) -> dict:
     # Walk models/ for sql files.
     sql_records: list[dict] = []
     date_hazards: list[dict] = []
+    nondeterminism_warnings: list[dict] = []
     for sql_path in _iter_files(models_dir, (".sql",)):
         rel = _rel(sql_path, project_dir)
         status, size, content = classify_sql_file(sql_path)
@@ -468,15 +478,24 @@ def scan_filesystem(project_dir: Path) -> dict:
             "materialization": sql_mat,
             "unique_key": sql_uk,
         })
-        matched_patterns = list(dict.fromkeys(
-            m.group(0).lower() for m in _RE_DATE_HAZARD.finditer(content)
-        ))
-        if matched_patterns:
-            date_hazards.append({
-                "file": rel,
-                "pattern": ", ".join(matched_patterns),
-                "model_name": sql_path.stem,
-            })
+        # Only flag COMPLETE models — stubs are going to be rewritten anyway,
+        # and flagging incomplete SQL wastes agent attention.
+        if status == ModelStatus.COMPLETE:
+            matched_patterns = list(dict.fromkeys(
+                m.group(0).lower() for m in _RE_DATE_HAZARD.finditer(content)
+            ))
+            if matched_patterns:
+                date_hazards.append({
+                    "file": rel,
+                    "pattern": ", ".join(matched_patterns),
+                    "model_name": sql_path.stem,
+                })
+            if _RE_NONDETERMINISTIC_WINDOW.search(content):
+                nondeterminism_warnings.append({
+                    "file": rel,
+                    "model_name": sql_path.stem,
+                    "pattern": "ROW_NUMBER/RANK/DENSE_RANK without verified unique ORDER BY",
+                })
 
     # Walk macros/.
     macros: list[MacroInfo] = []
@@ -498,6 +517,7 @@ def scan_filesystem(project_dir: Path) -> dict:
         "parse_errors": parse_errors,
         "scan_ms": scan_ms,
         "date_hazards": date_hazards,
+        "nondeterminism_warnings": nondeterminism_warnings,
     }
 
 

--- a/signalpilot/gateway/gateway/dbt/scanner.py
+++ b/signalpilot/gateway/gateway/dbt/scanner.py
@@ -67,6 +67,14 @@ _RE_TRIVIAL_SELECT = re.compile(
     re.IGNORECASE,
 )
 
+# Date hazard detection: SQL functions that produce the current date at runtime.
+# When used as spine endpoints in pre-shipped model files, they cause row-count
+# inflation when the project is run years after the source data was collected.
+_RE_DATE_HAZARD = re.compile(
+    r"\b(current_date|current_timestamp|now\(\)|getdate\(\)|sysdate)\b",
+    re.IGNORECASE,
+)
+
 
 def _iter_files(root: Path, suffixes: tuple[str, ...]) -> Iterable[Path]:
     """Yield files under root whose suffix is in `suffixes`, skipping _SKIP_DIRS."""
@@ -441,6 +449,7 @@ def scan_filesystem(project_dir: Path) -> dict:
 
     # Walk models/ for sql files.
     sql_records: list[dict] = []
+    date_hazards: list[dict] = []
     for sql_path in _iter_files(models_dir, (".sql",)):
         rel = _rel(sql_path, project_dir)
         status, size, content = classify_sql_file(sql_path)
@@ -459,6 +468,15 @@ def scan_filesystem(project_dir: Path) -> dict:
             "materialization": sql_mat,
             "unique_key": sql_uk,
         })
+        matched_patterns = list(dict.fromkeys(
+            m.group(0).lower() for m in _RE_DATE_HAZARD.finditer(content)
+        ))
+        if matched_patterns:
+            date_hazards.append({
+                "file": rel,
+                "pattern": ", ".join(matched_patterns),
+                "model_name": sql_path.stem,
+            })
 
     # Walk macros/.
     macros: list[MacroInfo] = []
@@ -479,6 +497,7 @@ def scan_filesystem(project_dir: Path) -> dict:
         "macros": macros,
         "parse_errors": parse_errors,
         "scan_ms": scan_ms,
+        "date_hazards": date_hazards,
     }
 
 

--- a/signalpilot/gateway/gateway/dbt/scanner.py
+++ b/signalpilot/gateway/gateway/dbt/scanner.py
@@ -412,6 +412,100 @@ def extract_macros_from_file(path: Path, project_dir: Path) -> list[MacroInfo]:
     return out
 
 
+# ── dbt_packages/ hazard detection ───────────────────────────────────────────
+
+# Skip set for use inside dbt_packages/ traversal.
+# Keeps dbt_packages in the set (prevents recursing into nested package installs)
+# and reuses the rest of _SKIP_DIRS as-is.
+_PKG_SKIP_DIRS = _SKIP_DIRS  # same set — dbt_packages in it blocks nested installs
+
+
+def scan_dbt_packages(project_dir: Path) -> tuple[list[dict], list[dict]]:
+    """Walk dbt_packages/ and return (date_hazards, nondeterminism_warnings).
+
+    All .sql files inside dbt_packages/ are treated as COMPLETE without calling
+    classify_sql_file — they are authored third-party code, not benchmark stubs.
+    Results include ``package: True`` and ``override_path`` so the formatter can
+    instruct the agent to create a local override in models/.
+
+    Returns empty lists if dbt_packages/ does not exist (e.g. before dbt deps).
+    """
+    pkg_dir = project_dir / "dbt_packages"
+    if not pkg_dir.exists():
+        return [], []
+
+    date_hazards: list[dict] = []
+    nd_warnings: list[dict] = []
+
+    # Walk pkg_dir using an explicit stack to respect _PKG_SKIP_DIRS.
+    # We start from pkg_dir itself, not the project root, so the dbt_packages
+    # entry in _PKG_SKIP_DIRS only blocks *nested* installs inside packages.
+    stack: list[Path] = []
+    try:
+        for entry in pkg_dir.iterdir():
+            if entry.is_dir() and entry.name not in _PKG_SKIP_DIRS:
+                stack.append(entry)
+            elif entry.is_file() and entry.suffix.lower() == ".sql":
+                stack.append(entry)
+    except OSError:
+        return [], []
+
+    while stack:
+        current = stack.pop()
+        try:
+            if current.is_dir():
+                for entry in current.iterdir():
+                    if entry.is_dir():
+                        if entry.name not in _PKG_SKIP_DIRS:
+                            stack.append(entry)
+                    elif entry.suffix.lower() == ".sql":
+                        stack.append(entry)
+            elif current.suffix.lower() == ".sql":
+                _scan_pkg_sql_file(current, project_dir, date_hazards, nd_warnings)
+        except OSError:
+            continue
+
+    return date_hazards, nd_warnings
+
+
+def _scan_pkg_sql_file(
+    sql_path: Path,
+    project_dir: Path,
+    date_hazards: list[dict],
+    nd_warnings: list[dict],
+) -> None:
+    """Scan a single package .sql file for date hazards and non-determinism."""
+    try:
+        content = sql_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return
+
+    rel = _rel(sql_path, project_dir)
+    stem = sql_path.stem
+    override_path = f"models/{stem}.sql"
+
+    matched_patterns = list(dict.fromkeys(
+        m.group(0).lower() for m in _RE_DATE_HAZARD.finditer(content)
+    ))
+    if matched_patterns:
+        date_hazards.append({
+            "file": rel,
+            "pattern": ", ".join(matched_patterns),
+            "model_name": stem,
+            "package": True,
+            "override_path": override_path,
+        })
+
+    if _RE_NONDETERMINISTIC_WINDOW.search(content):
+        nd_warnings.append({
+            "file": rel,
+            "model_name": stem,
+            "pattern": "ROW_NUMBER/RANK/DENSE_RANK without verified unique ORDER BY",
+            "package": True,
+            "override_path": override_path,
+        })
+
+
 # ── Top-level orchestration ──────────────────────────────────────────────────
 
 
@@ -496,6 +590,12 @@ def scan_filesystem(project_dir: Path) -> dict:
                     "model_name": sql_path.stem,
                     "pattern": "ROW_NUMBER/RANK/DENSE_RANK without verified unique ORDER BY",
                 })
+
+    # Walk dbt_packages/ for date hazards and non-determinism (read-only detection).
+    # Package models are not added to sql_records — they are third-party code.
+    pkg_date_hazards, pkg_nd_warnings = scan_dbt_packages(project_dir)
+    date_hazards.extend(pkg_date_hazards)
+    nondeterminism_warnings.extend(pkg_nd_warnings)
 
     # Walk macros/.
     macros: list[MacroInfo] = []

--- a/signalpilot/gateway/gateway/dbt/types.py
+++ b/signalpilot/gateway/gateway/dbt/types.py
@@ -128,6 +128,7 @@ class ProjectMap:
 
     parse_errors: list[ParseError] = field(default_factory=list)
     scan_time_ms: float = 0.0
+    date_hazards: list[dict] = field(default_factory=list)
 
     # Counts (cheap to access in formatters)
     @property

--- a/signalpilot/gateway/gateway/dbt/types.py
+++ b/signalpilot/gateway/gateway/dbt/types.py
@@ -129,6 +129,7 @@ class ProjectMap:
     parse_errors: list[ParseError] = field(default_factory=list)
     scan_time_ms: float = 0.0
     date_hazards: list[dict] = field(default_factory=list)
+    nondeterminism_warnings: list[dict] = field(default_factory=list)
 
     # Counts (cheap to access in formatters)
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""
+pytest configuration — auto-load .env before test collection.
+
+This ensures SPIDER2_DBT_DIR is set before test_dbt_project_map.py resolves
+its module-level SPIDER2_BASE path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")

--- a/tests/test_dbt_project_map.py
+++ b/tests/test_dbt_project_map.py
@@ -35,6 +35,7 @@ from signalpilot.gateway.gateway.dbt.scanner import (
     extract_refs_from_sql,
     extract_sources_from_sql,
     parse_yml_file,
+    scan_filesystem,
 )
 from signalpilot.gateway.gateway.dbt.types import ModelStatus
 from signalpilot.gateway.gateway.dbt.work_order import compute_work_order
@@ -45,7 +46,7 @@ from signalpilot.gateway.gateway.dbt.work_order import compute_work_order
 SPIDER2_BASE = Path(
     os.environ.get(
         "SPIDER2_DBT_DIR",
-        r"C:/Users/kiwi0/Desktop/what/spider2-repo/spider2-dbt",
+        "/nonexistent/SPIDER2_DBT_DIR_not_configured",
     )
 ) / "examples"
 
@@ -663,3 +664,37 @@ def test_render_project_map_idempotent_ordering(broken_project: Path):
 def test_render_output_ends_with_newline(broken_project: Path):
     rendered = build_project_map(str(broken_project))
     assert rendered.endswith("\n")
+
+
+# ── Date hazard detection ─────────────────────────────────────────────────────
+
+
+def test_date_hazards_found_in_models(tmp_path: Path):
+    """scan_filesystem detects current_date in a model SQL file."""
+    (tmp_path / "models").mkdir()
+    (tmp_path / "models" / "spine.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT UNNEST(GENERATE_SERIES('2020-01-01'::DATE, CURRENT_DATE, INTERVAL '1 day')) AS date_day
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    hazards = result["date_hazards"]
+    assert len(hazards) == 1
+    assert hazards[0]["model_name"] == "spine"
+    assert "current_date" in hazards[0]["pattern"]
+
+
+def test_date_hazards_empty_when_clean(tmp_path: Path):
+    """scan_filesystem returns no date_hazards for SQL that does not use current_date."""
+    (tmp_path / "models").mkdir()
+    (tmp_path / "models" / "clean_spine.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT UNNEST(GENERATE_SERIES('2020-01-01'::DATE,
+    (SELECT MAX(order_date) FROM {{ ref('stg_orders') }}),
+    INTERVAL '1 day')) AS date_day
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    assert result["date_hazards"] == []

--- a/tests/test_dbt_project_map.py
+++ b/tests/test_dbt_project_map.py
@@ -763,3 +763,77 @@ SELECT
     assert sql_records["stub_visits"]["status"] == ModelStatus.STUB
     # The COMPLETE-only filter must prevent this STUB from appearing in warnings.
     assert result["nondeterminism_warnings"] == []
+
+
+# ── dbt_packages/ hazard detection ────────────────────────────────────────────
+
+
+def test_date_hazard_in_dbt_packages(tmp_path: Path):
+    """scan_filesystem detects current_date in a dbt_packages/ model."""
+    (tmp_path / "models").mkdir()
+    pkg_models = tmp_path / "dbt_packages" / "some_pkg" / "models"
+    pkg_models.mkdir(parents=True)
+    (pkg_models / "spine.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT UNNEST(GENERATE_SERIES('2020-01-01'::DATE, CURRENT_DATE, INTERVAL '1 day')) AS date_day
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    hazards = result["date_hazards"]
+    assert len(hazards) == 1
+    h = hazards[0]
+    assert h["model_name"] == "spine"
+    assert "current_date" in h["pattern"]
+    assert h.get("package") is True
+    assert h["override_path"] == "models/spine.sql"
+    # Package models must NOT appear in sql_records (not part of the project graph).
+    assert all(rec["name"] != "spine" for rec in result["sql_records"])
+
+
+def test_nondeterminism_in_dbt_packages(tmp_path: Path):
+    """scan_filesystem detects ROW_NUMBER in a dbt_packages/ model."""
+    (tmp_path / "models").mkdir()
+    pkg_models = tmp_path / "dbt_packages" / "some_pkg" / "models"
+    pkg_models.mkdir(parents=True)
+    (pkg_models / "ranked_orders.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT
+    order_id,
+    customer_id,
+    ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date) AS rn
+FROM {{ ref('stg_orders') }}
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    warnings = result["nondeterminism_warnings"]
+    assert len(warnings) == 1
+    w = warnings[0]
+    assert w["model_name"] == "ranked_orders"
+    assert "ROW_NUMBER" in w["pattern"].upper()
+    assert w.get("package") is True
+    assert w["override_path"] == "models/ranked_orders.sql"
+    # Package models must NOT appear in sql_records.
+    assert all(rec["name"] != "ranked_orders" for rec in result["sql_records"])
+
+
+def test_dbt_packages_hazard_renders_override_instruction(tmp_path: Path):
+    """Formatter output contains PACKAGE MODEL and the override path for package hazards."""
+    pkg_hazard = {
+        "file": "dbt_packages/shopify_source/models/stg_shopify__order.sql",
+        "pattern": "current_date",
+        "model_name": "stg_shopify__order",
+        "package": True,
+        "override_path": "models/stg_shopify__order.sql",
+    }
+    # Build a minimal ProjectMap with the hazard injected directly.
+    project = scan_project(tmp_path)
+    # Inject the package hazard into the project's date_hazards list.
+    project.date_hazards.append(pkg_hazard)
+
+    from signalpilot.gateway.gateway.dbt.formatters import render_full
+    rendered = render_full(project, max_per_section=40, include_columns=False)
+
+    assert "PACKAGE MODEL" in rendered
+    assert "models/stg_shopify__order.sql" in rendered

--- a/tests/test_dbt_project_map.py
+++ b/tests/test_dbt_project_map.py
@@ -698,3 +698,68 @@ SELECT UNNEST(GENERATE_SERIES('2020-01-01'::DATE,
     )
     result = scan_filesystem(tmp_path)
     assert result["date_hazards"] == []
+
+
+# ── Non-determinism detection ─────────────────────────────────────────────────
+
+
+def test_nondeterminism_warning_for_rownum(tmp_path: Path):
+    """scan_filesystem detects ROW_NUMBER in a COMPLETE model SQL file."""
+    (tmp_path / "models").mkdir()
+    (tmp_path / "models" / "visits.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT
+    patient_id,
+    encounter_id,
+    visit_date,
+    ROW_NUMBER() OVER (ORDER BY patient_id) AS rn
+FROM {{ ref('stg_visits') }}
+WHERE visit_date IS NOT NULL
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    warnings = result["nondeterminism_warnings"]
+    assert len(warnings) == 1
+    assert warnings[0]["model_name"] == "visits"
+    assert "ROW_NUMBER" in warnings[0]["pattern"].upper()
+
+
+def test_nondeterminism_warning_empty_when_no_window_function(tmp_path: Path):
+    """scan_filesystem returns no nondeterminism_warnings for SQL with no ranking functions."""
+    (tmp_path / "models").mkdir()
+    (tmp_path / "models" / "summary.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT
+    patient_id,
+    COUNT(*) AS visit_count,
+    MAX(visit_date) AS latest_visit
+FROM {{ ref('stg_visits') }}
+WHERE visit_date IS NOT NULL
+GROUP BY patient_id
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    assert result["nondeterminism_warnings"] == []
+
+
+def test_nondeterminism_warning_skips_stub_models(tmp_path: Path):
+    """scan_filesystem does NOT flag ROW_NUMBER in a STUB model (COMPLETE-only filter)."""
+    (tmp_path / "models").mkdir()
+    # A stub with ROW_NUMBER — the body ends with a dangling comma so it is
+    # classified STUB. The non-determinism scan must NOT flag it.
+    (tmp_path / "models" / "stub_visits.sql").write_text(
+        """{{ config(materialized='table') }}
+SELECT
+    patient_id,
+    ROW_NUMBER() OVER (ORDER BY patient_id) AS rn,
+""",
+        encoding="utf-8",
+    )
+    result = scan_filesystem(tmp_path)
+    # Confirm the file was classified as STUB (dangling comma triggers stub heuristic).
+    sql_records = {rec["name"]: rec for rec in result["sql_records"]}
+    assert sql_records["stub_visits"]["status"] == ModelStatus.STUB
+    # The COMPLETE-only filter must prevent this STUB from appearing in warnings.
+    assert result["nondeterminism_warnings"] == []


### PR DESCRIPTION
## Summary
- Add `current_date` detection to `dbt_project_map` scanner with actionable system prompt guidance (date spine fix for 7 tasks)
- Add non-determinism detection (ROW_NUMBER/RANK/DENSE_RANK without unique ORDER BY) to scanner + system prompt
- Wire date hazard warnings into sequential fix steps in system prompt (call get_date_boundaries → use 'USE THIS' value → replace current_date)
- Add LEFT JOIN default guidance to system prompt Step 3 (targeting 4 wrong-JOIN tasks)
- Extend dbt-workflow skill with section 13: non-deterministic window function guidance
- Apply COMPLETE-only filter to both date hazard and non-determinism detection (skip stubs)
- New `dbt-date-spines` skill teaches agent the local-override pattern
- Fix test infrastructure: conftest.py auto-loads .env for pytest

## Test plan
- [x] 48/48 unit tests pass (43 original + 2 date hazard + 3 non-determinism)
- [x] Scanner detects current_date in affected tasks (shopify001, xero001, pendo001, quickbooks003)
- [x] Scanner detects ROW_NUMBER in pre-shipped models
- [x] STUB models with ROW_NUMBER are NOT flagged (COMPLETE-only filter)
- [x] System prompt at 9979 chars (under 10k limit)
- [x] All 5 skills on disk and copied to test-env
- [x] MCP handshake verified
- [ ] Run benchmark tasks to verify agent acts on warnings (shopify001, xero001, superstore001)

---
**Branch:** `autofyn/signalpilot-benc-c1707a` · **Run:** `3f76c8d8-6782-4461-b171-6620d5044733` · *Generated by AutoFyn*