### PR TITLE
Tier branding rework: clean, native, optically aligned

### DIFF
--- a/signalpilot/web/app/dashboard/page.tsx
+++ b/signalpilot/web/app/dashboard/page.tsx
@@ -39,6 +39,7 @@ import { DashboardSkeleton } from "@/components/ui/skeleton";
 import { useOnboardingStatus } from "@/lib/onboarding";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 import { TierWordmark } from "@/components/branding/tier-wordmark";
+import { TierBadge } from "@/components/branding/tier-badge";
 
 /* ── Metric card ── */
 function MetricCard({
@@ -122,14 +123,6 @@ function CloudStatusContent({ keyCount }: { keyCount: number | null }) {
   const planTier = plan?.tier ?? "free";
   const maxApiKeys = plan?.limits.api_keys === "unlimited" ? "∞" : (plan?.limits.api_keys ?? 1);
 
-  const tierColorMap: Record<string, string> = {
-    free: "text-[var(--color-text-dim)] border-[var(--color-border)]",
-    pro: "text-indigo-400 border-indigo-500/40",
-    team: "text-violet-300 border-violet-400/50",
-    enterprise: "text-amber-300 border-amber-400/50",
-  };
-  const tierClasses = tierColorMap[planTier] ?? tierColorMap.free;
-
   const statusLabel = status === "past_due" ? "past due" : status;
 
   // MCP endpoint detection — static check, no API call
@@ -150,14 +143,19 @@ function CloudStatusContent({ keyCount }: { keyCount: number | null }) {
       <div className="bg-[var(--color-bg-card)] p-5 hover:bg-[var(--color-bg-hover)] transition-all card-glow card-accent-top">
         <div className="flex items-center gap-2 mb-3">
           <CreditCard className="w-4 h-4 text-[var(--color-text-dim)]" strokeWidth={1.5} />
-          <span className="text-[12px] text-[var(--color-text-muted)] uppercase tracking-[0.15em]">
+          <span className="text-[12px] leading-none text-[var(--color-text-muted)] uppercase tracking-[0.15em]">
             subscription
           </span>
         </div>
         <div className="mb-1.5">
-          <span className={`px-2 py-0.5 text-[11px] border tracking-[0.15em] uppercase ${tierClasses}`}>
-            {planTier}
-          </span>
+          {planTier === "free" ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block w-[5px] h-[5px] flex-shrink-0 bg-[var(--color-text-dim)]" aria-hidden="true" />
+              <span className="text-[11px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-dim)]">free</span>
+            </span>
+          ) : (
+            <TierBadge size="sm" />
+          )}
         </div>
         <p className="text-[12px] text-[var(--color-text-muted)] mt-1.5 tracking-wider">
           {statusLabel}

--- a/signalpilot/web/app/dashboard/page.tsx
+++ b/signalpilot/web/app/dashboard/page.tsx
@@ -154,7 +154,7 @@ function CloudStatusContent({ keyCount }: { keyCount: number | null }) {
               <span className="text-[11px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-dim)]">free</span>
             </span>
           ) : (
-            <TierBadge size="sm" />
+            <TierBadge />
           )}
         </div>
         <p className="text-[12px] text-[var(--color-text-muted)] mt-1.5 tracking-wider">

--- a/signalpilot/web/app/settings/billing/page.tsx
+++ b/signalpilot/web/app/settings/billing/page.tsx
@@ -569,7 +569,7 @@ function BillingContent() {
                   <span className="text-[11px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-dim)]">free</span>
                 </span>
               ) : (
-                <TierBadge size="sm" />
+                <TierBadge />
               )}
               <div>
                 <span className="text-[12px] text-[var(--color-text-dim)] tracking-wider">

--- a/signalpilot/web/app/settings/billing/page.tsx
+++ b/signalpilot/web/app/settings/billing/page.tsx
@@ -564,8 +564,9 @@ function BillingContent() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               {planTier === "free" ? (
-                <span className="px-1.5 py-0.5 text-[11px] border tracking-[0.15em] uppercase text-[var(--color-text-dim)] border-[var(--color-border)]">
-                  free
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="inline-block w-[5px] h-[5px] flex-shrink-0 bg-[var(--color-text-dim)]" aria-hidden="true" />
+                  <span className="text-[11px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-dim)]">free</span>
                 </span>
               ) : (
                 <TierBadge size="sm" />

--- a/signalpilot/web/components/branding/tier-badge.tsx
+++ b/signalpilot/web/components/branding/tier-badge.tsx
@@ -2,15 +2,7 @@
 
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
-interface TierBadgeProps {
-  /**
-   * @deprecated Size prop is ignored — there is one canonical size.
-   * Accepted to avoid breaking existing call sites.
-   */
-  size?: "sm" | "md";
-}
-
-export function TierBadge({ size: _size }: TierBadgeProps) {
+export function TierBadge() {
   const b = useTierBranding();
 
   if (!b.enabled || b.tier === "free") return null;

--- a/signalpilot/web/components/branding/tier-badge.tsx
+++ b/signalpilot/web/components/branding/tier-badge.tsx
@@ -26,7 +26,7 @@ export function TierBadge({ size: _size }: TierBadgeProps) {
         style={{ backgroundColor: brand.accentHex }}
         aria-hidden="true"
       />
-      <span className="text-[11px] tracking-[0.15em] uppercase text-[var(--color-text-muted)]">
+      <span className="text-[11px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-muted)]">
         {brand.label}
       </span>
     </span>

--- a/signalpilot/web/components/branding/tier-badge.tsx
+++ b/signalpilot/web/components/branding/tier-badge.tsx
@@ -14,7 +14,7 @@ export function TierBadge() {
   return (
     <span className="inline-flex items-center gap-1.5">
       <span
-        className="inline-block w-[5px] h-[5px] flex-shrink-0"
+        className="inline-block w-[5px] h-[5px] flex-shrink-0 translate-y-[0.5px]"
         style={{ backgroundColor: brand.accentHex }}
         aria-hidden="true"
       />

--- a/signalpilot/web/components/branding/tier-favicon.tsx
+++ b/signalpilot/web/components/branding/tier-favicon.tsx
@@ -12,7 +12,7 @@ import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 // Free tier: no favicon injection (handled by early return in useEffect).
 
 const PRO_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><rect x="8" y="8" width="16" height="16" fill="#9ca3af"/></svg>';
+  '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><rect x="8" y="8" width="16" height="16" fill="#d4d4d4"/></svg>';
 
 // bottom-right 8x8 cut: TL(8,8) TR(24,8) right-mid(24,16) notch-corner(16,24) BL(8,24)
 const TEAM_SVG =

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -42,7 +42,7 @@ function EnterpriseSealInner({ brand }: InnerProps) {
     <div className="flex flex-col gap-0.5">
       <div className="flex items-center gap-1.5">
         <span
-          className="inline-block w-[5px] h-[5px] flex-shrink-0"
+          className="inline-block w-[5px] h-[5px] flex-shrink-0 translate-y-[0.5px]"
           style={{ backgroundColor: brand.accentHex }}
           aria-hidden="true"
         />
@@ -51,7 +51,7 @@ function EnterpriseSealInner({ brand }: InnerProps) {
         </span>
       </div>
       {orgName && (
-        <span className="text-[10px] text-[var(--color-text-dim)] tracking-wide pl-[11px]">
+        <span className="text-[10px] leading-none text-[var(--color-text-dim)] tracking-wide pl-[11px]">
           {orgName}
         </span>
       )}
@@ -65,7 +65,7 @@ function TeamSealInner({ brand }: InnerProps) {
   return (
     <div className="flex items-center gap-1.5">
       <span
-        className="inline-block w-[5px] h-[5px] flex-shrink-0"
+        className="inline-block w-[5px] h-[5px] flex-shrink-0 translate-y-[0.5px]"
         style={{ backgroundColor: brand.accentHex }}
         aria-hidden="true"
       />

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -57,12 +57,12 @@ function EnterpriseSealInner({ variant, brand }: EnterpriseSealInnerProps) {
             style={{ backgroundColor: brand.accentHex }}
             aria-hidden="true"
           />
-          <span className={`text-[10px] tracking-[0.2em] uppercase ${brand.accentText}`}>
+          <span className={`text-[10px] leading-none tracking-[0.2em] uppercase ${brand.accentText}`}>
             Enterprise
           </span>
         </div>
         {orgName && (
-          <span className="text-[10px] text-[var(--color-text-dim)] tracking-wide pl-2.5">
+          <span className="text-[10px] text-[var(--color-text-dim)] tracking-wide pl-[11px]">
             {orgName}
           </span>
         )}
@@ -72,7 +72,7 @@ function EnterpriseSealInner({ variant, brand }: EnterpriseSealInnerProps) {
 
   // Header variant — enterprise only
   return (
-    <span className={`inline-flex items-center gap-1.5 tracking-[0.2em] uppercase text-[11px] ${brand.accentText}`}>
+    <span className={`inline-flex items-center gap-1.5 leading-none tracking-[0.2em] uppercase text-[11px] ${brand.accentText}`}>
       <span
         className="inline-block w-[5px] h-[5px] flex-shrink-0"
         style={{ backgroundColor: brand.accentHex }}
@@ -101,7 +101,7 @@ function TeamSealInner({ brand }: TeamSealInnerProps) {
         style={{ backgroundColor: brand.accentHex }}
         aria-hidden="true"
       />
-      <span className={`text-[10px] tracking-[0.2em] uppercase ${brand.accentText}`}>
+      <span className={`text-[10px] leading-none tracking-[0.2em] uppercase ${brand.accentText}`}>
         Team
       </span>
     </div>

--- a/signalpilot/web/components/branding/tier-seal.tsx
+++ b/signalpilot/web/components/branding/tier-seal.tsx
@@ -4,94 +4,62 @@ import { useOrganization } from "@clerk/nextjs";
 import { type TierBrand } from "@/lib/tier-branding";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
-interface TierSealProps {
-  variant: "footer" | "header";
-}
-
 /**
- * TierSeal outer gate — branches by tier so inner components can call hooks
- * unconditionally (rules-of-hooks: no conditional hook calls).
+ * TierSeal — sidebar footer brand mark. Branches by tier so inner components
+ * can call hooks unconditionally (rules-of-hooks).
  *
  * - enterprise → EnterpriseSealInner (calls useOrganization, renders org name)
  * - team       → TeamSealInner      (no useOrganization, no org line)
  * - else       → null
- *
- * Header variant gate stays enterprise-only (unchanged from prior spec).
  */
-export function TierSeal({ variant }: TierSealProps) {
+export function TierSeal() {
   const b = useTierBranding();
 
   if (!b.enabled) return null;
 
   if (b.tier === "enterprise") {
-    return <EnterpriseSealInner variant={variant} brand={b.brand} />;
+    return <EnterpriseSealInner brand={b.brand} />;
   }
 
-  if (b.tier === "team" && variant === "footer") {
+  if (b.tier === "team") {
     return <TeamSealInner brand={b.brand} />;
   }
 
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// EnterpriseSealInner — safe to call useOrganization() here
-// ---------------------------------------------------------------------------
-
-interface EnterpriseSealInnerProps extends TierSealProps {
+interface InnerProps {
   brand: TierBrand;
 }
 
-function EnterpriseSealInner({ variant, brand }: EnterpriseSealInnerProps) {
+function EnterpriseSealInner({ brand }: InnerProps) {
   const { organization } = useOrganization();
   const orgName = organization?.name ?? null;
 
   if (!brand.accentHex) return null;
 
-  if (variant === "footer") {
-    return (
-      <div className="flex flex-col gap-0.5">
-        <div className="flex items-center gap-1.5">
-          <span
-            className="inline-block w-[5px] h-[5px] flex-shrink-0"
-            style={{ backgroundColor: brand.accentHex }}
-            aria-hidden="true"
-          />
-          <span className={`text-[10px] leading-none tracking-[0.2em] uppercase ${brand.accentText}`}>
-            Enterprise
-          </span>
-        </div>
-        {orgName && (
-          <span className="text-[10px] text-[var(--color-text-dim)] tracking-wide pl-[11px]">
-            {orgName}
-          </span>
-        )}
-      </div>
-    );
-  }
-
-  // Header variant — enterprise only
   return (
-    <span className={`inline-flex items-center gap-1.5 leading-none tracking-[0.2em] uppercase text-[11px] ${brand.accentText}`}>
-      <span
-        className="inline-block w-[5px] h-[5px] flex-shrink-0"
-        style={{ backgroundColor: brand.accentHex }}
-        aria-hidden="true"
-      />
-      ENTERPRISE
-    </span>
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-1.5">
+        <span
+          className="inline-block w-[5px] h-[5px] flex-shrink-0"
+          style={{ backgroundColor: brand.accentHex }}
+          aria-hidden="true"
+        />
+        <span className={`text-[10px] leading-none tracking-[0.2em] uppercase ${brand.accentText}`}>
+          Enterprise
+        </span>
+      </div>
+      {orgName && (
+        <span className="text-[10px] text-[var(--color-text-dim)] tracking-wide pl-[11px]">
+          {orgName}
+        </span>
+      )}
+    </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// TeamSealInner — no useOrganization(); footer only
-// ---------------------------------------------------------------------------
-
-interface TeamSealInnerProps {
-  brand: TierBrand;
-}
-
-function TeamSealInner({ brand }: TeamSealInnerProps) {
+function TeamSealInner({ brand }: InnerProps) {
   if (!brand.accentHex) return null;
 
   return (

--- a/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
+++ b/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
@@ -176,7 +176,7 @@ export default function TierUpgradeCelebration() {
           ref={closeRef}
           type="button"
           onClick={handleDismiss}
-          className="absolute top-4 right-4 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-current"
+          className="absolute top-4 right-4 mt-[1px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-current"
           aria-label="Dismiss"
         >
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
@@ -216,7 +216,7 @@ function CelebrationContent({ tier, brand }: CelebrationContentProps) {
       <div className="flex items-center gap-1.5">
         {brand.accentHex && (
           <span
-            className="inline-block w-[5px] h-[5px] flex-shrink-0"
+            className="inline-block w-[5px] h-[5px] flex-shrink-0 translate-y-[0.5px]"
             style={{ backgroundColor: brand.accentHex }}
             aria-hidden="true"
           />

--- a/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
+++ b/signalpilot/web/components/branding/tier-upgrade-celebration.tsx
@@ -221,7 +221,7 @@ function CelebrationContent({ tier, brand }: CelebrationContentProps) {
             aria-hidden="true"
           />
         )}
-        <span className="text-[10px] tracking-[0.2em] uppercase text-[var(--color-text-muted)]">
+        <span className="text-[10px] leading-none tracking-[0.2em] uppercase text-[var(--color-text-muted)]">
           {brand.label}
         </span>
       </div>

--- a/signalpilot/web/components/branding/tier-wordmark.tsx
+++ b/signalpilot/web/components/branding/tier-wordmark.tsx
@@ -20,7 +20,7 @@ export function TierWordmark({ variant = "sidebar" }: TierWordmarkProps) {
   return (
     <span className={`inline-flex items-center gap-1.5 leading-none tracking-[0.15em] uppercase ${brand.accentText} ${textSize}`}>
       <span
-        className="inline-block w-[5px] h-[5px] flex-shrink-0"
+        className="inline-block w-[5px] h-[5px] flex-shrink-0 translate-y-[0.5px]"
         style={{ backgroundColor: brand.accentHex }}
         aria-hidden="true"
       />

--- a/signalpilot/web/components/branding/tier-wordmark.tsx
+++ b/signalpilot/web/components/branding/tier-wordmark.tsx
@@ -18,7 +18,7 @@ export function TierWordmark({ variant = "sidebar" }: TierWordmarkProps) {
   const textSize = variant === "sidebar" ? "text-[11px]" : "text-[12px]";
 
   return (
-    <span className={`inline-flex items-center gap-1.5 tracking-[0.15em] uppercase ${brand.accentText} ${textSize}`}>
+    <span className={`inline-flex items-center gap-1.5 leading-none tracking-[0.15em] uppercase ${brand.accentText} ${textSize}`}>
       <span
         className="inline-block w-[5px] h-[5px] flex-shrink-0"
         style={{ backgroundColor: brand.accentHex }}

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -410,11 +410,11 @@ export default function Sidebar() {
             <SignalPilotLogo />
           </div>
           <div>
-            <h1 className="text-[13px] font-bold tracking-[0.2em] uppercase text-[var(--color-text)]">
+            <h1 className="text-[13px] font-bold tracking-[0.2em] uppercase leading-none text-[var(--color-text)]">
               SignalPilot
             </h1>
             {/* Subtitle slot — reserved height to prevent layout snap */}
-            <div className="min-h-[14px] mt-0.5">
+            <div className="min-h-[14px] mt-0.5 flex items-center">
               {showWordmark ? (
                 <TierWordmark variant="sidebar" />
               ) : (
@@ -503,7 +503,7 @@ export default function Sidebar() {
               <span className="animate-ping absolute inline-flex h-full w-full bg-[var(--color-success)] opacity-30" />
               <span className="relative inline-flex h-2 w-2 bg-[var(--color-success)]" />
             </span>
-            <span className="tracking-[0.15em] uppercase">governance active</span>
+            <span className="tracking-[0.15em] uppercase leading-none">governance active</span>
           </div>
         </Tooltip>
         {connHealth.total > 0 && (
@@ -513,7 +513,7 @@ export default function Sidebar() {
                 <ellipse cx="5" cy="3" rx="3.5" ry="1.5" stroke="currentColor" strokeWidth="0.75" fill="none" />
                 <path d="M1.5 3V7C1.5 8 3.1 9 5 9C6.9 9 8.5 8 8.5 7V3" stroke="currentColor" strokeWidth="0.75" />
               </svg>
-              <span className="tracking-[0.15em] uppercase">
+              <span className="tracking-[0.15em] uppercase leading-none">
                 db {connHealth.healthy}/{connHealth.total}
               </span>
               {connHealth.healthy < connHealth.total && (
@@ -528,7 +528,7 @@ export default function Sidebar() {
               <circle cx="5" cy="5" r="4" stroke="var(--color-border-hover)" strokeWidth="1" fill="none" />
               <path d="M5 2.5V5L6.5 6.5" stroke="var(--color-text-dim)" strokeWidth="0.8" strokeLinecap="round" />
             </svg>
-            <span className="tracking-wider">uptime <UptimeCounter /></span>
+            <span className="tracking-wider leading-none">uptime <UptimeCounter /></span>
           </div>
         </Tooltip>
         {/* System info line */}

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -118,7 +118,7 @@ const HIDDEN_SIDEBAR_PREFIXES = ["/sign-in", "/sign-up", "/onboarding"];
 function SignalPilotLogo() {
   return (
     /* eslint-disable-next-line @next/next/no-img-element */
-    <img src="/logo.svg" alt="SignalPilot" width={32} height={32} className="rounded-sm" />
+    <img src="/logo.svg" alt="SignalPilot" width={32} height={32} className="block rounded-sm" />
   );
 }
 
@@ -397,17 +397,6 @@ export default function Sidebar() {
   const tierBranding = useTierBranding();
   const showWordmark = tierBranding.enabled && tierBranding.tier !== "free";
 
-  // Tier-keyed logo glow — whole class tokens, no concatenation
-  const LOGO_GLOW: Record<string, string> = {
-    enterprise: "drop-shadow-[0_0_8px_rgba(251,191,36,0.4)]",
-    team: "drop-shadow-[0_0_8px_rgba(167,139,250,0.4)]",
-    pro: "drop-shadow-[0_0_8px_rgba(129,140,248,0.35)]",
-  };
-  const logoGlow =
-    tierBranding.enabled && tierBranding.tier !== "free"
-      ? (LOGO_GLOW[tierBranding.tier] ?? "")
-      : "";
-
   if (HIDDEN_SIDEBAR_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
     return null;
   }
@@ -417,7 +406,7 @@ export default function Sidebar() {
       {/* Logo */}
       <div className="px-5 py-5 border-b border-[var(--color-border)]">
         <Link href="/dashboard" className="flex items-center gap-3 group">
-          <div className={`transition-transform group-hover:scale-105 ${logoGlow}`}>
+          <div className="transition-transform group-hover:scale-105">
             <SignalPilotLogo />
           </div>
           <div>

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -533,7 +533,7 @@ export default function Sidebar() {
         </Tooltip>
         {/* System info line */}
         <div className="separator-subtle" />
-        <TierSeal variant="footer" />
+        <TierSeal />
         <div className="flex items-center justify-between">
           <Tooltip content="signalpilot gateway version" position="right">
             <div className="flex items-center gap-1.5 cursor-default">

--- a/signalpilot/web/components/ui/keyboard-shortcuts.tsx
+++ b/signalpilot/web/components/ui/keyboard-shortcuts.tsx
@@ -78,7 +78,7 @@ export function KeyboardShortcuts() {
             <span className="text-[12px] uppercase tracking-[0.15em] text-[var(--color-text-dim)]">
               keyboard shortcuts
             </span>
-            <TierBadge size="sm" />
+            <TierBadge />
           </div>
           <kbd className="px-1.5 py-0.5 bg-[var(--color-bg)] border border-[var(--color-border)] text-[11px] font-mono text-[var(--color-text-dim)]">
             esc

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -32,8 +32,9 @@ export function PageHeader({
           <div className="flex items-center gap-3 mb-1">
             <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
             <TierBadge size="sm" />
-            <span className="text-[12px] text-[var(--color-text-muted)] tracking-[0.15em] uppercase px-1.5 py-0.5 border border-[var(--color-border)]">
-              {subtitle}
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block w-[5px] h-[5px] flex-shrink-0 bg-[var(--color-text-dim)]" aria-hidden="true" />
+              <span className="text-[12px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-muted)]">{subtitle}</span>
             </span>
           </div>
           <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -2,7 +2,6 @@
 
 import { TierBadge } from "@/components/branding/tier-badge";
 import { TierAccent } from "@/components/branding/tier-accent";
-import { TierSeal } from "@/components/branding/tier-seal";
 import { useTierBranding } from "@/lib/hooks/use-tier-branding";
 
 /**
@@ -36,10 +35,7 @@ export function PageHeader({
           </div>
           <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>
         </div>
-        <div className="flex items-center gap-2">
-          {actions}
-          <TierSeal variant="header" />
-        </div>
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
       </div>
 
       {/* Bottom rule — exactly one line. Paid tier: tier-tinted accent.

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -29,7 +29,7 @@ export function PageHeader({
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-3 mb-1">
-            <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
+            <h1 className="text-xl font-light tracking-wide leading-none text-[var(--color-text)]">{title}</h1>
             <TierBadge />
             <span className="text-[12px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-muted)]">{subtitle}</span>
           </div>

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -32,10 +32,7 @@ export function PageHeader({
           <div className="flex items-center gap-3 mb-1">
             <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
             <TierBadge size="sm" />
-            <span className="inline-flex items-center gap-1.5">
-              <span className="inline-block w-[5px] h-[5px] flex-shrink-0 bg-[var(--color-text-dim)]" aria-hidden="true" />
-              <span className="text-[12px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-muted)]">{subtitle}</span>
-            </span>
+            <span className="text-[12px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-muted)]">{subtitle}</span>
           </div>
           <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>
         </div>

--- a/signalpilot/web/components/ui/page-header.tsx
+++ b/signalpilot/web/components/ui/page-header.tsx
@@ -30,7 +30,7 @@ export function PageHeader({
         <div>
           <div className="flex items-center gap-3 mb-1">
             <h1 className="text-xl font-light tracking-wide text-[var(--color-text)]">{title}</h1>
-            <TierBadge size="sm" />
+            <TierBadge />
             <span className="text-[12px] leading-none tracking-[0.15em] uppercase text-[var(--color-text-muted)]">{subtitle}</span>
           </div>
           <p className="text-sm text-[var(--color-text-muted)] tracking-wider">{description}</p>

--- a/signalpilot/web/components/ui/toast.tsx
+++ b/signalpilot/web/components/ui/toast.tsx
@@ -83,7 +83,7 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) =
       }`}
     >
       {icons[toast.type]}
-      <span className="text-[13px] text-[var(--color-text-muted)] tracking-wide">{toast.message}</span>
+      <span className="text-[13px] leading-none tracking-wide text-[var(--color-text-muted)]">{toast.message}</span>
       <button
         onClick={() => {
           setExiting(true);

--- a/signalpilot/web/lib/tier-branding.ts
+++ b/signalpilot/web/lib/tier-branding.ts
@@ -16,7 +16,7 @@ export const TIER_BRANDS: Record<BrandTier, TierBrand> = {
   pro: {
     label: "Pro",
     accentText: "text-[var(--color-text-muted)]",
-    accentHex: "#9ca3af",
+    accentHex: "#d4d4d4",
   },
   team: {
     label: "Team",


### PR DESCRIPTION
Reworks the per-tier branding (Free / Pro / Team / Enterprise) so it stops looking ornamental and bolted-on, and instead reads as a native extension of the app's existing terminal aesthetic.

## What changed
- Single principled signal per tier: a 5px accent dot, a 1px hairline, and a 1px top strip on the celebration card. Nothing else.
- Native palette only: `--color-success` (#00ff88) for Enterprise, blue-400 for Team, near-monochrome for Pro, no accent for Free. Removed the foreign indigo / violet / fuchsia / amber gradients.
- Removed: gradient backdrop band and 80px watermark icon in `page-header.tsx`, the corner-overlay `tier-crest.tsx` (deleted), shadow/blur/halo on the celebration card, decorative Lucide icons on always-on surfaces.
- Removed the per-tier amber/violet/indigo `LOGO_GLOW` drop-shadow on the sidebar logo, and the local `tierColorMap` on the dashboard subscription card. Every tier signal in the app now derives from a single source (`TIER_BRANDS` / `useTierBranding`).
- Rewrote `tier-badge`, `tier-wordmark`, `tier-accent`, `tier-seal`, `tier-favicon`, `tier-upgrade-celebration` as simple geometric SVG/text marks. Favicons use 8x8 corner notches so the differentiation survives 16x16 downscaling.
- Celebration overlay copy is now factual and capability-based, with a uniform `"<Tier> is active."` headline pattern.
- `lib/tier-branding.ts` slimmed from 8 fields to 3 (`label`, `accentText`, `accentHex: string | null`).
- `toast.tsx` `TIER_LEFT_BORDER` palette aligned to the new accents.

## Alignment pass
- Added `leading-none` to every tier label span (`tier-badge`, `tier-wordmark`, `tier-seal`, `tier-upgrade-celebration`, toast message, dashboard subscription header) so the 5px accent square aligns to the cap-line of the uppercase tracked label rather than the line-box midpoint.
- Set the sidebar logo `<img>` to `block` to drop phantom inline-baseline whitespace.
- Stripped the box (border + padding) off the free-tier neutral pill in PageHeader, dashboard, and billing — both states now render as bare `dot + uppercase label` at identical height.
- Tightened Enterprise org-name padding in `tier-seal` from `pl-2.5` to `pl-[11px]` (5px square + 6px gap).
- Dropped the redundant 5px dot from the PageHeader subtitle so the title row carries one anchored tier marker instead of two adjacent dot+uppercase clusters.

Net diff is a reduction. No new dependencies, no new design tokens, typecheck clean.


---
**Branch:** `autofyn/we-just-did-a-bu-25749b` · **Run:** `1ebb9643-a876-4e2d-bb43-00d275335ecc` · *Generated by AutoFyn*