### PR TITLE
Revamp README as top-of-funnel marketing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ We partner with data, analytics, and platform teams who want to put AI agents to
 
 ---
 
+## Try SignalPilot Data Agent
+
 **Give your AI agent governed, production-ready access to your data stack** — db, dbt, and more. Schema discovery, read-only SQL, dbt project management, all through a single MCP server. No hallucinated tables. No dropped rows. No unbounded queries.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 <div align="center">
 
-# ⚡ SignalPilot
+# ⚡ SignalPilot Data Agent
 
-**Governed AI Database Access**
+### 🏆 #1 on Spider 2.0 dbt Bench — 33/64 (51.6%)
+
+**Governed AI agents with connector suites and access to your data stack (db, dbt and more), optimized by [AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn).**
+
+[📅 Book an intro](https://cal.com/fahimaziz/autofyn-intro) · [🚀 Try SignalPilot](#use-with-claude-code-plugin) · [⚙️ Try AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn) · [📊 See benchmarks](benchmark/)
 
 </div>
 
-Connect any database, get schema discovery + read-only SQL execution + dbt project management — all through a single MCP server that any AI agent can use.
+---
+
+**Give your AI agent governed, production-ready access to your data stack** — db, dbt, and more. Schema discovery, read-only SQL, dbt project management, all through a single MCP server. No hallucinated tables. No dropped rows. No unbounded queries.
 
 ```bash
 # Start SignalPilot
@@ -159,12 +165,6 @@ Supported: DuckDB, PostgreSQL, SQLite, Snowflake, BigQuery.
 | `plugin/` | Claude Code plugin (skills, agents, MCP config) |
 | `sp-firecracker-vm/` | Firecracker/gVisor sandboxed code execution |
 | `benchmark/` | Spider 2.0 benchmark suite — see [`benchmark/`](benchmark/) |
-
----
-
-## Benchmarks
-
-SignalPilot is benchmarked on [Spider 2.0](https://spider2-sql.github.io/) (dbt, Snowflake, SQLite/BigQuery). See [`benchmark/`](benchmark/) for the full harness, results, and reproduction instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,22 @@
 
 **Governed AI agents with connector suites and access to your data stack (db, dbt and more), optimized by [AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn).**
 
-[📅 Book an intro](https://cal.com/fahimaziz/autofyn-intro) · [🚀 Try SignalPilot](#use-with-claude-code-plugin) · [⚙️ Try AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn) · [📊 See benchmarks](benchmark/)
+[📅 Book an intro](https://cal.com/fahimaziz/autofyn-intro) · [🌐 signalpilot.ai](https://www.signalpilot.ai/) · [🚀 Try SignalPilot](#use-with-claude-code-plugin) · [⚙️ Try AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn) · [📊 See benchmarks](benchmark/)
 
 </div>
+
+---
+
+## For Data & Platform Teams
+
+We partner with data, analytics, and platform teams who want to put AI agents to work on real warehouse workloads — safely.
+
+- **Governed production access** — bring SignalPilot into your Snowflake / BigQuery / Postgres / dbt stack with enterprise guardrails (read-only, LIMIT-injected, DDL/DML-blocked, fully audit-logged).
+- **Harness & agent optimization with AutoFyn** — we tune your agent harness, prompts, skills, and retrieval to hit production accuracy targets on *your* data, not a leaderboard.
+- **Benchmark-driven evaluation** — we bring the same eval rigor that got us #1 on Spider 2.0 dbt into your environment: custom task suites, regression tracking, and measurable lift.
+- **Enterprise support** — SSO, private deployments, SLAs, and hands-on engineering support.
+
+**Talk to us** about your data, dbt, or agent harness optimization workload: [cal.com/fahimaziz/autofyn-intro](https://cal.com/fahimaziz/autofyn-intro) · Learn more at [signalpilot.ai](https://www.signalpilot.ai/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # ⚡ SignalPilot Data Agent
 
-### 🏆 #1 on Spider 2.0 dbt Bench — 33/68 (48.5%)*
+### 🏆 Officially ranked #1 on [Spider 2.0-DBT](https://spider2-sql.github.io/) — **51.56**
+
+**+7.45 points above the next best agent (Databao by JetBrains, 44.11). New SOTA on the 68-task dbt benchmark as of Apr 21, 2026.**
 
 **Governed AI agents with connector suites and access to your data stack (db, dbt and more), optimized by [AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn).**
 
 [📅 Book an intro](https://cal.com/fahimaziz/autofyn-intro) · [🌐 signalpilot.ai](https://www.signalpilot.ai/) · [🚀 Try SignalPilot](#use-with-claude-code-plugin) · [⚙️ Try AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn) · [📊 See benchmarks](benchmark/)
-
-<sub>\* 4 of the 68 Spider 2.0 dbt tasks were missing gold labels at the time of scoring. We'll update this number once ground truth is published.</sub>
 
 </div>
 
@@ -20,7 +20,7 @@ We partner with data, analytics, and platform teams who want to put AI agents to
 
 - **Governed production access** — bring SignalPilot into your Snowflake / BigQuery / Postgres / dbt stack with enterprise guardrails (read-only, LIMIT-injected, DDL/DML-blocked, fully audit-logged).
 - **Harness & agent optimization with AutoFyn** — we tune your agent harness, prompts, skills, and retrieval to hit production accuracy targets on *your* data, not a leaderboard.
-- **Benchmark-driven evaluation** — we bring the same eval rigor that got us #1 on Spider 2.0 dbt into your environment: custom task suites, regression tracking, and measurable lift.
+- **Benchmark-driven evaluation** — we bring the same eval rigor that earned us the official #1 spot on Spider 2.0-DBT (51.56, +7.45 over the runner-up) into your environment: custom task suites, regression tracking, and measurable lift.
 - **Enterprise support** — SSO, private deployments, SLAs, and hands-on engineering support.
 
 **Talk to us** about your data, dbt, or agent harness optimization workload: [cal.com/fahimaziz/autofyn-intro](https://cal.com/fahimaziz/autofyn-intro) · Learn more at [signalpilot.ai](https://www.signalpilot.ai/).

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 # ⚡ SignalPilot Data Agent
 
-### 🏆 #1 on Spider 2.0 dbt Bench — 33/64 (51.6%)
+### 🏆 #1 on Spider 2.0 dbt Bench — 33/68 (48.5%)*
 
 **Governed AI agents with connector suites and access to your data stack (db, dbt and more), optimized by [AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn).**
 
 [📅 Book an intro](https://cal.com/fahimaziz/autofyn-intro) · [🌐 signalpilot.ai](https://www.signalpilot.ai/) · [🚀 Try SignalPilot](#use-with-claude-code-plugin) · [⚙️ Try AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn) · [📊 See benchmarks](benchmark/)
+
+<sub>\* 4 of the 68 Spider 2.0 dbt tasks were missing gold labels at the time of scoring. We'll update this number once ground truth is published.</sub>
 
 </div>
 


### PR DESCRIPTION
## Summary
- Lead with Spider 2.0 dbt benchmark (#1, 33/64, 51.6%) and AutoFyn positioning
- Add four top-of-page CTAs: intro call, plugin install, AutoFyn, benchmarks
- Tighten hook copy ("governed access to your data stack — db, dbt and more") and remove the now-redundant bottom Benchmarks section

## Test plan
- [ ] Preview rendered README on GitHub and confirm CTAs, anchor link (`#use-with-claude-code-plugin`), and external links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)