### PR TITLE
Cloud-only tier branding (free / pro / team / enterprise)

### DIFF
--- a/signalpilot/web/app/dashboard/page.tsx
+++ b/signalpilot/web/app/dashboard/page.tsx
@@ -37,6 +37,8 @@ import { SqlHighlight } from "@/components/ui/sql-highlight";
 import { TimeAgo } from "@/components/ui/time-ago";
 import { DashboardSkeleton } from "@/components/ui/skeleton";
 import { useOnboardingStatus } from "@/lib/onboarding";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+import { TierWordmark } from "@/components/branding/tier-wordmark";
 
 /* ── Metric card ── */
 function MetricCard({
@@ -423,13 +425,22 @@ function CloudStatusSection() {
 /* ── Signed-in user greeting ── */
 function UserGreeting() {
   const { isCloudMode, user } = useAppAuth();
+  const b = useTierBranding();
 
   if (!isCloudMode || !user) return null;
 
   const email = user.email ?? "—";
 
+  const showTierPrefix = b.enabled && b.tier !== "free";
+
   return (
     <p className="text-[12px] text-[var(--color-text-dim)] tracking-wider mb-4">
+      {showTierPrefix && (
+        <>
+          <TierWordmark variant="header" />
+          <span className="mx-2 text-[var(--color-text-dim)]">·</span>
+        </>
+      )}
       signed in as{" "}
       <span className="text-[var(--color-text-muted)]">{email}</span>
     </p>

--- a/signalpilot/web/app/dashboard/page.tsx
+++ b/signalpilot/web/app/dashboard/page.tsx
@@ -124,8 +124,9 @@ function CloudStatusContent({ keyCount }: { keyCount: number | null }) {
 
   const tierColorMap: Record<string, string> = {
     free: "text-[var(--color-text-dim)] border-[var(--color-border)]",
-    pro: "text-[var(--color-success)] border-[var(--color-success)]/40",
-    team: "text-[var(--color-warning)] border-[var(--color-warning)]/40",
+    pro: "text-indigo-400 border-indigo-500/40",
+    team: "text-violet-300 border-violet-400/50",
+    enterprise: "text-amber-300 border-amber-400/50",
   };
   const tierClasses = tierColorMap[planTier] ?? tierColorMap.free;
 

--- a/signalpilot/web/app/globals.css
+++ b/signalpilot/web/app/globals.css
@@ -82,6 +82,13 @@ input[type="checkbox"], input[type="radio"], summary {
 }
 .animate-fade-in { animation: fade-in 0.4s ease-out forwards; }
 
+/* Fade out */
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+.animate-fade-out { animation: fade-out 160ms ease-in forwards; }
+
 /* Staggered fade-in for lists */
 .stagger-fade-in > * {
   opacity: 0;
@@ -751,6 +758,7 @@ kbd {
 /* Must appear AFTER all keyframe definitions to win without added specificity. */
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-in,
+  .animate-fade-out,
   .animate-slide-in-left,
   .animate-slide-in-right,
   .animate-slide-in-up,

--- a/signalpilot/web/app/layout.tsx
+++ b/signalpilot/web/app/layout.tsx
@@ -4,6 +4,7 @@ import Sidebar from "@/components/layout/sidebar";
 
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { KeyboardShortcuts } from "@/components/ui/keyboard-shortcuts";
+import { TabTitle } from "@/components/layout/tab-title";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ToastProvider } from "@/components/ui/toast";
 import { GridBackground } from "@/components/ui/grid-background";
@@ -49,6 +50,7 @@ export default async function RootLayout({
                 <PageTransition>{children}</PageTransition>
               </ErrorBoundary>
               <KeyboardShortcuts />
+              <TabTitle />
               <CommandPalette />
             </MainContent>
           </SubscriptionProvider>

--- a/signalpilot/web/app/layout.tsx
+++ b/signalpilot/web/app/layout.tsx
@@ -15,6 +15,7 @@ import { AuthProvider } from "@/lib/auth-context";
 import { SWRProvider } from "@/lib/swr";
 import { SubscriptionProvider } from "@/lib/subscription-context";
 import { clerkAppearance } from "@/lib/clerk-theme";
+import TierUpgradeCelebration from "@/components/branding/tier-upgrade-celebration";
 
 export const metadata: Metadata = {
   title: "SignalPilot",
@@ -53,6 +54,7 @@ export default async function RootLayout({
               <TabTitle />
               <CommandPalette />
             </MainContent>
+            <TierUpgradeCelebration />
           </SubscriptionProvider>
         </AuthProvider>
       </ConnectionProvider>

--- a/signalpilot/web/app/layout.tsx
+++ b/signalpilot/web/app/layout.tsx
@@ -5,6 +5,7 @@ import Sidebar from "@/components/layout/sidebar";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { KeyboardShortcuts } from "@/components/ui/keyboard-shortcuts";
 import { TabTitle } from "@/components/layout/tab-title";
+import { TierFavicon } from "@/components/branding/tier-favicon";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ToastProvider } from "@/components/ui/toast";
 import { GridBackground } from "@/components/ui/grid-background";
@@ -52,6 +53,7 @@ export default async function RootLayout({
               </ErrorBoundary>
               <KeyboardShortcuts />
               <TabTitle />
+              <TierFavicon />
               <CommandPalette />
             </MainContent>
             <TierUpgradeCelebration />

--- a/signalpilot/web/app/settings/billing/page.tsx
+++ b/signalpilot/web/app/settings/billing/page.tsx
@@ -27,6 +27,8 @@ import { SectionHeader } from "@/components/ui/section-header";
 import { useToast } from "@/components/ui/toast";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { BillingSkeleton } from "@/components/ui/skeleton";
+import { TierBadge } from "@/components/branding/tier-badge";
+import { TierAccent } from "@/components/branding/tier-accent";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,26 +55,6 @@ const HIGHLIGHT_COLORS: Record<string, string> = {
   warning: "var(--color-warning)",
   default: "var(--color-text-muted)",
 };
-
-// ---------------------------------------------------------------------------
-// Tier badge
-// ---------------------------------------------------------------------------
-
-function TierBadge({ tier }: { tier: string }) {
-  const colorMap: Record<string, string> = {
-    free: "text-[var(--color-text-dim)] border-[var(--color-border)]",
-    pro: "text-[var(--color-success)] border-[var(--color-success)]/40",
-    team: "text-[var(--color-warning)] border-[var(--color-warning)]/40",
-  };
-  const classes = colorMap[tier] ?? colorMap.free;
-  return (
-    <span
-      className={`px-2 py-0.5 text-[11px] border tracking-[0.15em] uppercase ${classes}`}
-    >
-      {tier}
-    </span>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Billing interval toggle
@@ -581,7 +563,13 @@ function BillingContent() {
         <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <TierBadge tier={planTier} />
+              {planTier === "free" ? (
+                <span className="px-1.5 py-0.5 text-[11px] border tracking-[0.15em] uppercase text-[var(--color-text-dim)] border-[var(--color-border)]">
+                  free
+                </span>
+              ) : (
+                <TierBadge size="sm" />
+              )}
               <div>
                 <span className="text-[12px] text-[var(--color-text-dim)] tracking-wider">
                   status:{" "}
@@ -619,6 +607,7 @@ function BillingContent() {
             )}
           </div>
         </div>
+        <TierAccent />
       </section>
 
       {/* Pending downgrade banner */}

--- a/signalpilot/web/components/branding/tier-accent.tsx
+++ b/signalpilot/web/components/branding/tier-accent.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+export function TierAccent() {
+  const b = useTierBranding();
+
+  if (!b.enabled || b.tier === "free") return null;
+
+  const { brand } = b;
+
+  return (
+    <div
+      className={`mt-px h-px bg-gradient-to-r ${brand.gradientFrom} ${brand.gradientVia} ${brand.gradientTo}`}
+    />
+  );
+}

--- a/signalpilot/web/components/branding/tier-badge.tsx
+++ b/signalpilot/web/components/branding/tier-badge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+interface TierBadgeProps {
+  size?: "sm" | "md";
+}
+
+export function TierBadge({ size = "sm" }: TierBadgeProps) {
+  const b = useTierBranding();
+
+  if (!b.enabled || b.tier === "free") return null;
+
+  const { brand } = b;
+  const Icon = brand.icon;
+
+  const textSize = size === "sm" ? "text-[11px]" : "text-[12px]";
+  const iconSize = size === "sm" ? 10 : 12;
+  const padding = size === "sm" ? "px-1.5 py-0.5" : "px-2 py-1";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 border ${padding} ${textSize} tracking-[0.15em] uppercase ${brand.accentText} ${brand.accentBorder} ${brand.accentBg}`}
+    >
+      {Icon && <Icon size={iconSize} className="flex-shrink-0" />}
+      {brand.label}
+    </span>
+  );
+}

--- a/signalpilot/web/components/branding/tier-crest.tsx
+++ b/signalpilot/web/components/branding/tier-crest.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+/**
+ * Tiny absolute-positioned corner overlay for team avatar squares.
+ * Returns null for free and pro (Pro stays calm — no avatar overlay,
+ * only sidebar/header marks). Only Team and Enterprise get this crest.
+ *
+ * Usage: wrap the target element in `relative inline-flex` and render
+ * <TierCrest /> as a sibling.
+ */
+export function TierCrest() {
+  const b = useTierBranding();
+
+  if (!b.enabled) return null;
+  if (b.tier === "free" || b.tier === "pro") return null;
+
+  const { brand } = b;
+  const Icon = brand.icon;
+
+  if (!Icon) return null;
+
+  return (
+    <span
+      className={`absolute -bottom-0.5 -right-0.5 flex items-center justify-center w-3 h-3 bg-[var(--color-bg)] rounded-none ${brand.accentText}`}
+      aria-hidden="true"
+    >
+      <Icon size={9} className="flex-shrink-0" />
+    </span>
+  );
+}

--- a/signalpilot/web/components/branding/tier-favicon.tsx
+++ b/signalpilot/web/components/branding/tier-favicon.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+// Inline SVG string constants per tier — no react-dom/server, no extra HTTP fetch.
+// Paths match Lucide Crown / Gem / Sparkles at 32×32 viewport.
+
+const ENTERPRISE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 6.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.735H5.81a1 1 0 0 1-.957-.735L2.02 7.019a.5.5 0 0 1 .797-.519l4.278 2.664a1 1 0 0 0 1.516-.294z"/><path d="M5 21h14"/></svg>';
+
+const TEAM_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3l6 3 6-3v10l-6 3-6-3z"/><path d="M6 3v10"/><path d="M18 3v10"/><path d="M12 6v10"/></svg>';
+
+const PRO_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg>';
+
+const TIER_SVG: Record<string, string> = {
+  enterprise: ENTERPRISE_SVG,
+  team: TEAM_SVG,
+  pro: PRO_SVG,
+};
+
+/**
+ * Pure side-effect component. Returns null always.
+ * Appends a <link data-tier-favicon="true"> for paid cloud tiers.
+ * Browsers pick the last <link rel="icon"> match.
+ * On unmount or tier change, removes only the tier-favicon element.
+ * Original ico/svg/png links stay untouched.
+ */
+export function TierFavicon() {
+  const b = useTierBranding();
+
+  const enabled = b.enabled;
+  const tier = b.enabled ? b.tier : null;
+
+  useEffect(() => {
+    if (!enabled || tier === "free" || tier === null) {
+      return;
+    }
+
+    const svg = TIER_SVG[tier];
+    if (!svg) return;
+
+    const dataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+
+    const link = document.createElement("link");
+    link.rel = "icon";
+    link.setAttribute("data-tier-favicon", "true");
+    link.href = dataUrl;
+    document.head.appendChild(link);
+
+    return () => {
+      const existing = document.querySelector('link[data-tier-favicon="true"]');
+      if (existing) {
+        existing.remove();
+      }
+    };
+  }, [enabled, tier]);
+
+  return null;
+}

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -1,89 +1,45 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
 import { useOrganization } from "@clerk/nextjs";
 import { TIER_BRANDS } from "@/lib/tier-branding";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+const Crown = TIER_BRANDS.enterprise.icon;
 
 interface TierSealProps {
   variant: "footer" | "header";
 }
 
-/**
- * Enterprise-only watermark seal. Returns null for all non-enterprise tiers.
- *
- * The component is split into two pieces for hooks-rules safety:
- * - TierSeal: outer gate that calls only useTierBranding(). Exits early for
- *   local mode or non-enterprise tiers, so useOrganization() never runs in
- *   those cases.
- * - EnterpriseSealInner: mounts only when TierSeal decides to render the seal.
- *   Calls useOrganization() unconditionally (safe — only mounted in cloud mode
- *   after Clerk is initialized).
- */
+// Split into outer gate + inner mount so useOrganization() never runs outside
+// cloud+enterprise (Clerk hook is unsafe in local mode).
 export function TierSeal({ variant }: TierSealProps) {
   const b = useTierBranding();
 
-  // Gate: local mode or non-enterprise → nothing rendered, no Clerk hook called.
   if (!b.enabled || b.tier !== "enterprise") return null;
 
   return <EnterpriseSealInner variant={variant} />;
 }
 
-// ── Inner component — only ever mounted in cloud enterprise mode ──
-
-interface EnterpriseSealInnerProps {
-  variant: "footer" | "header";
-}
-
-function EnterpriseSealInner({ variant }: EnterpriseSealInnerProps) {
-  // This component is ONLY mounted inside ClerkProvider (cloud + enterprise).
-  const orgName = useEnterpriseOrgName();
+function EnterpriseSealInner({ variant }: TierSealProps) {
+  const { organization } = useOrganization();
+  const orgName = organization?.name ?? null;
 
   if (variant === "footer") {
-    return <FooterSeal orgName={orgName} />;
+    return (
+      <div className="flex items-center gap-2 py-2">
+        {Crown && (
+          <Crown
+            size={14}
+            className="flex-shrink-0 text-amber-300/30"
+            aria-hidden="true"
+          />
+        )}
+        <span className="text-[10px] text-[var(--color-text-dim)]/60 tracking-[0.2em] uppercase">
+          enterprise edition{orgName ? ` · ${orgName}` : ""}
+        </span>
+      </div>
+    );
   }
-
-  return <HeaderSeal />;
-}
-
-// ── Clerk org name hook — unconditional call is safe here ──
-
-function useEnterpriseOrgName(): string | null {
-  const { organization } = useOrganization();
-  return organization?.name ?? null;
-}
-
-// ── Shared helper: get Crown icon from config without re-importing lucide ──
-
-function getCrownIcon(): LucideIcon | null {
-  return TIER_BRANDS.enterprise.icon;
-}
-
-// ── Footer variant ──
-
-function FooterSeal({ orgName }: { orgName: string | null }) {
-  const Crown = getCrownIcon();
-
-  return (
-    <div className="flex items-center gap-2 py-2">
-      {Crown && (
-        <Crown
-          size={14}
-          className="flex-shrink-0 text-amber-300/30"
-          aria-hidden="true"
-        />
-      )}
-      <span className="text-[10px] text-[var(--color-text-dim)]/60 tracking-[0.2em] uppercase">
-        enterprise edition{orgName ? ` · ${orgName}` : ""}
-      </span>
-    </div>
-  );
-}
-
-// ── Header variant ──
-
-function HeaderSeal() {
-  const Crown = getCrownIcon();
 
   return (
     <span className="inline-flex items-center gap-1.5 text-amber-300 tracking-[0.2em] uppercase text-[11px]">

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import { useOrganization } from "@clerk/nextjs";
-import { TIER_BRANDS } from "@/lib/tier-branding";
+import { type TierBrand } from "@/lib/tier-branding";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
-
-const Crown = TIER_BRANDS.enterprise.icon;
-const Gem = TIER_BRANDS.team.icon;
 
 interface TierSealProps {
   variant: "footer" | "header";
@@ -27,11 +24,11 @@ export function TierSeal({ variant }: TierSealProps) {
   if (!b.enabled) return null;
 
   if (b.tier === "enterprise") {
-    return <EnterpriseSealInner variant={variant} />;
+    return <EnterpriseSealInner variant={variant} brand={b.brand} />;
   }
 
   if (b.tier === "team" && variant === "footer") {
-    return <TeamSealInner />;
+    return <TeamSealInner brand={b.brand} />;
   }
 
   return null;
@@ -41,9 +38,14 @@ export function TierSeal({ variant }: TierSealProps) {
 // EnterpriseSealInner — safe to call useOrganization() here
 // ---------------------------------------------------------------------------
 
-function EnterpriseSealInner({ variant }: TierSealProps) {
+interface EnterpriseSealInnerProps extends TierSealProps {
+  brand: TierBrand;
+}
+
+function EnterpriseSealInner({ variant, brand }: EnterpriseSealInnerProps) {
   const { organization } = useOrganization();
   const orgName = organization?.name ?? null;
+  const Icon = brand.icon;
 
   if (variant === "footer") {
     return (
@@ -51,8 +53,8 @@ function EnterpriseSealInner({ variant }: TierSealProps) {
         <div className="h-px bg-amber-400/60" />
         <div className="px-3 py-2 flex flex-col gap-1">
           <div className="flex items-center gap-2">
-            {Crown && (
-              <Crown
+            {Icon && (
+              <Icon
                 size={16}
                 className="flex-shrink-0 text-amber-300/80"
                 aria-hidden="true"
@@ -75,8 +77,8 @@ function EnterpriseSealInner({ variant }: TierSealProps) {
   // Header variant — enterprise only, unchanged
   return (
     <span className="inline-flex items-center gap-1.5 text-amber-300 tracking-[0.2em] uppercase text-[11px]">
-      {Crown && (
-        <Crown size={12} className="flex-shrink-0" aria-hidden="true" />
+      {Icon && (
+        <Icon size={12} className="flex-shrink-0" aria-hidden="true" />
       )}
       ENTERPRISE
     </span>
@@ -87,13 +89,19 @@ function EnterpriseSealInner({ variant }: TierSealProps) {
 // TeamSealInner — no useOrganization(); footer only
 // ---------------------------------------------------------------------------
 
-function TeamSealInner() {
+interface TeamSealInnerProps {
+  brand: TierBrand;
+}
+
+function TeamSealInner({ brand }: TeamSealInnerProps) {
+  const Icon = brand.icon;
+
   return (
     <div className="rounded border border-violet-400/30 bg-gradient-to-b from-violet-500/10 to-violet-500/5 overflow-hidden">
       <div className="h-px bg-violet-400/60" />
       <div className="px-3 py-2 flex items-center gap-2">
-        {Gem && (
-          <Gem
+        {Icon && (
+          <Icon
             size={16}
             className="flex-shrink-0 text-violet-300/80"
             aria-hidden="true"

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -5,20 +5,41 @@ import { TIER_BRANDS } from "@/lib/tier-branding";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
 const Crown = TIER_BRANDS.enterprise.icon;
+const Gem = TIER_BRANDS.team.icon;
 
 interface TierSealProps {
   variant: "footer" | "header";
 }
 
-// Split into outer gate + inner mount so useOrganization() never runs outside
-// cloud+enterprise (Clerk hook is unsafe in local mode).
+/**
+ * TierSeal outer gate — branches by tier so inner components can call hooks
+ * unconditionally (rules-of-hooks: no conditional hook calls).
+ *
+ * - enterprise → EnterpriseSealInner (calls useOrganization, renders org name)
+ * - team       → TeamSealInner      (no useOrganization, no org line)
+ * - else       → null
+ *
+ * Header variant gate stays enterprise-only (unchanged from prior spec).
+ */
 export function TierSeal({ variant }: TierSealProps) {
   const b = useTierBranding();
 
-  if (!b.enabled || b.tier !== "enterprise") return null;
+  if (!b.enabled) return null;
 
-  return <EnterpriseSealInner variant={variant} />;
+  if (b.tier === "enterprise") {
+    return <EnterpriseSealInner variant={variant} />;
+  }
+
+  if (b.tier === "team" && variant === "footer") {
+    return <TeamSealInner />;
+  }
+
+  return null;
 }
+
+// ---------------------------------------------------------------------------
+// EnterpriseSealInner — safe to call useOrganization() here
+// ---------------------------------------------------------------------------
 
 function EnterpriseSealInner({ variant }: TierSealProps) {
   const { organization } = useOrganization();
@@ -26,21 +47,32 @@ function EnterpriseSealInner({ variant }: TierSealProps) {
 
   if (variant === "footer") {
     return (
-      <div className="flex items-center gap-2 py-2">
-        {Crown && (
-          <Crown
-            size={14}
-            className="flex-shrink-0 text-amber-300/30"
-            aria-hidden="true"
-          />
-        )}
-        <span className="text-[10px] text-[var(--color-text-dim)]/60 tracking-[0.2em] uppercase">
-          enterprise edition{orgName ? ` · ${orgName}` : ""}
-        </span>
+      <div className="rounded border border-amber-400/30 bg-gradient-to-b from-amber-500/10 to-amber-500/5 overflow-hidden">
+        <div className="h-px bg-amber-400/60" />
+        <div className="px-3 py-2 flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            {Crown && (
+              <Crown
+                size={16}
+                className="flex-shrink-0 text-amber-300/80"
+                aria-hidden="true"
+              />
+            )}
+            <span className="text-[10px] text-amber-300 tracking-[0.2em] uppercase">
+              Enterprise Edition
+            </span>
+          </div>
+          {orgName && (
+            <span className="text-[10px] text-amber-300/60 tracking-wide pl-6">
+              {orgName}
+            </span>
+          )}
+        </div>
       </div>
     );
   }
 
+  // Header variant — enterprise only, unchanged
   return (
     <span className="inline-flex items-center gap-1.5 text-amber-300 tracking-[0.2em] uppercase text-[11px]">
       {Crown && (
@@ -48,5 +80,29 @@ function EnterpriseSealInner({ variant }: TierSealProps) {
       )}
       ENTERPRISE
     </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TeamSealInner — no useOrganization(); footer only
+// ---------------------------------------------------------------------------
+
+function TeamSealInner() {
+  return (
+    <div className="rounded border border-violet-400/30 bg-gradient-to-b from-violet-500/10 to-violet-500/5 overflow-hidden">
+      <div className="h-px bg-violet-400/60" />
+      <div className="px-3 py-2 flex items-center gap-2">
+        {Gem && (
+          <Gem
+            size={16}
+            className="flex-shrink-0 text-violet-300/80"
+            aria-hidden="true"
+          />
+        )}
+        <span className="text-[10px] text-violet-300 tracking-[0.2em] uppercase">
+          Team Edition
+        </span>
+      </div>
+    </div>
   );
 }

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { useOrganization } from "@clerk/nextjs";
+import { TIER_BRANDS } from "@/lib/tier-branding";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+interface TierSealProps {
+  variant: "footer" | "header";
+}
+
+/**
+ * Enterprise-only watermark seal. Returns null for all non-enterprise tiers.
+ *
+ * The component is split into two pieces for hooks-rules safety:
+ * - TierSeal: outer gate that calls only useTierBranding(). Exits early for
+ *   local mode or non-enterprise tiers, so useOrganization() never runs in
+ *   those cases.
+ * - EnterpriseSealInner: mounts only when TierSeal decides to render the seal.
+ *   Calls useOrganization() unconditionally (safe — only mounted in cloud mode
+ *   after Clerk is initialized).
+ */
+export function TierSeal({ variant }: TierSealProps) {
+  const b = useTierBranding();
+
+  // Gate: local mode or non-enterprise → nothing rendered, no Clerk hook called.
+  if (!b.enabled || b.tier !== "enterprise") return null;
+
+  return <EnterpriseSealInner variant={variant} />;
+}
+
+// ── Inner component — only ever mounted in cloud enterprise mode ──
+
+interface EnterpriseSealInnerProps {
+  variant: "footer" | "header";
+}
+
+function EnterpriseSealInner({ variant }: EnterpriseSealInnerProps) {
+  // This component is ONLY mounted inside ClerkProvider (cloud + enterprise).
+  const orgName = useEnterpriseOrgName();
+
+  if (variant === "footer") {
+    return <FooterSeal orgName={orgName} />;
+  }
+
+  return <HeaderSeal />;
+}
+
+// ── Clerk org name hook — unconditional call is safe here ──
+
+function useEnterpriseOrgName(): string | null {
+  const { organization } = useOrganization();
+  return organization?.name ?? null;
+}
+
+// ── Shared helper: get Crown icon from config without re-importing lucide ──
+
+function getCrownIcon(): LucideIcon | null {
+  return TIER_BRANDS.enterprise.icon;
+}
+
+// ── Footer variant ──
+
+function FooterSeal({ orgName }: { orgName: string | null }) {
+  const Crown = getCrownIcon();
+
+  return (
+    <div className="flex items-center gap-2 py-2">
+      {Crown && (
+        <Crown
+          size={14}
+          className="flex-shrink-0 text-amber-300/30"
+          aria-hidden="true"
+        />
+      )}
+      <span className="text-[10px] text-[var(--color-text-dim)]/60 tracking-[0.2em] uppercase">
+        enterprise edition{orgName ? ` · ${orgName}` : ""}
+      </span>
+    </div>
+  );
+}
+
+// ── Header variant ──
+
+function HeaderSeal() {
+  const Crown = getCrownIcon();
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-amber-300 tracking-[0.2em] uppercase text-[11px]">
+      {Crown && (
+        <Crown size={12} className="flex-shrink-0" aria-hidden="true" />
+      )}
+      ENTERPRISE
+    </span>
+  );
+}

--- a/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
+++ b/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
@@ -3,14 +3,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Crown } from "lucide-react";
 import { useTierUpgrade } from "@/lib/hooks/use-tier-upgrade";
-import { TIER_BRANDS } from "@/lib/tier-branding";
+import { TIER_BRANDS, type BrandTier } from "@/lib/tier-branding";
 import { TierBadge } from "@/components/branding/tier-badge";
 import { TierWordmark } from "@/components/branding/tier-wordmark";
 import { TierAccent } from "@/components/branding/tier-accent";
 import { TierSeal } from "@/components/branding/tier-seal";
 
 // Per-tier dismiss delays — Enterprise copy is longest, gets the most time.
-const DISMISS_DELAY_MS: Record<string, number> = {
+const DISMISS_DELAY_MS: Record<BrandTier, number> = {
+  free: 8000,
   pro: 6000,
   team: 8000,
   enterprise: 12000,
@@ -56,7 +57,7 @@ export default function TierUpgradeCelebration() {
   useEffect(() => {
     if (!celebratingTier) return;
 
-    const delay = DISMISS_DELAY_MS[celebratingTier] ?? 8000;
+    const delay = DISMISS_DELAY_MS[celebratingTier];
     let remaining = delay;
     let start = Date.now();
     let timerId: ReturnType<typeof setTimeout> | null = null;

--- a/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
+++ b/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
@@ -135,7 +135,8 @@ export default function TierUpgradeCelebration() {
 
   if (!celebratingTier) return null;
 
-  const tierLabel = TIER_BRANDS[celebratingTier].label;
+  const brand = TIER_BRANDS[celebratingTier];
+  const tierLabel = brand.label;
 
   return (
     // Backdrop — z-[80] sits below toasts (z-[90])
@@ -158,18 +159,12 @@ export default function TierUpgradeCelebration() {
         aria-modal="true"
         aria-labelledby={HEADLINE_ID}
         aria-label={`${tierLabel} upgrade celebration`}
-        className={`relative z-10 w-full max-w-sm mx-4 bg-[var(--color-bg-card)] border ${
-          celebratingTier === "pro"
-            ? "border-indigo-500/40 bg-indigo-500/10"
-            : celebratingTier === "team"
-            ? "border-violet-400/50"
-            : "border-amber-400/50"
-        } ${
-          celebratingTier === "team"
-            ? "bg-violet-500/10"
-            : celebratingTier === "enterprise"
-            ? "bg-gradient-to-b from-amber-500/10 to-transparent"
-            : ""
+        className={`relative z-10 w-full max-w-sm mx-4 bg-[var(--color-bg-card)] border ${brand.accentBorder} ${
+          celebratingTier === "enterprise"
+            ? // enterprise celebration uses a gradient bg — deliberate one-off;
+              // brand.accentBg is the flat token (bg-amber-500/10) which differs
+              "bg-gradient-to-b from-amber-500/10 to-transparent"
+            : brand.accentBg
         } shadow-xl ${exiting ? "animate-slide-out-up" : "animate-slide-in-up"}`}
       >
         {/* Close button */}

--- a/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
+++ b/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Crown } from "lucide-react";
+import { useTierUpgrade } from "@/lib/hooks/use-tier-upgrade";
+import { TIER_BRANDS } from "@/lib/tier-branding";
+import { TierBadge } from "@/components/branding/tier-badge";
+import { TierWordmark } from "@/components/branding/tier-wordmark";
+import { TierAccent } from "@/components/branding/tier-accent";
+import { TierSeal } from "@/components/branding/tier-seal";
+
+// Per-tier dismiss delays — Enterprise copy is longest, gets the most time.
+const DISMISS_DELAY_MS: Record<string, number> = {
+  pro: 6000,
+  team: 8000,
+  enterprise: 12000,
+};
+const EXIT_DURATION_MS = 160;
+
+const HEADLINE_ID = "tier-celebration-headline";
+
+/**
+ * Self-contained, mount-point-agnostic tier upgrade celebration overlay.
+ * Renders nothing when there is nothing to celebrate (returns null early).
+ * No props — all state is owned by useTierUpgrade().
+ */
+export default function TierUpgradeCelebration() {
+  const { celebratingTier, dismiss } = useTierUpgrade();
+  const [exiting, setExiting] = useState(false);
+
+  // Track hover/focus so we can pause the auto-dismiss timer.
+  const pausedRef = useRef(false);
+  // Ref to close button for focus management.
+  const closeRef = useRef<HTMLButtonElement>(null);
+  // Ref to the element that had focus before the overlay opened.
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  // Ref to the pending exit setTimeout so we can cancel it on unmount.
+  const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleDismiss = useCallback(() => {
+    setExiting(true);
+    exitTimeoutRef.current = setTimeout(dismiss, EXIT_DURATION_MS);
+  }, [dismiss]);
+
+  // Cleanup exit timeout on unmount to avoid calling setState on an
+  // unmounted component.
+  useEffect(() => {
+    return () => {
+      if (exitTimeoutRef.current !== null) {
+        clearTimeout(exitTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Auto-dismiss with pause-on-hover/focus support.
+  useEffect(() => {
+    if (!celebratingTier) return;
+
+    const delay = DISMISS_DELAY_MS[celebratingTier] ?? 8000;
+    let remaining = delay;
+    let start = Date.now();
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    function schedule() {
+      timerId = setTimeout(() => {
+        if (!pausedRef.current) {
+          handleDismiss();
+        }
+      }, remaining);
+    }
+
+    function pause() {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+        remaining -= Date.now() - start;
+      }
+      pausedRef.current = true;
+    }
+
+    function resume() {
+      pausedRef.current = false;
+      start = Date.now();
+      schedule();
+    }
+
+    schedule();
+
+    const cardEl = document.getElementById("tier-celebration-card");
+    if (cardEl) {
+      cardEl.addEventListener("mouseenter", pause);
+      cardEl.addEventListener("mouseleave", resume);
+      cardEl.addEventListener("focusin", pause);
+      cardEl.addEventListener("focusout", resume);
+    }
+
+    return () => {
+      if (timerId !== null) clearTimeout(timerId);
+      if (cardEl) {
+        cardEl.removeEventListener("mouseenter", pause);
+        cardEl.removeEventListener("mouseleave", resume);
+        cardEl.removeEventListener("focusin", pause);
+        cardEl.removeEventListener("focusout", resume);
+      }
+    };
+  }, [celebratingTier, handleDismiss]);
+
+  // Esc key dismisses.
+  useEffect(() => {
+    if (!celebratingTier) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") handleDismiss();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [celebratingTier, handleDismiss]);
+
+  // Focus management: move focus to close button on open; restore on close.
+  useEffect(() => {
+    if (celebratingTier) {
+      // Record where focus was before the overlay opened.
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+      // Small delay to let the component fully render before attempting focus.
+      const t = setTimeout(() => closeRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    } else {
+      // Overlay closed — restore previous focus.
+      if (previousFocusRef.current && "focus" in previousFocusRef.current) {
+        previousFocusRef.current.focus();
+      }
+      previousFocusRef.current = null;
+    }
+  }, [celebratingTier]);
+
+  if (!celebratingTier) return null;
+
+  const tierLabel = TIER_BRANDS[celebratingTier].label;
+
+  return (
+    // Backdrop — z-[80] sits below toasts (z-[90])
+    <div
+      className={`fixed inset-0 z-[80] flex items-center justify-center ${
+        exiting ? "animate-fade-out" : "animate-fade-in"
+      }`}
+    >
+      {/* Backdrop — clicking dismisses */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={handleDismiss}
+        aria-hidden="true"
+      />
+
+      {/* Card */}
+      <div
+        id="tier-celebration-card"
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby={HEADLINE_ID}
+        aria-label={`${tierLabel} upgrade celebration`}
+        className={`relative z-10 w-full max-w-sm mx-4 bg-[var(--color-bg-card)] border ${
+          celebratingTier === "pro"
+            ? "border-indigo-500/40 bg-indigo-500/8"
+            : celebratingTier === "team"
+            ? "border-violet-400/50"
+            : "border-amber-400/50"
+        } ${
+          celebratingTier === "team"
+            ? "bg-violet-500/10"
+            : celebratingTier === "enterprise"
+            ? "bg-gradient-to-b from-amber-500/10 to-transparent"
+            : ""
+        } shadow-xl ${exiting ? "animate-slide-out-up" : "animate-slide-in-up"}`}
+      >
+        {/* Close button */}
+        <button
+          ref={closeRef}
+          type="button"
+          onClick={handleDismiss}
+          className="absolute top-3 right-3 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-current"
+          aria-label="Dismiss"
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+            <path
+              d="M2 2L8 8M8 2L2 8"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+
+        <div className="p-5">
+          {celebratingTier === "pro" && <ProVariant />}
+          {celebratingTier === "team" && <TeamVariant />}
+          {celebratingTier === "enterprise" && <EnterpriseVariant />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Pro variant — clear step up: indigo wash, prominent headline ──────────────
+
+function ProVariant() {
+  return (
+    <div className="space-y-3">
+      <h2
+        id={HEADLINE_ID}
+        className="text-[15px] font-semibold text-[var(--color-text)] tracking-tight leading-snug"
+      >
+        Welcome to Pro
+      </h2>
+      <div className="flex items-center gap-2">
+        <TierBadge size="md" />
+        <span className="text-[12px] text-indigo-400/70 tracking-wide">
+          indigo mark is live
+        </span>
+      </div>
+      <p className="text-[13px] text-[var(--color-text-muted)]">
+        Your new badge is live across the app.
+      </p>
+      <TierAccent />
+    </div>
+  );
+}
+
+// ── Team variant — richer ─────────────────────────────────────────────────────
+
+function TeamVariant() {
+  return (
+    <div className="space-y-3">
+      <TierAccent />
+      <h2
+        id={HEADLINE_ID}
+        className="sr-only"
+      >
+        Welcome to Team
+      </h2>
+      <div className="flex items-center gap-2 py-1">
+        <TierWordmark variant="header" />
+      </div>
+      <p className="text-[13px] text-[var(--color-text-muted)]">
+        Invite your team and share signals together. Collaborators and shared
+        pipelines are now live.
+      </p>
+      <TierAccent />
+    </div>
+  );
+}
+
+// ── Enterprise variant — most premium ────────────────────────────────────────
+// TierCrest is a corner-overlay primitive; we feature the crown crest by
+// rendering TierBadge (Crown icon + label) as the focal hero, centered, with
+// TierSeal below as the authoritative wordmark. No placeholder squares.
+
+function EnterpriseVariant() {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col items-center gap-3 pt-2 pb-1">
+        <Crown
+          size={40}
+          strokeWidth={1.25}
+          className="text-amber-300 drop-shadow-[0_0_12px_rgba(251,191,36,0.35)]"
+          aria-hidden="true"
+        />
+        <TierSeal variant="header" />
+      </div>
+      <h2
+        id={HEADLINE_ID}
+        className="text-[15px] font-semibold text-[var(--color-text)] tracking-tight text-center leading-snug"
+      >
+        Enterprise is active
+      </h2>
+      <p className="text-[13px] text-[var(--color-text-muted)] text-center">
+        The Enterprise edition is active. Your console now bears the crown.
+      </p>
+      <TierAccent />
+    </div>
+  );
+}

--- a/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
+++ b/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
@@ -155,12 +155,12 @@ export default function TierUpgradeCelebration() {
       <div
         id="tier-celebration-card"
         role="dialog"
-        aria-modal="false"
+        aria-modal="true"
         aria-labelledby={HEADLINE_ID}
         aria-label={`${tierLabel} upgrade celebration`}
         className={`relative z-10 w-full max-w-sm mx-4 bg-[var(--color-bg-card)] border ${
           celebratingTier === "pro"
-            ? "border-indigo-500/40 bg-indigo-500/8"
+            ? "border-indigo-500/40 bg-indigo-500/10"
             : celebratingTier === "team"
             ? "border-violet-400/50"
             : "border-amber-400/50"
@@ -214,7 +214,7 @@ function ProVariant() {
       <div className="flex items-center gap-2">
         <TierBadge size="md" />
         <span className="text-[12px] text-indigo-400/70 tracking-wide">
-          indigo mark is live
+          Your Pro badge is active
         </span>
       </div>
       <p className="text-[13px] text-[var(--color-text-muted)]">

--- a/signalpilot/web/components/branding/tier-wordmark.tsx
+++ b/signalpilot/web/components/branding/tier-wordmark.tsx
@@ -21,7 +21,7 @@ export function TierWordmark({ variant = "sidebar" }: TierWordmarkProps) {
       className={`inline-flex items-center gap-1 tracking-[0.15em] uppercase ${brand.accentText} ${variant === "sidebar" ? "text-[11px]" : "text-[12px]"}`}
     >
       {Icon && <Icon size={iconSize} className="flex-shrink-0" />}
-      {brand.label.toUpperCase()}
+      {brand.label}
     </span>
   );
 }

--- a/signalpilot/web/components/branding/tier-wordmark.tsx
+++ b/signalpilot/web/components/branding/tier-wordmark.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+interface TierWordmarkProps {
+  variant?: "sidebar" | "header";
+}
+
+export function TierWordmark({ variant = "sidebar" }: TierWordmarkProps) {
+  const b = useTierBranding();
+
+  if (!b.enabled || b.tier === "free") return null;
+
+  const { brand } = b;
+  const Icon = brand.icon;
+
+  const iconSize = variant === "sidebar" ? 10 : 12;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 tracking-[0.15em] uppercase ${brand.accentText} ${variant === "sidebar" ? "text-[11px]" : "text-[12px]"}`}
+    >
+      {Icon && <Icon size={iconSize} className="flex-shrink-0" />}
+      {brand.label.toUpperCase()}
+    </span>
+  );
+}

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -8,7 +8,7 @@ import { KeyRound, CreditCard, Plug, BarChart3, Shield, Lock, Users } from "luci
 import { Tooltip } from "@/components/ui/tooltip";
 import { useAppAuth } from "@/lib/auth-context";
 import { getSandboxes, getProjects } from "@/lib/api";
-import { useConnectionsHealth, usePlan } from "@/lib/hooks/use-gateway-data";
+import { useConnectionsHealth } from "@/lib/hooks/use-gateway-data";
 import { TierWordmark } from "@/components/branding/tier-wordmark";
 import { TierAccent } from "@/components/branding/tier-accent";
 import { TierSeal } from "@/components/branding/tier-seal";
@@ -282,10 +282,10 @@ function McpConnectNavLink({ pathname }: { pathname: string }) {
 }
 
 function ByokNavLink({ pathname }: { pathname: string }) {
-  const { data: plan } = usePlan();
-  const tier = plan?.tier ?? "free";
-  // BYOK is team/enterprise only
-  if (tier === "free" || tier === "pro") return null;
+  const branding = useTierBranding();
+  // BYOK is team/enterprise only; hidden until tier branding is resolved (cloud + loaded)
+  if (!branding.enabled) return null;
+  if (branding.tier !== "team" && branding.tier !== "enterprise") return null;
 
   const active = pathname.startsWith("/settings/byok");
 

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -397,6 +397,17 @@ export default function Sidebar() {
   const tierBranding = useTierBranding();
   const showWordmark = tierBranding.enabled && tierBranding.tier !== "free";
 
+  // Tier-keyed logo glow — whole class tokens, no concatenation
+  const LOGO_GLOW: Record<string, string> = {
+    enterprise: "drop-shadow-[0_0_8px_rgba(251,191,36,0.4)]",
+    team: "drop-shadow-[0_0_8px_rgba(167,139,250,0.4)]",
+    pro: "drop-shadow-[0_0_8px_rgba(129,140,248,0.35)]",
+  };
+  const logoGlow =
+    tierBranding.enabled && tierBranding.tier !== "free"
+      ? (LOGO_GLOW[tierBranding.tier] ?? "")
+      : "";
+
   if (HIDDEN_SIDEBAR_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
     return null;
   }
@@ -406,7 +417,7 @@ export default function Sidebar() {
       {/* Logo */}
       <div className="px-5 py-5 border-b border-[var(--color-border)]">
         <Link href="/dashboard" className="flex items-center gap-3 group">
-          <div className="transition-transform group-hover:scale-105">
+          <div className={`transition-transform group-hover:scale-105 ${logoGlow}`}>
             <SignalPilotLogo />
           </div>
           <div>

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -9,6 +9,9 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { useAppAuth } from "@/lib/auth-context";
 import { getSandboxes, getProjects } from "@/lib/api";
 import { useConnectionsHealth, usePlan } from "@/lib/hooks/use-gateway-data";
+import { TierWordmark } from "@/components/branding/tier-wordmark";
+import { TierAccent } from "@/components/branding/tier-accent";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
 /* Custom SVG nav icons — geometric, minimal, brutalism-lite */
 function NavIconDashboard({ active }: { active: boolean }) {
@@ -390,6 +393,9 @@ export default function Sidebar() {
   }, [router, filteredNav]);
 
   // Hide sidebar on auth pages — checked after all hooks are called
+  const tierBranding = useTierBranding();
+  const showWordmark = tierBranding.enabled && tierBranding.tier !== "free";
+
   if (HIDDEN_SIDEBAR_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
     return null;
   }
@@ -406,12 +412,21 @@ export default function Sidebar() {
             <h1 className="text-[13px] font-bold tracking-[0.2em] uppercase text-[var(--color-text)]">
               SignalPilot
             </h1>
-            <p className="text-[11px] text-[var(--color-text-dim)] tracking-[0.15em] uppercase mt-0.5">
-              governed infra
-            </p>
+            {/* Subtitle slot — reserved height to prevent layout snap */}
+            <div className="min-h-[14px] mt-0.5">
+              {showWordmark ? (
+                <TierWordmark variant="sidebar" />
+              ) : (
+                <p className="text-[11px] text-[var(--color-text-dim)] tracking-[0.15em] uppercase">
+                  governed infra
+                </p>
+              )}
+            </div>
           </div>
         </Link>
       </div>
+      {/* Tier accent hairline below logo block — visible for paid cloud tiers only */}
+      <TierAccent />
 
       {/* Command palette hint */}
       <div className="px-3 pt-4 pb-2">

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import { getSandboxes, getProjects } from "@/lib/api";
 import { useConnectionsHealth, usePlan } from "@/lib/hooks/use-gateway-data";
 import { TierWordmark } from "@/components/branding/tier-wordmark";
 import { TierAccent } from "@/components/branding/tier-accent";
+import { TierSeal } from "@/components/branding/tier-seal";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
 /* Custom SVG nav icons — geometric, minimal, brutalism-lite */
@@ -532,6 +533,7 @@ export default function Sidebar() {
         </Tooltip>
         {/* System info line */}
         <div className="separator-subtle" />
+        <TierSeal variant="footer" />
         <div className="flex items-center justify-between">
           <Tooltip content="signalpilot gateway version" position="right">
             <div className="flex items-center gap-1.5 cursor-default">

--- a/signalpilot/web/components/layout/tab-title.tsx
+++ b/signalpilot/web/components/layout/tab-title.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+/**
+ * Pure side-effect component. Returns null always. Sets document.title to
+ * "[<Tier>] SignalPilot" for paid cloud tiers; restores "SignalPilot" on
+ * unmount or when branding becomes disabled.
+ *
+ * NOTE: The reset value is the literal "SignalPilot" — this MUST match
+ * metadata.title in app/layout.tsx. If that value ever changes, update
+ * this constant too.
+ *
+ * Why a client effect and not metadata: metadata.title is server-rendered
+ * and static per route. Tier is per-user, per-session, and dynamic. A
+ * client component is the smallest correct solution.
+ *
+ * Effect deps: [b.enabled, b.tier, b.brand?.label] — explicit stable
+ * primitives, not the b object (referential instability would re-fire
+ * on every render).
+ */
+
+const CANONICAL_TITLE = "SignalPilot";
+
+export function TabTitle() {
+  const b = useTierBranding();
+
+  // Stable primitives extracted to avoid referential instability in deps.
+  const enabled = b.enabled;
+  const tier = b.enabled ? b.tier : null;
+  const label = b.enabled ? b.brand.label : null;
+
+  useEffect(() => {
+    if (!enabled || tier === "free") {
+      // No-op for free tier and local mode.
+      return;
+    }
+
+    document.title = `[${label}] ${CANONICAL_TITLE}`;
+
+    return () => {
+      // Restore canonical title on unmount or when tier changes.
+      document.title = CANONICAL_TITLE;
+    };
+  }, [enabled, tier, label]);
+
+  return null;
+}

--- a/signalpilot/web/components/layout/team-switcher.tsx
+++ b/signalpilot/web/components/layout/team-switcher.tsx
@@ -18,6 +18,7 @@ import { Component, type ReactNode } from "react";
 import { LogOut, ChevronDown, Check, Plus } from "lucide-react";
 import { useCreateTeam } from "@/lib/use-create-team";
 import { PendingButton } from "@/components/ui/pending-button";
+import { TierCrest } from "@/components/branding/tier-crest";
 
 const LIST_MSG_CLASS = "px-3 py-2 text-[10px] text-[var(--color-text-dim)] tracking-wider font-mono";
 
@@ -217,11 +218,14 @@ function TeamSwitcherInner({ displayName }: { displayName: string }) {
         className="w-full flex items-center gap-2 px-2 py-1.5 hover:bg-[var(--color-bg-hover)] transition-colors text-left focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-text)] focus-visible:ring-inset"
       >
         {/* Team avatar — first letter of team name, or dash for no-team state */}
-        <span
-          className="flex-shrink-0 w-5 h-5 flex items-center justify-center bg-[var(--color-border)] text-[10px] font-mono text-[var(--color-text-muted)] uppercase"
-          aria-hidden="true"
-        >
-          {organization ? teamName.charAt(0) : "–"}
+        <span className="relative inline-flex flex-shrink-0">
+          <span
+            className="w-5 h-5 flex items-center justify-center bg-[var(--color-border)] text-[10px] font-mono text-[var(--color-text-muted)] uppercase"
+            aria-hidden="true"
+          >
+            {organization ? teamName.charAt(0) : "–"}
+          </span>
+          <TierCrest />
         </span>
         <span className="flex-1 text-[11px] text-[var(--color-text-dim)] tracking-wide truncate font-mono">
           {teamName}

--- a/signalpilot/web/components/ui/keyboard-shortcuts.tsx
+++ b/signalpilot/web/components/ui/keyboard-shortcuts.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { TierBadge } from "@/components/branding/tier-badge";
 
 const NAV_SHORTCUTS = [
   { key: "1", label: "dashboard", path: "/dashboard" },
@@ -77,6 +78,7 @@ export function KeyboardShortcuts() {
             <span className="text-[12px] uppercase tracking-[0.15em] text-[var(--color-text-dim)]">
               keyboard shortcuts
             </span>
+            <TierBadge size="sm" />
           </div>
           <kbd className="px-1.5 py-0.5 bg-[var(--color-bg)] border border-[var(--color-border)] text-[11px] font-mono text-[var(--color-text-dim)]">
             esc

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -2,6 +2,7 @@
 
 import { TierBadge } from "@/components/branding/tier-badge";
 import { TierAccent } from "@/components/branding/tier-accent";
+import { TierSeal } from "@/components/branding/tier-seal";
 
 /**
  * Consistent page header with terminal-style breadcrumb.
@@ -30,7 +31,10 @@ export function PageHeader({
           </div>
           <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>
         </div>
-        {actions && <div className="flex items-center gap-2">{actions}</div>}
+        <div className="flex items-center gap-2">
+          {actions}
+          <TierSeal variant="header" />
+        </div>
       </div>
       {/* Neutral gradient accent line — always rendered */}
       <div className="mt-4 h-px bg-gradient-to-r from-transparent via-[var(--color-border-hover)] to-transparent" />

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -3,6 +3,14 @@
 import { TierBadge } from "@/components/branding/tier-badge";
 import { TierAccent } from "@/components/branding/tier-accent";
 import { TierSeal } from "@/components/branding/tier-seal";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+
+// Whole-token gradient class map — no concatenation, no arbitrary opacity.
+const TIER_GRADIENT: Record<string, string> = {
+  enterprise: "bg-gradient-to-r from-amber-500/10 via-transparent to-amber-500/10",
+  team:       "bg-gradient-to-r from-violet-500/10 via-transparent to-violet-500/10",
+  pro:        "bg-gradient-to-r from-indigo-500/10 via-transparent to-indigo-500/10",
+};
 
 /**
  * Consistent page header with terminal-style breadcrumb.
@@ -18,24 +26,54 @@ export function PageHeader({
   description: string;
   actions?: React.ReactNode;
 }) {
+  const b = useTierBranding();
+  const showBackdrop = b.enabled && b.tier !== "free";
+
+  const gradientClass = showBackdrop ? (TIER_GRADIENT[b.tier] ?? "") : "";
+  const Icon = showBackdrop ? b.brand.icon : null;
+  const accentText = showBackdrop ? b.brand.accentText : "";
+
   return (
     <div className="mb-8">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="flex items-center gap-3 mb-1">
-            <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
-            <TierBadge size="sm" />
-            <span className="text-[12px] text-[var(--color-text-muted)] tracking-[0.15em] uppercase px-1.5 py-0.5 border border-[var(--color-border)]">
-              {subtitle}
-            </span>
+      {/* Relative container for backdrop layers */}
+      <div className="relative">
+        {/* Gradient band — behind everything */}
+        {showBackdrop && gradientClass && (
+          <div
+            className={`absolute inset-x-0 -inset-y-2 ${gradientClass} pointer-events-none`}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Watermark icon — behind title row */}
+        {showBackdrop && Icon && (
+          <div
+            className={`absolute right-2 top-1/2 -translate-y-1/2 opacity-10 ${accentText} pointer-events-none`}
+            aria-hidden="true"
+          >
+            <Icon size={80} />
           </div>
-          <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          {actions}
-          <TierSeal variant="header" />
+        )}
+
+        {/* Title row — above backdrop layers */}
+        <div className="flex items-center justify-between relative z-10">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
+              <TierBadge size="sm" />
+              <span className="text-[12px] text-[var(--color-text-muted)] tracking-[0.15em] uppercase px-1.5 py-0.5 border border-[var(--color-border)]">
+                {subtitle}
+              </span>
+            </div>
+            <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            {actions}
+            <TierSeal variant="header" />
+          </div>
         </div>
       </div>
+
       {/* Neutral gradient accent line — always rendered */}
       <div className="mt-4 h-px bg-gradient-to-r from-transparent via-[var(--color-border-hover)] to-transparent" />
       {/* Tier-tinted accent — renders only for paid cloud tiers */}

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { TierBadge } from "@/components/branding/tier-badge";
+import { TierAccent } from "@/components/branding/tier-accent";
+
 /**
  * Consistent page header with terminal-style breadcrumb.
  */
@@ -20,6 +23,7 @@ export function PageHeader({
         <div>
           <div className="flex items-center gap-3 mb-1">
             <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
+            <TierBadge size="sm" />
             <span className="text-[12px] text-[var(--color-text-muted)] tracking-[0.15em] uppercase px-1.5 py-0.5 border border-[var(--color-border)]">
               {subtitle}
             </span>
@@ -28,8 +32,10 @@ export function PageHeader({
         </div>
         {actions && <div className="flex items-center gap-2">{actions}</div>}
       </div>
-      {/* Gradient accent line */}
+      {/* Neutral gradient accent line — always rendered */}
       <div className="mt-4 h-px bg-gradient-to-r from-transparent via-[var(--color-border-hover)] to-transparent" />
+      {/* Tier-tinted accent — renders only for paid cloud tiers */}
+      <TierAccent />
     </div>
   );
 }

--- a/signalpilot/web/components/ui/toast.tsx
+++ b/signalpilot/web/components/ui/toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
 interface Toast {
   id: string;
@@ -21,7 +22,17 @@ export function useToast() {
   return useContext(ToastContext);
 }
 
+// Left-edge color literals for paid tiers. Tailwind has no side-specific border-color
+// shorthand that works with opacity modifiers, so these must be full literal strings
+// (not assembled from TIER_BRANDS tokens) to satisfy JIT. Color semantics mirror accentText.
+const TIER_LEFT_BORDER: Record<"pro" | "team" | "enterprise", string> = {
+  pro:        "border-l-2 border-l-indigo-400/60",
+  team:       "border-l-2 border-l-violet-400/60",
+  enterprise: "border-l-2 border-l-amber-300/60",
+};
+
 function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) => void }) {
+  const b = useTierBranding();
   const [exiting, setExiting] = useState(false);
 
   useEffect(() => {
@@ -60,9 +71,14 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) =
     info: "border-[var(--color-border)]",
   };
 
+  const tierLeftClass =
+    b.enabled && b.tier !== "free"
+      ? TIER_LEFT_BORDER[b.tier as "pro" | "team" | "enterprise"]
+      : "";
+
   return (
     <div
-      className={`flex items-center gap-3 px-4 py-3 bg-[var(--color-bg-card)] border ${borderColors[toast.type]} shadow-lg ${
+      className={`flex items-center gap-3 px-4 py-3 bg-[var(--color-bg-card)] border ${borderColors[toast.type]} ${tierLeftClass} shadow-lg ${
         exiting ? "animate-slide-out-right" : "animate-slide-in-right"
       }`}
     >

--- a/signalpilot/web/lib/hooks/use-tier-branding.ts
+++ b/signalpilot/web/lib/hooks/use-tier-branding.ts
@@ -1,0 +1,31 @@
+import { useAppAuth } from "@/lib/auth-context";
+import { useSubscription } from "@/lib/subscription-context";
+import { getTierBrand, type BrandTier, type TierBrand } from "@/lib/tier-branding";
+
+const KNOWN_TIERS = new Set<string>(["free", "pro", "team", "enterprise"]);
+
+export type TierBrandingState =
+  | { enabled: false }
+  | { enabled: true; tier: BrandTier; brand: TierBrand };
+
+export function useTierBranding(): TierBrandingState {
+  const { isCloudMode } = useAppAuth();
+  const { planTier, isLoaded } = useSubscription();
+
+  if (!isCloudMode) {
+    return { enabled: false };
+  }
+
+  if (!isLoaded) {
+    return { enabled: false };
+  }
+
+  if (!KNOWN_TIERS.has(planTier)) {
+    return { enabled: false };
+  }
+
+  const tier = planTier as BrandTier;
+  const brand = getTierBrand(tier);
+
+  return { enabled: true, tier, brand };
+}

--- a/signalpilot/web/lib/hooks/use-tier-branding.ts
+++ b/signalpilot/web/lib/hooks/use-tier-branding.ts
@@ -1,10 +1,8 @@
 import { useAppAuth } from "@/lib/auth-context";
 import { useSubscription } from "@/lib/subscription-context";
-import { getTierBrand, type BrandTier, type TierBrand } from "@/lib/tier-branding";
+import { TIER_BRANDS, type BrandTier, type TierBrand } from "@/lib/tier-branding";
 
-const KNOWN_TIERS = new Set<string>(["free", "pro", "team", "enterprise"]);
-
-export type TierBrandingState =
+type TierBrandingState =
   | { enabled: false }
   | { enabled: true; tier: BrandTier; brand: TierBrand };
 
@@ -12,20 +10,10 @@ export function useTierBranding(): TierBrandingState {
   const { isCloudMode } = useAppAuth();
   const { planTier, isLoaded } = useSubscription();
 
-  if (!isCloudMode) {
-    return { enabled: false };
-  }
-
-  if (!isLoaded) {
-    return { enabled: false };
-  }
-
-  if (!KNOWN_TIERS.has(planTier)) {
+  if (!isCloudMode || !isLoaded || !(planTier in TIER_BRANDS)) {
     return { enabled: false };
   }
 
   const tier = planTier as BrandTier;
-  const brand = getTierBrand(tier);
-
-  return { enabled: true, tier, brand };
+  return { enabled: true, tier, brand: TIER_BRANDS[tier] };
 }

--- a/signalpilot/web/lib/hooks/use-tier-upgrade.ts
+++ b/signalpilot/web/lib/hooks/use-tier-upgrade.ts
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 import type { BrandTier } from "@/lib/tier-branding";
 
-// Follow repo convention: sp_ prefix + snake_case (sp_api_key, sp_query_history, etc.)
 const STORAGE_KEY = "sp_tier_last_seen";
 
 const TIER_RANK: Record<BrandTier, number> = {
@@ -29,33 +28,28 @@ function writeStorage(tier: BrandTier): void {
   try {
     localStorage.setItem(STORAGE_KEY, tier);
   } catch {
-    // localStorage unavailable (private mode, quota) — acceptable, user may see
-    // celebration twice across sessions, not a correctness bug.
+    // localStorage unavailable (private mode, quota) — user may see celebration
+    // twice across sessions; not a correctness bug.
   }
 }
 
-export interface TierUpgradeState {
+interface TierUpgradeState {
   celebratingTier: BrandTier | null;
   dismiss: () => void;
 }
 
 export function useTierUpgrade(): TierUpgradeState {
-  // Hooks are always called unconditionally — early returns are by state, not
-  // by short-circuiting before hook calls.
   const branding = useTierBranding();
 
-  // Lazy initializer reads from storage only on the client (SSR-safe).
-  // NOTE: the initializer is PURE — it does NOT write to storage.
-  // The null-case write happens in the useEffect below (spec-reviewer fix #2).
+  // Lazy initializer is PURE — null-case write happens in the effect below so
+  // first-mount writes don't run during render.
   const [lastSeen] = useState<BrandTier | null>(() => readStorage());
 
   const [celebratingTier, setCelebratingTier] = useState<BrandTier | null>(null);
 
-  // Tracks whether the effect has fired so we only run the comparison once.
   const comparedRef = useRef(false);
 
-  // Capture primitive deps so dismiss doesn't re-create on every branding object
-  // reference change (useTierBranding returns a new object each render).
+  // Capture primitives so dismiss is stable across new branding object identities.
   const brandingEnabled = branding.enabled;
   const brandingTier = branding.enabled ? branding.tier : ("free" as BrandTier);
 
@@ -66,10 +60,8 @@ export function useTierUpgrade(): TierUpgradeState {
     setCelebratingTier(null);
   }, [brandingEnabled, brandingTier]);
 
-  // One-shot effect: compare lastSeen vs current tier and decide whether to celebrate.
-  // comparedRef must NOT latch before enabled — if cloud subscription loads after
-  // first render (e.g. Stripe webhook), the ref must still be clear so this effect
-  // runs once branding is ready.
+  // comparedRef must NOT latch before enabled — if subscription loads after
+  // first render (e.g. Stripe webhook), the effect must still fire once ready.
   useEffect(() => {
     if (!branding.enabled) return;
     if (comparedRef.current) return;
@@ -78,28 +70,20 @@ export function useTierUpgrade(): TierUpgradeState {
     const current = branding.tier;
 
     if (lastSeen === null) {
-      // First-ever mount for this user: silently record; no celebration.
       writeStorage(current);
       return;
     }
 
-    const lastRank = TIER_RANK[lastSeen];
-    const currentRank = TIER_RANK[current];
-
-    if (currentRank > lastRank) {
-      // Upgrade detected — celebrate! Storage is written only when dismissed.
+    if (TIER_RANK[current] > TIER_RANK[lastSeen]) {
       setCelebratingTier(current);
     }
-    // Same rank or downgrade: no-op (no celebration, no storage write needed).
   }, [branding, lastSeen]);
 
-  // Cross-tab safety: if another tab dismisses (writes storage), clear here too.
   useEffect(() => {
     if (!branding.enabled) return;
 
     function handleStorageEvent(e: StorageEvent) {
       if (e.key !== STORAGE_KEY) return;
-      // Another tab wrote the key — treat as dismiss in this tab.
       setCelebratingTier(null);
     }
 

--- a/signalpilot/web/lib/hooks/use-tier-upgrade.ts
+++ b/signalpilot/web/lib/hooks/use-tier-upgrade.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTierBranding } from "@/lib/hooks/use-tier-branding";
+import type { BrandTier } from "@/lib/tier-branding";
+
+// Follow repo convention: sp_ prefix + snake_case (sp_api_key, sp_query_history, etc.)
+const STORAGE_KEY = "sp_tier_last_seen";
+
+const TIER_RANK: Record<BrandTier, number> = {
+  free: 0,
+  pro: 1,
+  team: 2,
+  enterprise: 3,
+};
+
+function readStorage(): BrandTier | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw && raw in TIER_RANK) return raw as BrandTier;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(tier: BrandTier): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, tier);
+  } catch {
+    // localStorage unavailable (private mode, quota) — acceptable, user may see
+    // celebration twice across sessions, not a correctness bug.
+  }
+}
+
+export interface TierUpgradeState {
+  celebratingTier: BrandTier | null;
+  dismiss: () => void;
+}
+
+export function useTierUpgrade(): TierUpgradeState {
+  // Hooks are always called unconditionally — early returns are by state, not
+  // by short-circuiting before hook calls.
+  const branding = useTierBranding();
+
+  // Lazy initializer reads from storage only on the client (SSR-safe).
+  // NOTE: the initializer is PURE — it does NOT write to storage.
+  // The null-case write happens in the useEffect below (spec-reviewer fix #2).
+  const [lastSeen] = useState<BrandTier | null>(() => readStorage());
+
+  const [celebratingTier, setCelebratingTier] = useState<BrandTier | null>(null);
+
+  // Tracks whether the effect has fired so we only run the comparison once.
+  const comparedRef = useRef(false);
+
+  // Capture primitive deps so dismiss doesn't re-create on every branding object
+  // reference change (useTierBranding returns a new object each render).
+  const brandingEnabled = branding.enabled;
+  const brandingTier = branding.enabled ? branding.tier : ("free" as BrandTier);
+
+  const dismiss = useCallback(() => {
+    if (brandingEnabled) {
+      writeStorage(brandingTier);
+    }
+    setCelebratingTier(null);
+  }, [brandingEnabled, brandingTier]);
+
+  // One-shot effect: compare lastSeen vs current tier and decide whether to celebrate.
+  // comparedRef must NOT latch before enabled — if cloud subscription loads after
+  // first render (e.g. Stripe webhook), the ref must still be clear so this effect
+  // runs once branding is ready.
+  useEffect(() => {
+    if (!branding.enabled) return;
+    if (comparedRef.current) return;
+    comparedRef.current = true;
+
+    const current = branding.tier;
+
+    if (lastSeen === null) {
+      // First-ever mount for this user: silently record; no celebration.
+      writeStorage(current);
+      return;
+    }
+
+    const lastRank = TIER_RANK[lastSeen];
+    const currentRank = TIER_RANK[current];
+
+    if (currentRank > lastRank) {
+      // Upgrade detected — celebrate! Storage is written only when dismissed.
+      setCelebratingTier(current);
+    }
+    // Same rank or downgrade: no-op (no celebration, no storage write needed).
+  }, [branding, lastSeen]);
+
+  // Cross-tab safety: if another tab dismisses (writes storage), clear here too.
+  useEffect(() => {
+    if (!branding.enabled) return;
+
+    function handleStorageEvent(e: StorageEvent) {
+      if (e.key !== STORAGE_KEY) return;
+      // Another tab wrote the key — treat as dismiss in this tab.
+      setCelebratingTier(null);
+    }
+
+    window.addEventListener("storage", handleStorageEvent);
+    return () => window.removeEventListener("storage", handleStorageEvent);
+  }, [branding.enabled]);
+
+  if (!branding.enabled) {
+    return { celebratingTier: null, dismiss: () => {} };
+  }
+
+  return { celebratingTier, dismiss };
+}

--- a/signalpilot/web/lib/tier-branding.ts
+++ b/signalpilot/web/lib/tier-branding.ts
@@ -3,7 +3,6 @@ import { Sparkles, Gem, Crown, type LucideIcon } from "lucide-react";
 export type BrandTier = "free" | "pro" | "team" | "enterprise";
 
 export interface TierBrand {
-  tier: BrandTier;
   label: string;
   icon: LucideIcon | null;
   accentText: string;
@@ -16,7 +15,6 @@ export interface TierBrand {
 
 export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
   free: {
-    tier: "free",
     label: "Free",
     icon: null,
     accentText: "",
@@ -27,7 +25,6 @@ export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
     gradientTo: "",
   },
   pro: {
-    tier: "pro",
     label: "Pro",
     icon: Sparkles,
     accentText: "text-indigo-400",
@@ -38,7 +35,6 @@ export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
     gradientTo: "to-indigo-500/0",
   },
   team: {
-    tier: "team",
     label: "Team",
     icon: Gem,
     accentText: "text-violet-300",
@@ -49,7 +45,6 @@ export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
     gradientTo: "to-indigo-500/0",
   },
   enterprise: {
-    tier: "enterprise",
     label: "Enterprise",
     icon: Crown,
     accentText: "text-amber-300",
@@ -60,7 +55,3 @@ export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
     gradientTo: "to-amber-500/0",
   },
 };
-
-export function getTierBrand(tier: BrandTier): TierBrand {
-  return TIER_BRANDS[tier];
-}

--- a/signalpilot/web/lib/tier-branding.ts
+++ b/signalpilot/web/lib/tier-branding.ts
@@ -1,0 +1,66 @@
+import { Sparkles, Gem, Crown, type LucideIcon } from "lucide-react";
+
+export type BrandTier = "free" | "pro" | "team" | "enterprise";
+
+export interface TierBrand {
+  tier: BrandTier;
+  label: string;
+  icon: LucideIcon | null;
+  accentText: string;
+  accentBorder: string;
+  accentBg: string;
+  gradientFrom: string;
+  gradientVia: string;
+  gradientTo: string;
+}
+
+export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
+  free: {
+    tier: "free",
+    label: "Free",
+    icon: null,
+    accentText: "",
+    accentBorder: "",
+    accentBg: "",
+    gradientFrom: "",
+    gradientVia: "",
+    gradientTo: "",
+  },
+  pro: {
+    tier: "pro",
+    label: "Pro",
+    icon: Sparkles,
+    accentText: "text-indigo-400",
+    accentBorder: "border-indigo-500/40",
+    accentBg: "bg-indigo-500/10",
+    gradientFrom: "from-indigo-500/0",
+    gradientVia: "via-indigo-400/50",
+    gradientTo: "to-indigo-500/0",
+  },
+  team: {
+    tier: "team",
+    label: "Team",
+    icon: Gem,
+    accentText: "text-violet-300",
+    accentBorder: "border-violet-400/50",
+    accentBg: "bg-violet-500/10",
+    gradientFrom: "from-fuchsia-500/0",
+    gradientVia: "via-violet-400/50",
+    gradientTo: "to-indigo-500/0",
+  },
+  enterprise: {
+    tier: "enterprise",
+    label: "Enterprise",
+    icon: Crown,
+    accentText: "text-amber-300",
+    accentBorder: "border-amber-400/50",
+    accentBg: "bg-amber-500/10",
+    gradientFrom: "from-amber-500/0",
+    gradientVia: "via-amber-300/60",
+    gradientTo: "to-amber-500/0",
+  },
+};
+
+export function getTierBrand(tier: BrandTier): TierBrand {
+  return TIER_BRANDS[tier];
+}

--- a/signalpilot/web/package-lock.json
+++ b/signalpilot/web/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "recharts": "^2.15.0",
+        "swr": "^2.4.1",
         "tailwind-merge": "^3.0.2"
       },
       "devDependencies": {
@@ -354,6 +355,19 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@clerk/shared/node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@clerk/types": {
@@ -6264,12 +6278,13 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
-      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary
Progressive, cloud-only tier branding so paid customers feel the upgrade across the app. All branding is gated on `isCloudMode`; local mode is unchanged.

A single source of truth (`TIER_BRANDS` config + `useTierBranding()` hook) drives every surface:
- Sidebar logo + per-tier drop-shadow glow + footer seal plate
- **Page-header backdrop** — per-tier gradient band + 80px watermark icon behind every page title
- **Per-tier favicon** — tier-colored Crown/Gem/Sparkles SVG swapped into the browser tab
- Page-header left + right slots, dashboard greeting accent, team avatar crest
- Browser tab title, toast left-spine tier color
- Billing page badge + accent, keyboard-shortcuts dialog header
- **Post-upgrade celebration overlay** — one-time per tier, dismissible, escalating Pro → Team → Enterprise
- **Footer seal plate** — bordered amber/violet plate with top accent hairline; enterprise shows org name

## Architecture
- `lib/tier-branding.ts` — `TIER_BRANDS` config table (one literal entry per tier) and `useTierBranding()` hook
- `lib/hooks/use-tier-upgrade.ts` — detects upgrades via localStorage; SSR-safe; cross-tab via `storage` event; never fires on first mount or downgrades
- `components/branding/*` — reusable primitives (TierBadge, TierWordmark, TierAccent, TierCrest, TierSeal, TierFavicon) composed across surfaces and the celebration overlay
- `EnterpriseSealInner` / `TeamSealInner` split keeps `useOrganization()` enterprise-only (rules-of-hooks)
- All visual surfaces gate on `useTierBranding().enabled` (false in local mode)

## Test plan
- [ ] Local mode (`NEXT_PUBLIC_DEPLOYMENT=local`) — no tier branding visible anywhere; celebration never fires
- [ ] Cloud mode free tier — neutral defaults
- [ ] Cloud mode pro / team / enterprise — surfaces escalate; favicon and page backdrop reflect tier; celebration fires once on upgrade
- [ ] Esc / backdrop click / close button all dismiss the celebration; auto-dismiss pauses on hover
- [ ] `npx tsc --noEmit` passes


---
**Branch:** `autofyn/i-want-you-to-wo-7c1019` · **Run:** `81c7c9ba-7f15-420a-8eb0-880f6fc22279` · *Generated by AutoFyn*