### PR TITLE
Full audit trail for Spider 2.0 submission

### DIFF
--- a/benchmark/agent/sdk_runner.py
+++ b/benchmark/agent/sdk_runner.py
@@ -11,11 +11,15 @@ from pathlib import Path
 from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
+    RateLimitEvent,
     ResultMessage,
+    StreamEvent,
+    SystemMessage,
     TextBlock,
     ThinkingBlock,
     ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
     query,
 )
 from claude_agent_sdk._errors import ClaudeSDKError, ProcessError
@@ -133,19 +137,110 @@ async def run_sdk_agent(
                                 "type": "tool_result",
                                 "turn": turn_count,
                                 "timestamp": now_ts,
+                                "tool_use_id": getattr(block, "tool_use_id", None),
+                                "is_error": getattr(block, "is_error", None),
                                 "content": result_str,
                             })
+
+                elif isinstance(message, UserMessage):
+                    # UserMessage carries tool results back to the model.
+                    # content can be a string or list of content blocks.
+                    log(f"[user_message] ({elapsed:.1f}s)")
+                    content = message.content
+                    if isinstance(content, str):
+                        transcript.append({
+                            "type": "user_message",
+                            "turn": turn_count,
+                            "timestamp": now_ts,
+                            "content": content,
+                        })
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, ToolResultBlock):
+                                result_str = str(block.content) if hasattr(block, "content") else str(block)
+                                truncated = result_str[:2000] + "..." if len(result_str) > 2000 else result_str
+                                log(f"[tool_result] id={getattr(block, 'tool_use_id', '?')} err={getattr(block, 'is_error', False)}")
+                                transcript.append({
+                                    "type": "tool_result",
+                                    "turn": turn_count,
+                                    "timestamp": now_ts,
+                                    "tool_use_id": getattr(block, "tool_use_id", None),
+                                    "is_error": getattr(block, "is_error", None),
+                                    "content": result_str,
+                                })
+                            elif isinstance(block, TextBlock):
+                                transcript.append({
+                                    "type": "user_text",
+                                    "turn": turn_count,
+                                    "timestamp": now_ts,
+                                    "content": block.text,
+                                })
+                            else:
+                                transcript.append({
+                                    "type": "user_block",
+                                    "turn": turn_count,
+                                    "timestamp": now_ts,
+                                    "content": str(block),
+                                })
+                    # Also capture tool_use_result dict if present
+                    if message.tool_use_result:
+                        transcript.append({
+                            "type": "tool_use_result",
+                            "turn": turn_count,
+                            "timestamp": now_ts,
+                            "content": message.tool_use_result,
+                        })
+
+                elif isinstance(message, SystemMessage):
+                    log(f"[system] {message.subtype}")
+                    transcript.append({
+                        "type": "system",
+                        "turn": turn_count,
+                        "timestamp": now_ts,
+                        "subtype": message.subtype,
+                        "data": message.data,
+                    })
 
                 elif isinstance(message, ResultMessage):
                     elapsed = time.monotonic() - start_time
                     log(f"AGENT FINISHED after {turn_count} turns, {elapsed:.1f}s")
-                    if hasattr(message, "cost_usd"):
-                        cost_usd = getattr(message, "cost_usd", None)
+                    cost_usd = getattr(message, "total_cost_usd", None)
+                    if cost_usd is not None:
                         log(f"  Cost: ${cost_usd!r}")
-                    if hasattr(message, "usage"):
-                        usage = getattr(message, "usage", None)
+                    usage = getattr(message, "usage", None)
+                    if usage is not None:
                         log(f"  Usage: {usage!r}")
-                    success = True
+                    transcript.append({
+                        "type": "result",
+                        "turn": turn_count,
+                        "timestamp": now_ts,
+                        "num_turns": getattr(message, "num_turns", None),
+                        "stop_reason": getattr(message, "stop_reason", None),
+                        "total_cost_usd": cost_usd,
+                        "duration_ms": getattr(message, "duration_ms", None),
+                        "duration_api_ms": getattr(message, "duration_api_ms", None),
+                        "is_error": getattr(message, "is_error", None),
+                        "usage": usage,
+                    })
+                    success = not getattr(message, "is_error", False)
+
+                elif isinstance(message, RateLimitEvent):
+                    log(f"[rate_limit] {message.rate_limit_info}", "WARN")
+                    transcript.append({
+                        "type": "rate_limit",
+                        "turn": turn_count,
+                        "timestamp": now_ts,
+                        "info": str(message.rate_limit_info),
+                    })
+
+                elif isinstance(message, StreamEvent):
+                    # Low-level stream events (hooks, etc.)
+                    transcript.append({
+                        "type": "stream_event",
+                        "turn": turn_count,
+                        "timestamp": now_ts,
+                        "event": message.event,
+                    })
 
         except (ProcessError, ClaudeSDKError) as e:
             err_str = str(e)

