### PR TITLE
Improve database connectors page error handling

### DIFF
--- a/signalpilot/gateway/gateway/api/connections.py
+++ b/signalpilot/gateway/gateway/api/connections.py
@@ -70,6 +70,8 @@ def _validate_connection_params(conn: ConnectionCreate) -> list[str]:
             errors.append(f"{db} requires a host")
         if not conn.username:
             errors.append(f"{db} requires a username")
+        if not conn.database:
+            errors.append(f"{db} requires a database")
 
     if db == "trino":
         if not conn.host:

--- a/signalpilot/web/app/connections/page.tsx
+++ b/signalpilot/web/app/connections/page.tsx
@@ -967,10 +967,26 @@ function validateForm(form: FormState): Record<string, string> {
     if (!form.database.trim()) errors.database = "database file path is required";
   }
 
+  // Gap 1+2: database required for standard relational connectors
+  if (["postgres", "mysql", "mssql", "clickhouse", "redshift"].includes(form.db_type) && !form.connection_string) {
+    if (!form.database.trim()) errors.database = "database is required";
+  }
+
   if (form.db_type === "snowflake") {
     if (!form.account.trim()) errors.account = "account identifier is required";
     else if (!form.account.includes(".") && !form.account.includes("-")) {
       errors.account = "use full identifier: org-account or account.region";
+    }
+    // Gap 4: key-pair / OAuth token validation
+    if (form.snowflake_auth_method === "key_pair" && !form.sf_private_key.trim()) {
+      errors.sf_private_key = "private key (PEM) is required for key-pair auth";
+    }
+    if (form.snowflake_auth_method === "key_pair" && form.sf_private_key.trim()
+        && !form.sf_private_key.trim().startsWith("-----BEGIN")) {
+      errors.sf_private_key = "must be a PEM-format private key (-----BEGIN ... PRIVATE KEY-----)";
+    }
+    if (form.snowflake_auth_method === "oauth" && !form.sf_oauth_token.trim()) {
+      errors.sf_oauth_token = "OAuth access token is required";
     }
   }
 
@@ -981,6 +997,17 @@ function validateForm(form: FormState): Record<string, string> {
     } else if (form.bq_auth_method === "service_account" && form.credentials_json.trim()) {
       try { JSON.parse(form.credentials_json); } catch { errors.credentials_json = "invalid JSON format"; }
     }
+    // Gap 5: bq_oauth_token required when OAuth method selected
+    if (form.bq_auth_method === "oauth" && !form.bq_oauth_token.trim()) {
+      errors.bq_oauth_token = "OAuth access token is required";
+    }
+  }
+
+  // Gap 3: Azure AD required fields
+  if (form.db_type === "mssql" && form.azure_ad_auth) {
+    if (!form.azure_tenant_id.trim()) errors.azure_tenant_id = "tenant ID is required for Azure AD auth";
+    if (!form.azure_client_id.trim()) errors.azure_client_id = "client ID is required for Azure AD auth";
+    if (!form.azure_client_secret.trim()) errors.azure_client_secret = "client secret is required for Azure AD auth";
   }
 
   if (form.db_type === "databricks") {
@@ -1005,6 +1032,11 @@ function validateForm(form: FormState): Record<string, string> {
     }
     const sshPort = parseInt(form.ssh_port || "22");
     if (isNaN(sshPort) || sshPort < 1 || sshPort > 65535) errors.ssh_port = "SSH port must be 1-65535";
+  }
+
+  // Gap 7: SSL CA cert required for verify modes
+  if (form.ssl_enabled && form.ssl_mode.startsWith("verify") && !form.ssl_ca_cert.trim()) {
+    errors.ssl_ca_cert = "CA certificate is required for verify-ca / verify-full mode";
   }
 
   // Timeout validation (if provided, must be positive integers)
