### PR TITLE
Add GitHub import for dbt projects

### DIFF
--- a/signalpilot/gateway/gateway/store.py
+++ b/signalpilot/gateway/gateway/store.py
@@ -718,6 +718,8 @@ def create_project(proj: ProjectCreate) -> ProjectInfo:
 
     if proj.source.value == "local":
         return _create_local_project(proj, connection, data)
+    if proj.source.value == "github":
+        return _create_github_project(proj, connection, data)
     return _create_new_project(proj, connection, data)
 
 
@@ -767,6 +769,54 @@ def _create_local_project(
         storage=storage,
         source=proj.source,
         db_type=connection.db_type,
+        description=proj.description,
+        tags=proj.tags,
+    )
+    data[proj.name] = info.model_dump()
+    _save_json(PROJECTS_FILE, data)
+    return info
+
+
+def _create_github_project(
+    proj: ProjectCreate, connection: ConnectionInfo, data: dict
+) -> ProjectInfo:
+    """Handle source='github': clone a repo into a managed project."""
+    import subprocess
+
+    if not proj.git_url:
+        raise ValueError("git_url is required for GitHub import")
+
+    branch = proj.git_branch or "main"
+    project_dir = DATA_DIR / "projects" / proj.name
+
+    result = subprocess.run(
+        ["git", "clone", "--branch", branch, "--depth", "1", proj.git_url, str(project_dir)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"git clone failed: {result.stderr.strip()}")
+
+    if not (project_dir / "dbt_project.yml").exists():
+        shutil.rmtree(project_dir)
+        raise ValueError("Cloned repo does not contain dbt_project.yml")
+
+    # Generate profiles.yml wired to the connection
+    (project_dir / "profiles.yml").write_text(
+        _generate_profiles_yml(proj.name, connection)
+    )
+
+    info = ProjectInfo(
+        id=str(uuid.uuid4()),
+        name=proj.name,
+        connection_name=proj.connection_name,
+        project_dir=str(project_dir),
+        storage=ProjectStorage.managed,
+        source=proj.source,
+        db_type=connection.db_type,
+        git_remote=proj.git_url,
+        git_branch=branch,
         description=proj.description,
         tags=proj.tags,
     )

--- a/signalpilot/web/app/projects/page.tsx
+++ b/signalpilot/web/app/projects/page.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   ArrowRight,
   Upload,
+  GitBranch,
 } from "lucide-react";
 import { getProjects, createProject, deleteProject, getConnections } from "@/lib/api";
 import type { ProjectInfo, ConnectionInfo } from "@/lib/types";
@@ -39,9 +40,11 @@ export default function ProjectsPage() {
   const [connections, setConnections] = useState<ConnectionInfo[]>([]);
   const [showCreate, setShowCreate] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  const [showGithub, setShowGithub] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createForm, setCreateForm] = useState({ name: "", connection_name: "" });
   const [importForm, setImportForm] = useState({ name: "", path: "", connection_name: "", mode: "link" as "link" | "copy" });