--- a/benchmark/core/audit.py
+++ b/benchmark/core/audit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -73,7 +74,7 @@ def init_run(
     run_dir = _run_dir(run_id)
 
     try:
-        for subdir in ("tasks", "traces", "queries"):
+        for subdir in ("tasks", "traces", "queries", "projects"):
             (run_dir / subdir).mkdir(parents=True, exist_ok=True)
     except OSError as e:
         raise RuntimeError(
@@ -156,3 +157,35 @@ def copy_gateway_audit(run_id: str, instance_id: str, connection_name: str) -> N
                 continue
 
     dest_path.write_text("\n".join(matching_lines) + ("\n" if matching_lines else ""))
+
+
+def archive_workdir(run_id: str, instance_id: str, work_dir: Path) -> Path | None:
+    """Copy the agent's workdir to the audit volume for post-run evaluation.
+
+    Copies the full project (SQL models, DuckDB output, dbt_project.yml, etc.)
+    to AUDIT_BASE/runs/{run_id}/projects/{instance_id}/. Without this, the
+    work products are lost when Docker containers stop.
+
+    Skips files that are unlikely to matter for submission/re-evaluation:
+    - dbt_packages/ (large, deterministic from packages.yml)
+    - .dbt/ (internal dbt state)
+    - __pycache__/
+
+    Returns the destination path, or None if the copy failed.
+    """
+    if not work_dir.exists():
+        return None
+
+    dest = _run_dir(run_id) / "projects" / instance_id
+    skip_dirs = {"dbt_packages", ".dbt", "__pycache__", "node_modules", "target"}
+
+    def _ignore(directory: str, contents: list[str]) -> set[str]:
+        return {c for c in contents if c in skip_dirs}
+
+    try:
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(work_dir, dest, ignore=_ignore)
+        return dest
+    except Exception:
+        return None

--- a/benchmark/package_submission.py
+++ b/benchmark/package_submission.py
@@ -131,6 +131,19 @@ def _build_archive(run_id: str, run_dir: Path, audit_base: Path) -> Path:
         for query_file in sorted(queries_dir.glob("*.jsonl")):
             tar.add(query_file, arcname=f"{archive_root}/queries/{query_file.name}")
 
+        # projects/{instance_id}/ — agent-generated work products (SQL models, DuckDB, etc.)
+        projects_dir = run_dir / "projects"
+        if projects_dir.exists():
+            for project_dir in sorted(projects_dir.iterdir()):
+                if project_dir.is_dir():
+                    tar.add(project_dir, arcname=f"{archive_root}/projects/{project_dir.name}")
+
+        # logs/{instance_id}.log — per-task console logs
+        logs_dir = run_dir / "logs"
+        if logs_dir.exists():
+            for log_file in sorted(logs_dir.glob("*.log")):
+                tar.add(log_file, arcname=f"{archive_root}/logs/{log_file.name}")
+
     return archive_path
 
 

--- a/benchmark/run_batch.py
+++ b/benchmark/run_batch.py
@@ -16,6 +16,7 @@ from .core.audit import (
     ResultAlreadyExistsError,
     RunMetadata,
     TaskResult,
+    archive_workdir,
     copy_gateway_audit,
     finalize_run,
     init_run,
@@ -23,7 +24,7 @@ from .core.audit import (
     save_task_transcript,
 )
 from .core.logging import close_log_file, log, set_log_file
-from .core.paths import AUDIT_BASE
+from .core.paths import AUDIT_BASE, SQL_WORK_DIR, WORK_DIR
 from .core.suite import BenchmarkSuite
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -274,6 +275,23 @@ async def run_task_async(
             copy_gateway_audit(run_id, instance_id, connection_name=f"{connection_prefix}{instance_id}")
         except Exception as e:
             log(f"Failed to copy gateway audit for '{instance_id}': {e}", "WARN")
+
+        # Archive the agent's workdir (SQL models, DuckDB output, etc.)
+        # Without this, work products are lost when the container stops.
+        try:
+            if suite == "spider2-dbt":
+                task_work_dir = WORK_DIR / instance_id
+            else:
+                # SQL suites use backend-specific subdirs
+                suite_enum = BenchmarkSuite(suite)
+                task_work_dir = SQL_WORK_DIR / suite_enum.value.split("-")[-1] / instance_id
+            archived = archive_workdir(run_id, instance_id, task_work_dir)
+            if archived:
+                log(f"Archived workdir to {archived}")
+            else:
+                log(f"Workdir archive skipped (not found: {task_work_dir})", "WARN")
+        except Exception as e:
+            log(f"Failed to archive workdir for '{instance_id}': {e}", "WARN")
 
         close_log_file(log_token)
         return task_result


### PR DESCRIPTION
## Summary
- **Parallel execution** with `--parallel N` flag (semaphore-based asyncio.gather)
- **Structured audit storage** at `AUDIT_BASE/runs/{run_id}/` with immutable per-task results
- **Full transcript capture** — all 6 SDK message types: thinking blocks, text, tool_use, tool_result (from UserMessage), system events, rate limits, stream events
- **Workdir archiving** — agent-generated projects (SQL models, DuckDB output) persisted to audit volume, no longer lost on container stop
- **Submission packager** — `python -m benchmark.package_submission --run-id <id>` builds tar.gz with scores, traces, queries, projects, logs
- **Per-task logging** with ContextVar isolation for safe parallel execution

## Audit volume layout
```
runs/{run_id}/
├── run_metadata.json
├── tasks/{id}.json
├── traces/{id}.json      ← full reasoning chain with timestamps
├── queries/{id}.jsonl    ← SQL audit from gateway
├── logs/{id}.log
└── projects/{id}/        ← agent work products (models, DuckDB, etc.)
```

## Test plan
- [ ] Run single DBT task with `--parallel 0` (sequential) — verify audit dir populated
- [ ] Run 3 tasks with `--parallel 2` — verify no cross-task log mixing
- [ ] Run `package_submission.py` on completed run — verify archive contents
- [ ] Verify transcript includes thinking blocks, tool results, and system events

🤖 Generated with [Claude Code](https://claude.com/claude-code)