@@ -1348,12 +1380,13 @@ function ConnectionFieldsForm({
               hint="RSA private key for Snowflake key-pair authentication"
               rows={4}
               className="col-span-2"
+              {...(fieldProps("sf_private_key", formErrors, fieldRefs) as { id: string; inputRef: React.Ref<HTMLTextAreaElement>; error: string | undefined })}
             />
             <FormInput label="key passphrase" value={form.sf_private_key_passphrase} onChange={(v) => setForm({ ...form, sf_private_key_passphrase: v })} type="password" hint="leave empty if key is unencrypted" className="col-span-2" />
           </>
         ) : (
           <>
-            <FormInput label="OAuth access token" value={form.sf_oauth_token} onChange={(v) => setForm({ ...form, sf_oauth_token: v })} type="password" required className="col-span-2" hint="from your identity provider (Okta, Azure AD, etc.)" />
+            <FormInput label="OAuth access token" value={form.sf_oauth_token} onChange={(v) => setForm({ ...form, sf_oauth_token: v })} type="password" required className="col-span-2" hint="from your identity provider (Okta, Azure AD, etc.)" {...fieldProps("sf_oauth_token", formErrors, fieldRefs)} />
             <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
               <div><span className="text-[var(--color-text-muted)]">setup:</span> Create a Snowflake security integration (CREATE SECURITY INTEGRATION ... TYPE = EXTERNAL_OAUTH) and configure your IdP to issue tokens.</div>
               <div><span className="text-[var(--color-text-muted)]">local dev:</span> Use Snowflake&apos;s built-in SNOWFLAKE$LOCAL_APPLICATION integration for quick setup without admin involvement.</div>
@@ -1418,7 +1451,7 @@ function ConnectionFieldsForm({
         )}
         {form.bq_auth_method === "oauth" && (
           <>
-            <FormInput label="OAuth access token" value={form.bq_oauth_token} onChange={(v) => setForm({ ...form, bq_oauth_token: v })} type="password" required className="col-span-2" hint="from Google Cloud OAuth flow or gcloud auth print-access-token" />
+            <FormInput label="OAuth access token" value={form.bq_oauth_token} onChange={(v) => setForm({ ...form, bq_oauth_token: v })} type="password" required className="col-span-2" hint="from Google Cloud OAuth flow or gcloud auth print-access-token" {...fieldProps("bq_oauth_token", formErrors, fieldRefs)} />
             <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
               <div><span className="text-[var(--color-text-muted)]">setup:</span> Create an OAuth client in GCP Console → APIs & Services → Credentials → OAuth 2.0 Client ID.</div>
               <div><span className="text-[var(--color-text-muted)]">scopes:</span> Token must include https://www.googleapis.com/auth/bigquery scope.</div>
@@ -1799,7 +1832,7 @@ function ConnectionFieldsForm({
       <>
         <FormInput label="host" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="sqlserver.example.com" hint="hostname or IP — for named instances: host\\INSTANCE" required {...fieldProps("host", formErrors, fieldRefs)} />
         <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder="1433" hint="default 1433 — Azure SQL uses 1433" {...fieldProps("port", formErrors, fieldRefs)} />
-        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="master" required />
+        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="master" required {...fieldProps("database", formErrors, fieldRefs)} />
         {!form.azure_ad_auth && (
           <>
             <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="sa" hint="SQL Server login" required {...fieldProps("username", formErrors, fieldRefs)} />
@@ -1824,9 +1857,9 @@ function ConnectionFieldsForm({
         </div>
         {form.azure_ad_auth && (
           <div className="col-span-2 grid grid-cols-2 gap-3 p-3 border border-blue-500/20 bg-blue-500/5">
-            <FormInput label="tenant ID" value={form.azure_tenant_id} onChange={(v) => setForm({ ...form, azure_tenant_id: v })} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" hint="Azure AD directory (tenant) ID" required />
-            <FormInput label="client ID" value={form.azure_client_id} onChange={(v) => setForm({ ...form, azure_client_id: v })} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" hint="App registration (client) ID" required />
-            <FormInput label="client secret" value={form.azure_client_secret} onChange={(v) => setForm({ ...form, azure_client_secret: v })} type="password" hint="Service principal client secret" required className="col-span-2" />
+            <FormInput label="tenant ID" value={form.azure_tenant_id} onChange={(v) => setForm({ ...form, azure_tenant_id: v })} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" hint="Azure AD directory (tenant) ID" required {...fieldProps("azure_tenant_id", formErrors, fieldRefs)} />
+            <FormInput label="client ID" value={form.azure_client_id} onChange={(v) => setForm({ ...form, azure_client_id: v })} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" hint="App registration (client) ID" required {...fieldProps("azure_client_id", formErrors, fieldRefs)} />
+            <FormInput label="client secret" value={form.azure_client_secret} onChange={(v) => setForm({ ...form, azure_client_secret: v })} type="password" hint="Service principal client secret" required className="col-span-2" {...fieldProps("azure_client_secret", formErrors, fieldRefs)} />
             <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
               <div><span className="text-[var(--color-text-muted)]">setup:</span> Azure Portal → App Registrations → New → Add API Permission for Azure SQL Database. Create a contained DB user: CREATE USER [app-name] FROM EXTERNAL PROVIDER.</div>
               <div><span className="text-[var(--color-text-muted)]">managed identity:</span> For Azure VMs/containers, leave client secret empty to use system-assigned managed identity (coming soon).</div>
@@ -1848,7 +1881,7 @@ function ConnectionFieldsForm({
       <>
         <FormInput label="cluster endpoint" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="my-cluster.abc123xyz.us-east-1.redshift.amazonaws.com" hint="Redshift console → Clusters → Properties → Endpoint" required {...fieldProps("host", formErrors, fieldRefs)} />
         <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder="5439" {...fieldProps("port", formErrors, fieldRefs)} />
-        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="dev" hint="default database is 'dev'" required />
+        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="dev" hint="default database is 'dev'" required {...fieldProps("database", formErrors, fieldRefs)} />
         {!form.iam_auth && (
           <>
             <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="awsuser" required {...fieldProps("username", formErrors, fieldRefs)} />
@@ -1956,7 +1989,12 @@ function ConnectionFieldsForm({
 }
 
 /* ── SSL Config Section ── */
-function SSLSection({ form, setForm }: { form: FormState; setForm: (f: FormState) => void }) {
+function SSLSection({ form, setForm, formErrors, fieldRefs }: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+  formErrors: Record<string, string>;
+  fieldRefs: MutableRefObject<Record<string, HTMLElement | null>>;
+}) {
   const config = DB_CONFIGS[form.db_type];
   if (!config.supportsSSL) return null;
 
@@ -2000,7 +2038,7 @@ function SSLSection({ form, setForm }: { form: FormState; setForm: (f: FormState
           <div />
           {form.ssl_mode !== "disable" && (
             <>
-              <FormTextArea label="ca certificate (pem)" value={form.ssl_ca_cert} onChange={(v) => setForm({ ...form, ssl_ca_cert: v })} placeholder="-----BEGIN CERTIFICATE-----" hint={form.ssl_mode.startsWith("verify") ? "required for certificate verification" : "optional — root CA for server verification"} rows={3} />
+              <FormTextArea label="ca certificate (pem)" value={form.ssl_ca_cert} onChange={(v) => setForm({ ...form, ssl_ca_cert: v })} placeholder="-----BEGIN CERTIFICATE-----" hint={form.ssl_mode.startsWith("verify") ? "required for certificate verification" : "optional — root CA for server verification"} rows={3} {...(fieldProps("ssl_ca_cert", formErrors, fieldRefs) as { id: string; inputRef: React.Ref<HTMLTextAreaElement>; error: string | undefined })} />
               <FormTextArea label="client certificate (pem)" value={form.ssl_client_cert} onChange={(v) => setForm({ ...form, ssl_client_cert: v })} placeholder="-----BEGIN CERTIFICATE-----" hint="optional — for mutual TLS (mTLS) authentication" rows={3} />
               <FormTextArea label="client key (pem)" value={form.ssl_client_key} onChange={(v) => setForm({ ...form, ssl_client_key: v })} placeholder="-----BEGIN PRIVATE KEY-----" hint="required when using client certificate" rows={3} className="col-span-2" />
             </>
@@ -2247,7 +2285,11 @@ export default function ConnectionsPage() {
     "name", "connection_string",
     "host", "port", "account", "project", "credentials_json",
     "http_path", "access_token", "dbx_oauth_client_id", "dbx_oauth_client_secret",
+    "sf_private_key", "sf_oauth_token",
+    "bq_oauth_token",
     "database", "catalog", "username",
+    "azure_tenant_id", "azure_client_id", "azure_client_secret",
+    "ssl_ca_cert",
     "ssh_host", "ssh_port", "ssh_username", "ssh_password", "ssh_private_key",
     "connection_timeout", "query_timeout",
   ] as const;
@@ -2273,7 +2315,8 @@ export default function ConnectionsPage() {
       ["Trino requires a catalog", "catalog"],
       ["requires a host", "host"],
       ["requires a username", "username"],
-      ["requires a database file path", "database"],
+      ["requires a database file path", "database"],   // duckdb/sqlite — must win
+      ["requires a database", "database"],              // pg/mysql/mssql/clickhouse/redshift — generic fallback
     ];
     for (const msg of messages) {
       let matched = false;
@@ -2296,6 +2339,8 @@ export default function ConnectionsPage() {
 
     const isSshField = ["ssh_host", "ssh_port", "ssh_username", "ssh_password", "ssh_private_key"].includes(firstKey);
     const isAdvancedField = ["connection_timeout", "query_timeout"].includes(firstKey);
+    const isSslField = firstKey === "ssl_ca_cert";
+    const isAzureAdField = ["azure_tenant_id", "azure_client_id", "azure_client_secret"].includes(firstKey);
 
     const focusEl = () => {
       requestAnimationFrame(() => {
@@ -2307,13 +2352,18 @@ export default function ConnectionsPage() {
       });
     };
 
-    if (isSshField) {
+    if (isSslField) {
+      if (!showAdvanced) setShowAdvanced(true);
+      setAdvancedTab("security");
+    } else if (isSshField) {
       if (!showAdvanced) setShowAdvanced(true);
       setAdvancedTab("security");
       if (!form.ssh_enabled) setForm((prev) => ({ ...prev, ssh_enabled: true }));
     } else if (isAdvancedField) {
       if (!showAdvanced) setShowAdvanced(true);
       setAdvancedTab("performance");
+    } else if (isAzureAdField) {
+      if (!form.azure_ad_auth) setForm((prev) => ({ ...prev, azure_ad_auth: true }));
     }
 
     // Double-rAF is safe whether or not we just expanded a section
@@ -3003,7 +3053,7 @@ export default function ConnectionsPage() {
                     {/* Security tab */}
                     {advancedTab === "security" && (
                       <div className="animate-fade-in">
-                    <SSLSection form={form} setForm={setForm} />
+                    <SSLSection form={form} setForm={setForm} formErrors={formErrors} fieldRefs={fieldRefs} />
                     <SSHSection form={form} setForm={setForm} serverIp={serverIp} formErrors={formErrors} fieldRefs={fieldRefs} clearServerError={(key) => setServerFieldErrors((prev) => { if (!(key in prev)) return prev; const { [key]: _, ...rest } = prev; return rest; })} />
                     {/* Connection Scope + Read-only (HEX pattern) */}
                     <div className="border-t border-[var(--color-border)] pt-4 mt-4">

--- a/signalpilot/web/app/connections/page.tsx
+++ b/signalpilot/web/app/connections/page.tsx
@@ -75,25 +75,25 @@ import { useConnection } from "@/lib/connection-context";
 const IS_CLOUD_MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE === "cloud";
 
 /* ── Local DB File Picker (DuckDB / SQLite) ── */
-function LocalDBFilePicker({ value, onChange, pattern = "*.duckdb", placeholder = "/path/to/database.duckdb", hint = "paste a file path or browse to select a file" }: { value: string; onChange: (v: string) => void; pattern?: string; placeholder?: string; hint?: string }) {
+function LocalDBFilePicker({ value, onChange, pattern = "*.duckdb", placeholder = "/path/to/database.duckdb", hint = "paste a file path or browse to select a file", id, inputRef, error }: { value: string; onChange: (v: string) => void; pattern?: string; placeholder?: string; hint?: string; id?: string; inputRef?: React.Ref<HTMLInputElement>; error?: string }) {
   const [browsing, setBrowsing] = useState(false);
   const [currentPath, setCurrentPath] = useState<string | null>(null);
   const [files, setFiles] = useState<{ name: string; path: string; size_bytes: number }[]>([]);
   const [directories, setDirectories] = useState<{ name: string; path: string }[]>([]);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [browseError, setBrowseError] = useState<string | null>(null);
 
   const browse = useCallback(async (path?: string) => {
     setLoading(true);
-    setError(null);
+    setBrowseError(null);
     try {
       const data = await browseFiles(path, pattern);
       setCurrentPath(data.path);
       setFiles(data.files || []);
       setDirectories(data.directories || []);
-      if (data.error) setError(data.error);
+      if (data.error) setBrowseError(data.error);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to browse files");
+      setBrowseError(e instanceof Error ? e.message : "Failed to browse files");
     } finally {
       setLoading(false);
     }
@@ -125,14 +125,18 @@ function LocalDBFilePicker({ value, onChange, pattern = "*.duckdb", placeholder 
   return (
     <div className="col-span-2">
       {/* Selected file display + browse button */}
-      <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">database file</label>
+      <label htmlFor={id} className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">database file</label>
       <div className="flex gap-2">
         <input
+          id={id}
+          ref={inputRef}
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="flex-1 px-2.5 py-1.5 bg-[var(--color-bg-code)] border border-[var(--color-border)] text-[13px] text-[var(--color-text)] font-mono tracking-wide focus:outline-none focus:border-[var(--color-text-dim)]"
+          aria-invalid={error ? "true" : undefined}
+          aria-describedby={error && id ? `${id}-error` : undefined}
+          className={`flex-1 px-2.5 py-1.5 bg-[var(--color-bg-code)] border text-[13px] text-[var(--color-text)] font-mono tracking-wide focus:outline-none${error ? " border-[var(--color-error)]/60 focus:border-[var(--color-error)]" : " border-[var(--color-border)] focus:border-[var(--color-text-dim)]"}`}
         />
         <button
           type="button"
@@ -143,6 +147,7 @@ function LocalDBFilePicker({ value, onChange, pattern = "*.duckdb", placeholder 
           browse
         </button>
       </div>
+      {error && id && <p id={`${id}-error`} role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
       <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider">
         {hint}
       </p>
@@ -180,11 +185,11 @@ function LocalDBFilePicker({ value, onChange, pattern = "*.duckdb", placeholder 
               </div>
             )}
 
-            {error && (
-              <div className="px-3 py-2 text-[11px] text-red-400 tracking-wider">{error}</div>
+            {browseError && (
+              <div className="px-3 py-2 text-[11px] text-red-400 tracking-wider">{browseError}</div>
             )}
 
-            {!loading && !error && files.length === 0 && directories.length === 0 && (
+            {!loading && !browseError && files.length === 0 && directories.length === 0 && (
               <div className="px-3 py-4 text-[11px] text-[var(--color-text-dim)] tracking-wider text-center">
                 no matching files found in this directory
               </div>
@@ -1654,8 +1659,8 @@ function ConnectionFieldsForm({
               pattern="*.sqlite,*.db"
               placeholder="/path/to/database.sqlite"
               hint="paste a file path or browse to select a .sqlite or .db file"
+              {...fieldProps("database", formErrors, fieldRefs)}
             />
-            {formErrors.database && <p id="database-error" role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{formErrors.database}</p>}
           </div>
         )}
 
@@ -1710,8 +1715,8 @@ function ConnectionFieldsForm({
               pattern="*.duckdb"
               placeholder="/path/to/database.duckdb"
               hint="paste a file path or browse to select a .duckdb file"
+              {...fieldProps("database", formErrors, fieldRefs)}
             />
-            {formErrors.database && <p id="database-error" role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{formErrors.database}</p>}
           </div>
         )}
 
@@ -3081,20 +3086,30 @@ export default function ConnectionsPage() {
                           </div>
                           <div className="grid grid-cols-3 gap-4">
                             <div>
-                              <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">connection timeout</label>
+                              {(() => { const { id: ctId, inputRef: ctRef, error: ctError } = fieldProps("connection_timeout", formErrors, fieldRefs); return (
+                              <>
+                              <label htmlFor={ctId} className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">connection timeout</label>
                               <div className="flex items-center gap-1.5">
-                                <input type="number" min="1" max="300" value={form.connection_timeout} onChange={(e) => setForm({ ...form, connection_timeout: e.target.value })} className="w-20 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tabular-nums" />
+                                <input type="number" min="1" max="300" id={ctId} ref={ctRef as React.Ref<HTMLInputElement>} aria-invalid={ctError ? "true" : undefined} aria-describedby={ctError ? `${ctId}-error` : undefined} value={form.connection_timeout} onChange={(e) => setForm({ ...form, connection_timeout: e.target.value })} className={`w-20 px-3 py-2 bg-[var(--color-bg-input)] border text-xs focus:outline-none tabular-nums${ctError ? " border-[var(--color-error)]/60 focus:border-[var(--color-error)]" : " border-[var(--color-border)] focus:border-[var(--color-text-dim)]"}`} />
                                 <span className="text-[11px] text-[var(--color-text-dim)] tracking-wider">sec</span>
                               </div>
+                              {ctError && <p id={`${ctId}-error`} role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{ctError}</p>}
                               <p className="text-[10px] text-[var(--color-text-dim)] mt-1 tracking-wider opacity-60">max time to establish connection</p>
+                              </>
+                              ); })()}
                             </div>
                             <div>
-                              <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">query timeout</label>
+                              {(() => { const { id: qtId, inputRef: qtRef, error: qtError } = fieldProps("query_timeout", formErrors, fieldRefs); return (
+                              <>
+                              <label htmlFor={qtId} className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">query timeout</label>
                               <div className="flex items-center gap-1.5">
-                                <input type="number" min="1" max="3600" value={form.query_timeout} onChange={(e) => setForm({ ...form, query_timeout: e.target.value })} className="w-20 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tabular-nums" />
+                                <input type="number" min="1" max="3600" id={qtId} ref={qtRef as React.Ref<HTMLInputElement>} aria-invalid={qtError ? "true" : undefined} aria-describedby={qtError ? `${qtId}-error` : undefined} value={form.query_timeout} onChange={(e) => setForm({ ...form, query_timeout: e.target.value })} className={`w-20 px-3 py-2 bg-[var(--color-bg-input)] border text-xs focus:outline-none tabular-nums${qtError ? " border-[var(--color-error)]/60 focus:border-[var(--color-error)]" : " border-[var(--color-border)] focus:border-[var(--color-text-dim)]"}`} />
                                 <span className="text-[11px] text-[var(--color-text-dim)] tracking-wider">sec</span>
                               </div>
+                              {qtError && <p id={`${qtId}-error`} role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{qtError}</p>}
                               <p className="text-[10px] text-[var(--color-text-dim)] mt-1 tracking-wider opacity-60">max query execution time</p>
+                              </>
+                              ); })()}
                             </div>
                             <div>
                               <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">keepalive interval</label>

--- a/signalpilot/web/app/connections/page.tsx
+++ b/signalpilot/web/app/connections/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef, type MutableRefObject } from "react";
 import {
   Plus,
   Trash2,
@@ -588,23 +588,29 @@ function DbTypeIcon({ type, size = 12 }: { type: string; size?: number }) {
 /* ── Form field components ── */
 function FormInput({
   label, value, onChange, type = "text", placeholder, hint, required, className = "", error,
+  id, inputRef,
 }: {
   label: string; value: string; onChange: (v: string) => void;
   type?: string; placeholder?: string; hint?: string; required?: boolean; className?: string; error?: string;
+  id?: string; inputRef?: React.Ref<HTMLInputElement>;
 }) {
   const [visible, setVisible] = useState(false);
   const isSecret = type === "password";
   return (
     <div className={className}>
-      <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">
+      <label htmlFor={id} className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">
         {label}{required && <span className="text-[var(--color-error)] ml-0.5">*</span>}
       </label>
       <div className="relative">
         <input
+          id={id}
+          ref={inputRef}
           type={isSecret && !visible ? "password" : "text"}
           placeholder={placeholder}
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          aria-invalid={error ? "true" : undefined}
+          aria-describedby={error && id ? `${id}-error` : undefined}
           className={`w-full px-3 py-2 ${isSecret ? "pr-9" : ""} bg-[var(--color-bg-input)] border text-xs focus:outline-none tracking-wide ${
             error ? "border-[var(--color-error)]/60 focus:border-[var(--color-error)]" : "border-[var(--color-border)] focus:border-[var(--color-text-dim)]"
           }`}
@@ -620,31 +626,55 @@ function FormInput({
           </button>
         )}
       </div>
-      {error && <p className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
+      {error && id && <p id={`${id}-error`} role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
+      {error && !id && <p className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
       {hint && !error && <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider opacity-60">{hint}</p>}
     </div>
   );
 }
 
 function FormTextArea({
-  label, value, onChange, placeholder, hint, rows = 4, className = "",
+  label, value, onChange, placeholder, hint, rows = 4, className = "", error,
+  id, inputRef,
 }: {
   label: string; value: string; onChange: (v: string) => void;
-  placeholder?: string; hint?: string; rows?: number; className?: string;
+  placeholder?: string; hint?: string; rows?: number; className?: string; error?: string;
+  id?: string; inputRef?: React.Ref<HTMLTextAreaElement>;
 }) {
   return (
     <div className={className}>
-      <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">{label}</label>
+      <label htmlFor={id} className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">{label}</label>
       <textarea
+        id={id}
+        ref={inputRef}
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         rows={rows}
-        className="w-full px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none focus:border-[var(--color-text-dim)] tracking-wide font-mono resize-y"
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={error && id ? `${id}-error` : undefined}
+        className={`w-full px-3 py-2 bg-[var(--color-bg-input)] border text-xs focus:outline-none tracking-wide font-mono resize-y ${
+          error ? "border-[var(--color-error)]/60 focus:border-[var(--color-error)]" : "border-[var(--color-border)] focus:border-[var(--color-text-dim)]"
+        }`}
       />
-      {hint && <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider opacity-60">{hint}</p>}
+      {error && id && <p id={`${id}-error`} role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
+      {error && !id && <p className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
+      {hint && !error && <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider opacity-60">{hint}</p>}
     </div>
   );
+}
+
+/** One-shot spread helper: returns id + inputRef + error for a given field key. */
+function fieldProps(
+  key: string,
+  formErrors: Record<string, string>,
+  refMap: MutableRefObject<Record<string, HTMLElement | null>>,
+) {
+  return {
+    id: key,
+    inputRef: (el: HTMLElement | null) => { refMap.current[key] = el; },
+    error: formErrors[key],
+  };
 }
 
 /* ── Connection form state ── */
@@ -915,6 +945,21 @@ function validateForm(form: FormState): Record<string, string> {
     if (isNaN(port) || port < 1 || port > 65535) errors.port = "port must be 1-65535";
   }
 
+  // §9 gap-fill: username required for connectors that use it
+  if (["postgres", "mysql", "redshift", "clickhouse", "mssql", "snowflake"].includes(form.db_type) && !form.connection_string) {
+    if (!form.username.trim()) errors.username = "username is required";
+  }
+
+  // §9 gap-fill: catalog required for trino
+  if (form.db_type === "trino" && !form.connection_string) {
+    if (!form.catalog.trim()) errors.catalog = "catalog is required";
+  }
+
+  // §9 gap-fill: database required for duckdb/sqlite (local mode)
+  if ((form.db_type === "duckdb" || form.db_type === "sqlite") && !form.connection_string) {
+    if (!form.database.trim()) errors.database = "database file path is required";
+  }
+
   if (form.db_type === "snowflake") {
     if (!form.account.trim()) errors.account = "account identifier is required";
     else if (!form.account.includes(".") && !form.account.includes("-")) {
@@ -1166,8 +1211,21 @@ function buildCreatePayload(form: FormState): Record<string, unknown> {
 }
 
 /* ── DB-specific form sections ── */
-function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f: FormState) => void }) {
+function ConnectionFieldsForm({
+  form, setForm, formErrors, fieldRefs, clearServerError,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+  formErrors: Record<string, string>;
+  fieldRefs: MutableRefObject<Record<string, HTMLElement | null>>;
+  clearServerError: (key: string) => void;
+}) {
   const config = DB_CONFIGS[form.db_type];
+
+  /** Wrap onChange to also clear the server error for this field key. */
+  function field(key: keyof FormState, update: (v: string) => void) {
+    return (v: string) => { update(v); clearServerError(key as string); };
+  }
 
   // URL mode
   if (form.connectionMode === "url") {
@@ -1189,6 +1247,7 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
           label="connection string"
           value={form.connection_string}
           onChange={(v) => {
+            clearServerError("connection_string");
             const detected = detectDbTypeFromUrl(v);
             if (detected && detected !== form.db_type) {
               // Auto-switch DB type when URL scheme is recognized
@@ -1201,6 +1260,7 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
           placeholder={urlHints[form.db_type] || "paste any connection string — db type auto-detected"}
           hint={form.db_type === "clickhouse" ? "native: clickhouse://... | HTTP: clickhouse+http://..." : "paste a URL — database type is auto-detected from the scheme"}
           className="col-span-2"
+          {...fieldProps("connection_string", formErrors, fieldRefs)}
         />
         {hasValidUrl && (
           <div className="col-span-2 -mt-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed">
@@ -1242,8 +1302,8 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
   if (form.db_type === "snowflake") {
     return (
       <>
-        <FormInput label="account identifier" value={form.account} onChange={(v) => setForm({ ...form, account: v })} placeholder="org-account" hint="e.g., xy12345.us-east-1" required />
-        <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder="ANALYTICS_USER" required />
+        <FormInput label="account identifier" value={form.account} onChange={field("account", (v) => setForm({ ...form, account: v }))} placeholder="org-account" hint="e.g., xy12345.us-east-1" required {...fieldProps("account", formErrors, fieldRefs)} />
+        <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="ANALYTICS_USER" required {...fieldProps("username", formErrors, fieldRefs)} />
         <div className="col-span-2 mb-1">
           <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">authentication method</label>
           <div className="flex gap-2">
@@ -1312,7 +1372,7 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
     const bqAuthLabels: Record<string, string> = { service_account: "service account", oauth: "OAuth token", adc: "application default" };
     return (
       <>
-        <FormInput label="gcp project id" value={form.project} onChange={(v) => setForm({ ...form, project: v })} placeholder="my-project-123" required />
+        <FormInput label="gcp project id" value={form.project} onChange={field("project", (v) => setForm({ ...form, project: v }))} placeholder="my-project-123" required {...fieldProps("project", formErrors, fieldRefs)} />
         <FormInput label="default dataset" value={form.dataset} onChange={(v) => setForm({ ...form, dataset: v })} placeholder="analytics" hint="optional — default dataset for queries" />
 
         {/* Auth method selector */}
@@ -1341,11 +1401,12 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
           <FormTextArea
             label="service account json"
             value={form.credentials_json}
-            onChange={(v) => setForm({ ...form, credentials_json: v })}
+            onChange={field("credentials_json", (v) => setForm({ ...form, credentials_json: v }))}
             placeholder='{"type": "service_account", "project_id": "...", ...}'
             hint="paste the full service account JSON key file contents"
             rows={6}
             className="col-span-2"
+            {...(fieldProps("credentials_json", formErrors, fieldRefs) as { id: string; inputRef: React.Ref<HTMLTextAreaElement>; error: string | undefined })}
           />
         )}
         {form.bq_auth_method === "oauth" && (
@@ -1400,8 +1461,8 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
   if (form.db_type === "databricks") {
     return (
       <>
-        <FormInput label="server hostname" value={form.host} onChange={(v) => setForm({ ...form, host: v })} placeholder="adb-1234567890123456.7.azuredatabricks.net" required />
-        <FormInput label="http path" value={form.http_path} onChange={(v) => setForm({ ...form, http_path: v })} placeholder="/sql/1.0/warehouses/abc123" hint="SQL warehouse or cluster HTTP path" required />
+        <FormInput label="server hostname" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="adb-1234567890123456.7.azuredatabricks.net" required {...fieldProps("host", formErrors, fieldRefs)} />
+        <FormInput label="http path" value={form.http_path} onChange={field("http_path", (v) => setForm({ ...form, http_path: v }))} placeholder="/sql/1.0/warehouses/abc123" hint="SQL warehouse or cluster HTTP path" required {...fieldProps("http_path", formErrors, fieldRefs)} />
         {/* Auth method selector */}
         <div className="col-span-2 mb-1">
           <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">authentication method</label>
@@ -1423,11 +1484,11 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
           </div>
         </div>
         {form.databricks_auth_method === "pat" ? (
-          <FormInput label="access token" value={form.access_token} onChange={(v) => setForm({ ...form, access_token: v })} type="password" hint="personal access token (PAT)" required className="col-span-2" />
+          <FormInput label="access token" value={form.access_token} onChange={field("access_token", (v) => setForm({ ...form, access_token: v }))} type="password" hint="personal access token (PAT)" required className="col-span-2" {...fieldProps("access_token", formErrors, fieldRefs)} />
         ) : form.databricks_auth_method === "oauth_m2m" ? (
           <div className="col-span-2 grid grid-cols-2 gap-3 p-3 border border-amber-500/20 bg-amber-500/5">
-            <FormInput label="client ID" value={form.dbx_oauth_client_id} onChange={(v) => setForm({ ...form, dbx_oauth_client_id: v })} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" hint="service principal application (client) ID" required />
-            <FormInput label="client secret" value={form.dbx_oauth_client_secret} onChange={(v) => setForm({ ...form, dbx_oauth_client_secret: v })} type="password" hint="service principal client secret" required />
+            <FormInput label="client ID" value={form.dbx_oauth_client_id} onChange={field("dbx_oauth_client_id", (v) => setForm({ ...form, dbx_oauth_client_id: v }))} placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" hint="service principal application (client) ID" required {...fieldProps("dbx_oauth_client_id", formErrors, fieldRefs)} />
+            <FormInput label="client secret" value={form.dbx_oauth_client_secret} onChange={field("dbx_oauth_client_secret", (v) => setForm({ ...form, dbx_oauth_client_secret: v }))} type="password" hint="service principal client secret" required {...fieldProps("dbx_oauth_client_secret", formErrors, fieldRefs)} />
             <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
               <div><span className="text-[var(--color-text-muted)]">setup:</span> Account Console → User Management → Service Principals → Add. Grant CAN USE on the SQL Warehouse and data access on Unity Catalog.</div>
               <div><span className="text-[var(--color-text-muted)]">recommended:</span> OAuth M2M is the production-grade auth method. PATs are workspace-scoped and expire.</div>
@@ -1457,10 +1518,10 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
     const trinoAuthLabels: Record<string, string> = { none: "no auth", password: "password", jwt: "JWT token", certificate: "client cert", kerberos: "Kerberos" };
     return (
       <>
-        <FormInput label="host" value={form.host} onChange={(v) => setForm({ ...form, host: v })} placeholder="trino.example.com" required />
-        <FormInput label="port" value={form.port} onChange={(v) => setForm({ ...form, port: v })} placeholder={form.trino_https ? "443" : "8080"} />
-        <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder="trino" />
-        <FormInput label="catalog" value={form.catalog} onChange={(v) => setForm({ ...form, catalog: v })} placeholder="hive" hint="default catalog for queries" />
+        <FormInput label="host" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="trino.example.com" required {...fieldProps("host", formErrors, fieldRefs)} />
+        <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder={form.trino_https ? "443" : "8080"} {...fieldProps("port", formErrors, fieldRefs)} />
+        <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="trino" {...fieldProps("username", formErrors, fieldRefs)} />
+        <FormInput label="catalog" value={form.catalog} onChange={field("catalog", (v) => setForm({ ...form, catalog: v }))} placeholder="hive" hint="default catalog for queries" {...fieldProps("catalog", formErrors, fieldRefs)} />
         <FormInput label="schema" value={form.schema_name} onChange={(v) => setForm({ ...form, schema_name: v })} placeholder="default" hint="optional — default schema" />
 
         {/* Auth method selector */}
@@ -1586,13 +1647,16 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
         </div>
 
         {!IS_CLOUD_MODE && sqliteMode === "local" && (
-          <LocalDBFilePicker
-            value={form.database}
-            onChange={(v) => setForm({ ...form, database: v })}
-            pattern="*.sqlite,*.db"
-            placeholder="/path/to/database.sqlite"
-            hint="paste a file path or browse to select a .sqlite or .db file"
-          />
+          <div className="col-span-2">
+            <LocalDBFilePicker
+              value={form.database}
+              onChange={(v) => { setForm({ ...form, database: v }); clearServerError("database"); }}
+              pattern="*.sqlite,*.db"
+              placeholder="/path/to/database.sqlite"
+              hint="paste a file path or browse to select a .sqlite or .db file"
+            />
+            {formErrors.database && <p id="database-error" role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{formErrors.database}</p>}
+          </div>
         )}
 
         {sqliteMode === "memory" && (
@@ -1639,13 +1703,16 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
         </div>
 
         {!IS_CLOUD_MODE && form.duckdb_mode === "local" && (
-          <LocalDBFilePicker
-            value={form.database}
-            onChange={(v) => setForm({ ...form, database: v })}
-            pattern="*.duckdb"
-            placeholder="/path/to/database.duckdb"
-            hint="paste a file path or browse to select a .duckdb file"
-          />
+          <div className="col-span-2">
+            <LocalDBFilePicker
+              value={form.database}
+              onChange={(v) => { setForm({ ...form, database: v }); clearServerError("database"); }}
+              pattern="*.duckdb"
+              placeholder="/path/to/database.duckdb"
+              hint="paste a file path or browse to select a .duckdb file"
+            />
+            {formErrors.database && <p id="database-error" role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{formErrors.database}</p>}
+          </div>
         )}
 
         {form.duckdb_mode === "motherduck" && (
@@ -1653,10 +1720,11 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
             <FormInput
               label="database name"
               value={form.database.startsWith("md:") ? form.database.slice(3) : form.database}
-              onChange={(v) => setForm({ ...form, database: `md:${v}` })}
+              onChange={field("database", (v) => setForm({ ...form, database: `md:${v}` }))}
               placeholder="my_database"
               hint="MotherDuck database name (without md: prefix)"
               required
+              {...fieldProps("database", formErrors, fieldRefs)}
             />
             <FormInput
               label="token"
@@ -1709,10 +1777,10 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
               : "native protocol — fastest performance, direct binary protocol"}
           </p>
         </div>
-        <FormInput label="host" value={form.host} onChange={(v) => setForm({ ...form, host: v })} placeholder="localhost" required />
-        <FormInput label="port" value={form.port} onChange={(v) => setForm({ ...form, port: v })} placeholder={form.ch_protocol === "http" ? httpPort : nativePort} />
-        <FormInput label="database" value={form.database} onChange={(v) => setForm({ ...form, database: v })} placeholder="default" required />
-        <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder="default" required />
+        <FormInput label="host" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="localhost" required {...fieldProps("host", formErrors, fieldRefs)} />
+        <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder={form.ch_protocol === "http" ? httpPort : nativePort} {...fieldProps("port", formErrors, fieldRefs)} />
+        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="default" required {...fieldProps("database", formErrors, fieldRefs)} />
+        <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="default" required {...fieldProps("username", formErrors, fieldRefs)} />
         <FormInput label="password" value={form.password} onChange={(v) => setForm({ ...form, password: v })} type="password" />
       </>
     );
@@ -1722,12 +1790,12 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
   if (form.db_type === "mssql") {
     return (
       <>
-        <FormInput label="host" value={form.host} onChange={(v) => setForm({ ...form, host: v })} placeholder="sqlserver.example.com" hint="hostname or IP — for named instances: host\\INSTANCE" required />
-        <FormInput label="port" value={form.port} onChange={(v) => setForm({ ...form, port: v })} placeholder="1433" hint="default 1433 — Azure SQL uses 1433" />
-        <FormInput label="database" value={form.database} onChange={(v) => setForm({ ...form, database: v })} placeholder="master" required />
+        <FormInput label="host" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="sqlserver.example.com" hint="hostname or IP — for named instances: host\\INSTANCE" required {...fieldProps("host", formErrors, fieldRefs)} />
+        <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder="1433" hint="default 1433 — Azure SQL uses 1433" {...fieldProps("port", formErrors, fieldRefs)} />
+        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="master" required />
         {!form.azure_ad_auth && (
           <>
-            <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder="sa" hint="SQL Server login" required />
+            <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="sa" hint="SQL Server login" required {...fieldProps("username", formErrors, fieldRefs)} />
             <FormInput label="password" value={form.password} onChange={(v) => setForm({ ...form, password: v })} type="password" />
           </>
         )}
@@ -1771,12 +1839,12 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
   if (form.db_type === "redshift") {
     return (
       <>
-        <FormInput label="cluster endpoint" value={form.host} onChange={(v) => setForm({ ...form, host: v })} placeholder="my-cluster.abc123xyz.us-east-1.redshift.amazonaws.com" hint="Redshift console → Clusters → Properties → Endpoint" required />
-        <FormInput label="port" value={form.port} onChange={(v) => setForm({ ...form, port: v })} placeholder="5439" />
-        <FormInput label="database" value={form.database} onChange={(v) => setForm({ ...form, database: v })} placeholder="dev" hint="default database is 'dev'" required />
+        <FormInput label="cluster endpoint" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder="my-cluster.abc123xyz.us-east-1.redshift.amazonaws.com" hint="Redshift console → Clusters → Properties → Endpoint" required {...fieldProps("host", formErrors, fieldRefs)} />
+        <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder="5439" {...fieldProps("port", formErrors, fieldRefs)} />
+        <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder="dev" hint="default database is 'dev'" required />
         {!form.iam_auth && (
           <>
-            <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder="awsuser" required />
+            <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="awsuser" required {...fieldProps("username", formErrors, fieldRefs)} />
             <FormInput label="password" value={form.password} onChange={(v) => setForm({ ...form, password: v })} type="password" />
           </>
         )}
@@ -1798,7 +1866,7 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
         </div>
         {form.iam_auth && (
           <div className="col-span-2 grid grid-cols-2 gap-3 p-3 border border-amber-500/20 bg-amber-500/5">
-            <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder="awsuser" hint="Redshift DB user to get temporary credentials for" required />
+            <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="awsuser" hint="Redshift DB user to get temporary credentials for" required {...fieldProps("username", formErrors, fieldRefs)} />
             <FormInput label="AWS region" value={form.aws_region} onChange={(v) => setForm({ ...form, aws_region: v })} placeholder="us-east-1" hint="Redshift cluster region" />
             <FormInput label="cluster ID" value={form.redshift_cluster_id} onChange={(v) => setForm({ ...form, redshift_cluster_id: v })} placeholder="my-redshift-cluster" hint="provisioned cluster ID (auto-detected from endpoint if blank)" />
             <FormInput label="workgroup" value={form.redshift_workgroup} onChange={(v) => setForm({ ...form, redshift_workgroup: v })} placeholder="default" hint="for Redshift Serverless only" />
@@ -1826,10 +1894,10 @@ function ConnectionFieldsForm({ form, setForm }: { form: FormState; setForm: (f:
   const ph = placeholders[form.db_type] || { host: "localhost", db: "mydb", user: "user" };
   return (
     <>
-      <FormInput label="host" value={form.host} onChange={(v) => setForm({ ...form, host: v })} placeholder={ph.host} required />
-      <FormInput label="port" value={form.port} onChange={(v) => setForm({ ...form, port: v })} placeholder={String(config.defaultPort)} />
-      <FormInput label="database" value={form.database} onChange={(v) => setForm({ ...form, database: v })} placeholder={ph.db} required />
-      <FormInput label="username" value={form.username} onChange={(v) => setForm({ ...form, username: v })} placeholder={ph.user} required />
+      <FormInput label="host" value={form.host} onChange={field("host", (v) => setForm({ ...form, host: v }))} placeholder={ph.host} required {...fieldProps("host", formErrors, fieldRefs)} />
+      <FormInput label="port" value={form.port} onChange={field("port", (v) => setForm({ ...form, port: v }))} placeholder={String(config.defaultPort)} {...fieldProps("port", formErrors, fieldRefs)} />
+      <FormInput label="database" value={form.database} onChange={field("database", (v) => setForm({ ...form, database: v }))} placeholder={ph.db} required />
+      <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder={ph.user} required {...fieldProps("username", formErrors, fieldRefs)} />
       {!form.iam_auth && (
         <FormInput label="password" value={form.password} onChange={(v) => setForm({ ...form, password: v })} type="password" />
       )}
@@ -1937,7 +2005,16 @@ function SSLSection({ form, setForm }: { form: FormState; setForm: (f: FormState
 }
 
 /* ── SSH Tunnel Section ── */
-function SSHSection({ form, setForm, serverIp }: { form: FormState; setForm: (f: FormState) => void; serverIp?: string | null }) {
+function SSHSection({
+  form, setForm, serverIp, formErrors, fieldRefs, clearServerError,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+  serverIp?: string | null;
+  formErrors: Record<string, string>;
+  fieldRefs: MutableRefObject<Record<string, HTMLElement | null>>;
+  clearServerError: (key: string) => void;
+}) {
   const config = DB_CONFIGS[form.db_type];
   if (!config.supportsSSH) return null;
 
@@ -1955,9 +2032,9 @@ function SSHSection({ form, setForm, serverIp }: { form: FormState; setForm: (f:
       </button>
       {form.ssh_enabled && (
         <div className="grid grid-cols-2 gap-4 mt-3 animate-fade-in">
-          <FormInput label="ssh host" value={form.ssh_host} onChange={(v) => setForm({ ...form, ssh_host: v })} placeholder="bastion.example.com" required />
-          <FormInput label="ssh port" value={form.ssh_port} onChange={(v) => setForm({ ...form, ssh_port: v })} placeholder="22" />
-          <FormInput label="ssh username" value={form.ssh_username} onChange={(v) => setForm({ ...form, ssh_username: v })} placeholder="ubuntu" required />
+          <FormInput label="ssh host" value={form.ssh_host} onChange={(v) => { setForm({ ...form, ssh_host: v }); clearServerError("ssh_host"); }} placeholder="bastion.example.com" required {...fieldProps("ssh_host", formErrors, fieldRefs)} />
+          <FormInput label="ssh port" value={form.ssh_port} onChange={(v) => { setForm({ ...form, ssh_port: v }); clearServerError("ssh_port"); }} placeholder="22" {...fieldProps("ssh_port", formErrors, fieldRefs)} />
+          <FormInput label="ssh username" value={form.ssh_username} onChange={(v) => { setForm({ ...form, ssh_username: v }); clearServerError("ssh_username"); }} placeholder="ubuntu" required {...fieldProps("ssh_username", formErrors, fieldRefs)} />
           <div>
             <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">auth method</label>
             <select
@@ -1971,11 +2048,11 @@ function SSHSection({ form, setForm, serverIp }: { form: FormState; setForm: (f:
             </select>
           </div>
           {form.ssh_auth_method === "password" && (
-            <FormInput label="ssh password" value={form.ssh_password} onChange={(v) => setForm({ ...form, ssh_password: v })} type="password" className="col-span-2" />
+            <FormInput label="ssh password" value={form.ssh_password} onChange={(v) => { setForm({ ...form, ssh_password: v }); clearServerError("ssh_password"); }} type="password" className="col-span-2" {...fieldProps("ssh_password", formErrors, fieldRefs)} />
           )}
           {form.ssh_auth_method === "key" && (
             <>
-              <FormTextArea label="private key (pem)" value={form.ssh_private_key} onChange={(v) => setForm({ ...form, ssh_private_key: v })} placeholder="-----BEGIN OPENSSH PRIVATE KEY-----" rows={4} className="col-span-2" />
+              <FormTextArea label="private key (pem)" value={form.ssh_private_key} onChange={(v) => { setForm({ ...form, ssh_private_key: v }); clearServerError("ssh_private_key"); }} placeholder="-----BEGIN OPENSSH PRIVATE KEY-----" rows={4} className="col-span-2" {...(fieldProps("ssh_private_key", formErrors, fieldRefs) as { id: string; inputRef: React.Ref<HTMLTextAreaElement>; error: string | undefined })} />
               <FormInput label="key passphrase" value={form.ssh_key_passphrase} onChange={(v) => setForm({ ...form, ssh_key_passphrase: v })} type="password" hint="leave empty if key is not encrypted" className="col-span-2" />
             </>
           )}
@@ -2063,8 +2140,15 @@ export default function ConnectionsPage() {
   const [exploredData, setExploredData] = useState<Record<string, { columns: { name: string; type: string; sample_values?: string[]; value_stats?: { min: unknown; max: unknown; avg: number | null } }[] }>>({});
   const [healthHistory, setHealthHistory] = useState<Record<string, number[]>>({});
 
-  // Real-time form validation — computed on every form change
-  const formErrors = showForm ? validateForm(form) : {};
+  // Field ref map for scroll+focus on first invalid field
+  const fieldRefs = useRef<Record<string, HTMLElement | null>>({});
+  // Server-side validation errors mapped back to field keys
+  const [serverFieldErrors, setServerFieldErrors] = useState<Record<string, string>>({});
+
+  // Real-time form validation — computed on every form change.
+  // errors render live because validateForm recomputes on every render; this is the existing behavior.
+  const validateErrors = showForm ? validateForm(form) : {};
+  const formErrors: Record<string, string> = { ...validateErrors, ...serverFieldErrors };
   const hasFormErrors = Object.keys(formErrors).length > 0;
 
   const refresh = useCallback(() => {
@@ -2110,6 +2194,8 @@ export default function ConnectionsPage() {
 
   function handleDbTypeChange(newType: DBType) {
     const config = DB_CONFIGS[newType];
+    // Switching db_type invalidates connector-specific server errors (e.g. catalog for trino)
+    setServerFieldErrors({});
     setForm({
       ...form,
       db_type: newType,
@@ -2120,6 +2206,13 @@ export default function ConnectionsPage() {
   }
 
   async function handleCreate() {
+    const errors = { ...validateForm(form), ...serverFieldErrors };
+    const n = Object.keys(errors).length;
+    if (n > 0) {
+      scrollToFirstInvalidField(errors);
+      toast(`Please fix ${n} field${n > 1 ? "s" : ""} before saving`, "error");
+      return;
+    }
     setSaving(true);
     try {
       const payload = buildCreatePayload(form);
@@ -2135,9 +2228,89 @@ export default function ConnectionsPage() {
       setShowForm(false);
       setEditingConnection(null);
       setForm({ ...defaultForm });
+      setServerFieldErrors({});
       setShowAdvanced(false);
       refresh();
-    } catch (e) { toast(_parseError(e), "error"); } finally { setSaving(false); }
+    } catch (e) { handleServerError(e); } finally { setSaving(false); }
+  }
+
+  // §6 priority order for scroll/focus — first hit wins.
+  // In URL mode, validateForm early-returns so only name and connection_string produce errors.
+  const FIELD_PRIORITY = [
+    "name", "connection_string",
+    "host", "port", "account", "project", "credentials_json",
+    "http_path", "access_token", "dbx_oauth_client_id", "dbx_oauth_client_secret",
+    "database", "catalog", "username",
+    "ssh_host", "ssh_port", "ssh_username", "ssh_password", "ssh_private_key",
+    "connection_timeout", "query_timeout",
+  ] as const;
+
+  /** Map gateway validation_errors[] strings to field keys (§7). */
+  function mapServerValidationErrors(messages: string[]): { fieldErrors: Record<string, string>; unmapped: string[] } {
+    const fieldErrors: Record<string, string> = {};
+    const unmapped: string[] = [];
+    // Evaluated in order — SSH patterns first, then specific-vendor, then generic. First match per message wins.
+    const mappingTable: [string, string][] = [
+      ["SSH tunnel requires a bastion host", "ssh_host"],
+      ["SSH tunnel requires a username", "ssh_username"],
+      ["SSH tunnel with key auth requires a private key", "ssh_private_key"],
+      ["SSH tunnel with password auth requires a password", "ssh_password"],
+      ["Databricks requires a server hostname", "host"],
+      ["Databricks requires an HTTP path", "http_path"],
+      ["Databricks requires a personal access token", "access_token"],
+      ["Snowflake requires an account identifier", "account"],
+      ["Snowflake requires a username", "username"],
+      ["BigQuery requires a GCP project ID", "project"],
+      ["BigQuery requires service account credentials JSON", "credentials_json"],
+      ["Trino requires a host", "host"],
+      ["Trino requires a catalog", "catalog"],
+      ["requires a host", "host"],
+      ["requires a username", "username"],
+      ["requires a database file path", "database"],
+    ];
+    for (const msg of messages) {
+      let matched = false;
+      for (const [substr, key] of mappingTable) {
+        if (msg.includes(substr)) {
+          fieldErrors[key] = fieldErrors[key] ?? msg;
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) unmapped.push(msg);
+    }
+    return { fieldErrors, unmapped };
+  }
+
+  /** Scroll to and focus the first invalid field, expanding collapsed sections as needed. */
+  function scrollToFirstInvalidField(errors: Record<string, string>) {
+    const firstKey = FIELD_PRIORITY.find((k) => errors[k]);
+    if (!firstKey) return;
+
+    const isSshField = ["ssh_host", "ssh_port", "ssh_username", "ssh_password", "ssh_private_key"].includes(firstKey);
+    const isAdvancedField = ["connection_timeout", "query_timeout"].includes(firstKey);
+
+    const focusEl = () => {
+      requestAnimationFrame(() => {
+        const el = fieldRefs.current[firstKey];
+        el?.scrollIntoView({ behavior: "smooth", block: "center" });
+        requestAnimationFrame(() => {
+          fieldRefs.current[firstKey]?.focus({ preventScroll: true });
+        });
+      });
+    };
+
+    if (isSshField) {
+      if (!showAdvanced) setShowAdvanced(true);
+      setAdvancedTab("security");
+      if (!form.ssh_enabled) setForm((prev) => ({ ...prev, ssh_enabled: true }));
+    } else if (isAdvancedField) {
+      if (!showAdvanced) setShowAdvanced(true);
+      setAdvancedTab("performance");
+    }
+
+    // Double-rAF is safe whether or not we just expanded a section
+    focusEl();
   }
 
   function _parseError(e: unknown): string {
@@ -2156,7 +2329,48 @@ export default function ConnectionsPage() {
     return msg.replace(/^Error:\s*\d+:\s*/, "").replace(/^"?(.*?)"?$/, "$1").slice(0, 200);
   }
 
+  /** Attempt to parse gateway validation_errors from an error, map to fields, scroll to first. Falls back to _parseError toast. */
+  function handleServerError(e: unknown) {
+    const msg = String(e);
+    // Strip "Error: <status>: " prefix to get raw body
+    const body = msg.replace(/^Error:\s*\d+:\s*/, "");
+    try {
+      const parsed: unknown = JSON.parse(body);
+      if (parsed && typeof parsed === "object") {
+        const obj = parsed as Record<string, unknown>;
+        const validationArr =
+          (obj.detail && typeof obj.detail === "object" && (obj.detail as Record<string, unknown>).validation_errors) ||
+          obj.validation_errors;
+        if (Array.isArray(validationArr) && validationArr.every((v) => typeof v === "string")) {
+          const { fieldErrors, unmapped } = mapServerValidationErrors(validationArr as string[]);
+          if (Object.keys(fieldErrors).length > 0) {
+            setServerFieldErrors((prev) => ({ ...prev, ...fieldErrors }));
+            const mergedErrors = { ...formErrors, ...fieldErrors };
+            scrollToFirstInvalidField(mergedErrors);
+          }
+          if (unmapped.length > 0) {
+            toast(unmapped.join("; "), "error");
+          } else if (Object.keys(fieldErrors).length === 0) {
+            // validation_errors was empty/unparseable — avoid silent failure
+            toast(_parseError(e), "error");
+          }
+          return;
+        }
+      }
+    } catch {
+      // JSON parse failed — fall through to _parseError
+    }
+    toast(_parseError(e), "error");
+  }
+
   async function handleSaveAndTest() {
+    const errors = { ...validateForm(form), ...serverFieldErrors };
+    const n = Object.keys(errors).length;
+    if (n > 0) {
+      scrollToFirstInvalidField(errors);
+      toast(`Please fix ${n} field${n > 1 ? "s" : ""} before saving`, "error");
+      return;
+    }
     setSaving(true);
     try {
       const payload = buildCreatePayload(form);
@@ -2169,6 +2383,7 @@ export default function ConnectionsPage() {
       setShowForm(false);
       setEditingConnection(null);
       setForm({ ...defaultForm });
+      setServerFieldErrors({});
       setShowAdvanced(false);
       refresh();
       // Auto-test after save
@@ -2177,10 +2392,17 @@ export default function ConnectionsPage() {
       const result = await testConnection(connName);
       setTestResult((prev) => ({ ...prev, [connName]: result }));
       toast(result.status === "healthy" ? `${connName}: connection healthy` : `${connName}: ${result.message}`, result.status === "healthy" ? "success" : "error");
-    } catch (e) { toast(_parseError(e), "error"); } finally { setSaving(false); }
+    } catch (e) { handleServerError(e); } finally { setSaving(false); }
   }
 
   async function handlePreTest() {
+    const errors = { ...validateForm(form), ...serverFieldErrors };
+    const n = Object.keys(errors).length;
+    if (n > 0) {
+      scrollToFirstInvalidField(errors);
+      toast(`Please fix ${n} field${n > 1 ? "s" : ""} before saving`, "error");
+      return;
+    }
     setPreTesting(true);
     setPreTestResult(null);
     try {
@@ -2194,7 +2416,7 @@ export default function ConnectionsPage() {
         toast(failedPhase?.message || result.message, "error");
       }
     } catch (e) {
-      toast(_parseError(e), "error");
+      handleServerError(e);
       setPreTestResult({ status: "error", message: _parseError(e), phases: [] });
     } finally {
       setPreTesting(false);
@@ -2265,6 +2487,7 @@ export default function ConnectionsPage() {
     });
     setEditingConnection(conn.name);
     setShowForm(true);
+    setServerFieldErrors({}); // clear stale server errors when loading a connection (§8)
     const hasCustomTimeouts = (conn.connection_timeout && conn.connection_timeout !== 15) || (conn.query_timeout && conn.query_timeout !== 120) || (conn.keepalive_interval && conn.keepalive_interval > 0);
     setShowAdvanced(!!(conn.ssl || conn.ssh_tunnel?.enabled || conn.schema_refresh_interval || conn.schema_filter_include?.length || conn.schema_filter_exclude?.length || hasCustomTimeouts));
   }
@@ -2629,7 +2852,7 @@ export default function ConnectionsPage() {
                   <div className="px-3 py-2 bg-[var(--color-bg-hover)] border border-[var(--color-border)] text-xs text-[var(--color-text-dim)] tracking-wide">{editingConnection}</div>
                 </div>
               ) : (
-                <FormInput label="connection name" value={form.name} onChange={(v) => setForm({ ...form, name: v })} placeholder="prod-analytics" hint="alphanumeric, dashes, underscores" required error={form.name.length > 0 ? formErrors.name : undefined} />
+                <FormInput label="connection name" value={form.name} onChange={(v) => { setForm({ ...form, name: v }); setServerFieldErrors((prev) => { if (!("name" in prev)) return prev; const { name: _, ...rest } = prev; return rest; }); }} placeholder="prod-analytics" hint="alphanumeric, dashes, underscores" required {...fieldProps("name", formErrors, fieldRefs)} />
               )}
               <FormInput label="description" value={form.description} onChange={(v) => setForm({ ...form, description: v })} placeholder="Production analytics DB" />
             </div>
@@ -2700,7 +2923,7 @@ export default function ConnectionsPage() {
 
             {/* DB-specific fields */}
             <div className="grid grid-cols-2 gap-4 mb-4">
-              <ConnectionFieldsForm form={form} setForm={setForm} />
+              <ConnectionFieldsForm form={form} setForm={setForm} formErrors={formErrors} fieldRefs={fieldRefs} clearServerError={(key) => setServerFieldErrors((prev) => { if (!(key in prev)) return prev; const { [key]: _, ...rest } = prev; return rest; })} />
             </div>
 
             {/* Connection string preview with copy button */}
@@ -2774,7 +2997,7 @@ export default function ConnectionsPage() {
                     {advancedTab === "security" && (
                       <div className="animate-fade-in">
                     <SSLSection form={form} setForm={setForm} />
-                    <SSHSection form={form} setForm={setForm} serverIp={serverIp} />
+                    <SSHSection form={form} setForm={setForm} serverIp={serverIp} formErrors={formErrors} fieldRefs={fieldRefs} clearServerError={(key) => setServerFieldErrors((prev) => { if (!(key in prev)) return prev; const { [key]: _, ...rest } = prev; return rest; })} />
                     {/* Connection Scope + Read-only (HEX pattern) */}
                     <div className="border-t border-[var(--color-border)] pt-4 mt-4">
                       <div className="flex items-center gap-2 text-[12px] text-[var(--color-text-dim)] tracking-wider mb-3">
@@ -3054,18 +3277,18 @@ export default function ConnectionsPage() {
 
             {/* Action buttons */}
             <div className="flex items-center gap-3 mt-5 pt-4 border-t border-[var(--color-border)]">
-              <button onClick={handleCreate} disabled={saving || preTesting || (!editingConnection && !form.name)} className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30">
+              <button onClick={handleCreate} disabled={saving || preTesting || hasFormErrors} className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30">
                 {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
                 {editingConnection ? "update connection" : "save connection"}
               </button>
-              <button onClick={handlePreTest} disabled={saving || preTesting} className="flex items-center gap-2 px-4 py-2 border border-emerald-500/30 text-xs text-emerald-400 hover:bg-emerald-500/10 hover:border-emerald-500/50 transition-all tracking-wider">
+              <button onClick={handlePreTest} disabled={saving || preTesting || hasFormErrors} className="flex items-center gap-2 px-4 py-2 border border-emerald-500/30 text-xs text-emerald-400 hover:bg-emerald-500/10 hover:border-emerald-500/50 transition-all tracking-wider disabled:opacity-40 disabled:cursor-not-allowed">
                 {preTesting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <TestTube className="w-3.5 h-3.5" strokeWidth={1.5} />}
                 test connection
               </button>
-              <button onClick={handleSaveAndTest} disabled={saving || preTesting || (!editingConnection && !form.name) || hasFormErrors} className="flex items-center gap-2 px-4 py-2 border border-[var(--color-border)] text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] hover:border-[var(--color-border-hover)] transition-all tracking-wider disabled:opacity-40 disabled:cursor-not-allowed">
+              <button onClick={handleSaveAndTest} disabled={saving || preTesting || hasFormErrors} className="flex items-center gap-2 px-4 py-2 border border-[var(--color-border)] text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] hover:border-[var(--color-border-hover)] transition-all tracking-wider disabled:opacity-40 disabled:cursor-not-allowed">
                 {editingConnection ? "update & test" : "save & test"}
               </button>
-              <button onClick={() => { setShowForm(false); setEditingConnection(null); setForm({ ...defaultForm }); setShowAdvanced(false); setPreTestResult(null); }} className="px-4 py-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors tracking-wider">
+              <button onClick={() => { setShowForm(false); setEditingConnection(null); setForm({ ...defaultForm }); setServerFieldErrors({}); setShowAdvanced(false); setPreTestResult(null); }} className="px-4 py-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors tracking-wider">
                 cancel
               </button>
               {editingConnection && (

--- a/signalpilot/web/app/connections/page.tsx
+++ b/signalpilot/web/app/connections/page.tsx
@@ -148,9 +148,11 @@ function LocalDBFilePicker({ value, onChange, pattern = "*.duckdb", placeholder 
         </button>
       </div>
       {error && id && <p id={`${id}-error`} role="alert" className="text-[11px] text-[var(--color-error)] mt-1 tracking-wider">{error}</p>}
-      <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider">
-        {hint}
-      </p>
+      {!error && (
+        <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider">
+          {hint}
+        </p>
+      )}
 
       {/* File browser modal */}
       {browsing && (


### PR DESCRIPTION
## Summary

Overhauls error UX on the `/connections` page so users get clear, actionable feedback instead of obscure toasts.

- Inline red-bordered errors with descriptive messages on every validated field across all 11 connector types (postgres, mysql, redshift, snowflake, bigquery, clickhouse, databricks, mssql, trino, duckdb, sqlite) — previously only `name` showed an inline error.
- Auto-scrolls and focuses the first invalid field on submit, auto-expanding the Advanced panel (and switching to the correct sub-tab) and enabling SSH when the invalid field lives there.
- Gap-fills client-side validation for fields the gateway rejects but the form never pre-checked (`username` for several dialects, Trino `catalog`, local-file `database`, etc.).
- Maps gateway `validation_errors` strings back to their originating fields so server-side failures also appear inline — falls back to a clear toast only when a message can't be mapped.
- Full a11y wiring: `htmlFor`, `aria-invalid`, `aria-describedby`, `role="alert"` on error text.
- `FormTextArea` now accepts an `error` prop so BigQuery `credentials_json` and SSH `private_key` can render inline errors.
- Errors clear as the user edits the field; all form-reset paths (edit, cancel, connector-type change) clear both client and server error state.
- Save buttons consistently gate on `hasFormErrors`.
- Round 2 closes remaining gaps: the `connection_timeout` / `query_timeout` raw number inputs now red-border and inline-error correctly, and the local-file picker (sqlite/duckdb) gets a proper ref + red border + `aria-invalid` so scroll/focus lands on it.
- Round 125 extends coverage to previously-missed conditional sub-forms: MSSQL/Redshift `database`, MSSQL Azure AD (`tenant_id`/`client_id`/`client_secret`), Snowflake key-pair (`sf_private_key` + PEM format check) and OAuth (`sf_oauth_token`) modes, BigQuery OAuth (`bq_oauth_token`), and SSL `verify-ca`/`verify-full` CA cert. Scroll-expansion now also opens the Azure AD panel when an Azure AD field is the first invalid field. Gateway adds `database` presence validation for postgres/mysql/mssql/clickhouse/redshift, and the client substring map picks up those verbatim strings (ordered so duckdb's file-path-specific message wins first).

## Test plan
- [ ] Submit with empty name → name field highlights red, scroll jumps to it
- [ ] Submit postgres with empty host → host highlights, scroll+focus
- [ ] Submit with invalid port → inline error
- [ ] BigQuery: paste malformed JSON in credentials → textarea shows inline error
- [ ] Enable SSH, leave ssh_host blank, submit from collapsed Advanced → Advanced panel opens on Security tab, scrolls/focuses ssh_host
- [ ] Server-side validation error (e.g. trigger 422) surfaces inline on the originating field, not just a toast
- [ ] Typing into a field with an error clears the error
- [ ] Edit an existing connection → no stale errors from previous form state
- [ ] Submit with `connection_timeout=0` → Advanced opens on Performance tab, input red-borders, focus lands on it
- [ ] Submit duckdb local with empty database path → picker input red-borders, focus lands on it
- [ ] Submit MSSQL / Redshift with empty database → inline red error + scroll
- [ ] Toggle MSSQL Azure AD on, leave tenant/client/secret blank → Azure AD panel expands, three fields red, scroll to first
- [ ] Snowflake key-pair mode with blank `sf_private_key` → inline error; paste non-PEM text → format error
- [ ] Snowflake OAuth mode with blank `sf_oauth_token` → inline error
- [ ] BigQuery OAuth mode with blank `bq_oauth_token` → inline error
- [ ] SSL `verify-ca` / `verify-full` mode with empty CA cert → Advanced → Security tab opens, CA cert textarea red, scroll/focus lands on it


---
**Branch:** `autofyn/i-want-you-to-im-47bcf0` · **Run:** `064505be-70f0-484c-8023-34bb03e952cd` · *Generated by AutoFyn*