+  const [githubForm, setGithubForm] = useState({ name: "", git_url: "", git_branch: "main", connection_name: "" });
 
   const refresh = useCallback(() => {
     getProjects().then(setProjects).catch(() => {});
@@ -106,6 +109,36 @@ export default function ProjectsPage() {
     finally { setCreating(false); }
   }
 
+  async function handleGithub() {
+    if (!githubForm.name || !NAME_PATTERN.test(githubForm.name)) {
+      toast("name must match [a-zA-Z0-9_-]", "error");
+      return;
+    }
+    if (!githubForm.git_url) {
+      toast("repo url is required", "error");
+      return;
+    }
+    if (!githubForm.connection_name) {
+      toast("select a connection", "error");
+      return;
+    }
+    setCreating(true);
+    try {
+      const p = await createProject({
+        name: githubForm.name,
+        git_url: githubForm.git_url,
+        git_branch: githubForm.git_branch || "main",
+        connection_name: githubForm.connection_name,
+        source: "github",
+      });
+      setProjects((prev) => [p, ...prev]);
+      setShowGithub(false);
+      setGithubForm({ name: "", git_url: "", git_branch: "main", connection_name: "" });
+      toast(`cloned ${githubForm.git_url}`, "success");
+    } catch (e) { toast(String(e), "error"); }
+    finally { setCreating(false); }
+  }
+
   async function handleDelete(name: string) {
     try {
       await deleteProject(name);
@@ -121,6 +154,12 @@ export default function ProjectsPage() {
         description="dbt project management"
         actions={
           <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowGithub(true)}
+              className="flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
+            >
+              <GitBranch className="w-3.5 h-3.5" /> github
+            </button>
             <button
               onClick={() => setShowImport(true)}
               className="flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
@@ -279,6 +318,79 @@ export default function ProjectsPage() {
               </button>
               <button
                 onClick={() => setShowImport(false)}
+                className="px-4 py-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors tracking-wider"
+              >
+                cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* GitHub dialog */}
+      {showGithub && (
+        <div className="mb-6 border border-[var(--color-border)] bg-[var(--color-bg-card)] animate-scale-in overflow-hidden">
+          <div className="px-5 py-3 border-b border-[var(--color-border)] flex items-center gap-2">
+            <GitBranch className="w-3.5 h-3.5 text-[var(--color-text-dim)]" strokeWidth={1.5} />
+            <span className="text-[12px] text-[var(--color-text-dim)] uppercase tracking-[0.15em]">import from github</span>
+          </div>
+          <div className="p-5">
+            <div className="grid grid-cols-4 gap-4 mb-4">
+              <div>
+                <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">name</label>
+                <input
+                  type="text"
+                  placeholder="my-project"
+                  value={githubForm.name}
+                  onChange={(e) => setGithubForm({ ...githubForm, name: e.target.value })}
+                  className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tracking-wide"
+                />
+              </div>
+              <div>
+                <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">repo url</label>
+                <input
+                  type="text"
+                  placeholder="https://github.com/org/repo.git"
+                  value={githubForm.git_url}
+                  onChange={(e) => setGithubForm({ ...githubForm, git_url: e.target.value })}
+                  className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tracking-wide font-mono"
+                />
+              </div>
+              <div>
+                <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">branch</label>
+                <input
+                  type="text"
+                  placeholder="main"
+                  value={githubForm.git_branch}
+                  onChange={(e) => setGithubForm({ ...githubForm, git_branch: e.target.value })}
+                  className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tracking-wide"
+                />
+              </div>
+              <div>
+                <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">connection</label>
+                <select
+                  value={githubForm.connection_name}
+                  onChange={(e) => setGithubForm({ ...githubForm, connection_name: e.target.value })}
+                  className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)]"
+                >
+                  <option value="">select connection</option>
+                  {connections.map((c) => (
+                    <option key={c.name} value={c.name}>{c.name} ({c.db_type})</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleGithub}
+                disabled={creating}
+                className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
+              >
+                {creating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <GitBranch className="w-3.5 h-3.5" />}
+                clone
+              </button>
+              <button
+                onClick={() => setShowGithub(false)}
                 className="px-4 py-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors tracking-wider"
               >
                 cancel

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -198,6 +198,52 @@ class TestCreateProject:
         assert proj.project_dir != str(local_dir)
         assert Path(proj.project_dir).exists()
         shutil.rmtree(local_dir)
+
+    def test_create_github_project(self):
+        conn = _make_connection("pg", "postgres")
+        mock_run = MagicMock(returncode=0, stderr="", stdout="")
+        with patch("signalpilot.gateway.gateway.store.get_connection", return_value=conn), \
+             patch("subprocess.run", return_value=mock_run) as mock_sub:
+            # Pre-create the dir with dbt_project.yml to simulate clone
+            project_dir = Path(_test_dir) / "projects" / "gh-proj"
+            project_dir.mkdir(parents=True, exist_ok=True)
+            (project_dir / "dbt_project.yml").write_text("name: test")
+            proj = create_project(ProjectCreate(
+                name="gh-proj",
+                connection_name="pg",
+                source=ProjectSource.github,
+                git_url="https://github.com/org/repo.git",
+                git_branch="develop",
+            ))
+        assert proj.storage == ProjectStorage.managed
+        assert proj.source == ProjectSource.github
+        assert proj.git_remote == "https://github.com/org/repo.git"
+        assert proj.git_branch == "develop"
+        mock_sub.assert_called_once()
+        assert "--branch" in mock_sub.call_args[0][0]
+
+    def test_create_github_missing_url_raises(self):
+        conn = _make_connection("pg", "postgres")
+        with patch("signalpilot.gateway.gateway.store.get_connection", return_value=conn):
+            with pytest.raises(ValueError, match="git_url is required"):
+                create_project(ProjectCreate(
+                    name="no-url",
+                    connection_name="pg",
+                    source=ProjectSource.github,
+                ))
+
+    def test_create_github_clone_failure_raises(self):
+        conn = _make_connection("pg", "postgres")
+        mock_run = MagicMock(returncode=128, stderr="fatal: repo not found", stdout="")
+        with patch("signalpilot.gateway.gateway.store.get_connection", return_value=conn), \
+             patch("subprocess.run", return_value=mock_run):
+            with pytest.raises(ValueError, match="git clone failed"):
+                create_project(ProjectCreate(
+                    name="bad-clone",
+                    connection_name="pg",
+                    source=ProjectSource.github,
+                    git_url="https://github.com/org/nope.git",
+                ))
 
     def test_create_local_missing_path_raises(self):
         conn = _make_connection("pg", "postgres")


### PR DESCRIPTION
## Summary
- **Backend:** `_create_github_project` in `store.py` — clones repo via `git clone --branch {branch} --depth 1`, validates `dbt_project.yml` exists, generates `profiles.yml` wired to the connection, stores `git_remote`/`git_branch` on project
- **Frontend:** GitHub button + modal on projects page (name, repo URL, branch, connection dropdown) with clone action
- **Tests:** 3 new tests covering clone success, missing URL validation, and clone failure handling (37 total project tests pass)

## Test plan
- [x] `pytest tests/test_projects.py` — 37 tests pass
- [x] Manual: clone a public dbt repo via the GitHub modal
- [x] Manual: verify cloned project appears with git_remote set on detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)