### PR TITLE
docs(readme): one entrypoint, three pieces of infra + mark non-Claude MCP as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@
 
 ---
 
-**Index** — [How It Works](#how-it-works) · [Try](#try-signalpilot-data-agent) · [Architecture](#architecture) · [MCP Tools](#mcp-tools) · [Community](#community)
+## What SignalPilot Is
+
+**One entrypoint, three pieces of infrastructure** on the same gateway.
+
+Today the supported entrypoint is **[Claude Code](https://claude.com/claude-code)**. Underneath it, three components do the work:
+
+1. **Plugin (skill + tool)** — [`plugin/`](plugin/) adds 10 dbt/SQL skills + a verifier agent + 40 MCP tools to your Claude Code session. This is the recommended way to use SignalPilot.
+2. **MCP server** — standard `streamable-http`, the layer the plugin talks to. *Experimental for non-Claude clients*: Cursor / Codex / custom Agent SDK builds can connect and call the 40 MCP tools, but the **skills are Claude Code-specific** and don't run there. Use at your own risk until other platforms ship a skill-equivalent surface.
+3. **Observability platform** — `docker compose up -d` brings up the gateway, web UI (`:3200`), audit log, query history, latency/error dashboards, encrypted credential storage. Or use [SignalPilot Cloud](https://signalpilot.ai) for SSO and hosted history.
+
+---
+
+**Index** — [What It Is](#what-signalpilot-is) · [How It Works](#how-it-works) · [Try](#try-signalpilot-data-agent) · [Architecture](#architecture) · [MCP Tools](#mcp-tools) · [Community](#community)
 
 ---
 
@@ -121,9 +133,9 @@ Other MCP-DB servers don't enforce LIMIT injection, DDL blocking, or audit loggi
 
 ---
 
-## Use With Claude Code (Plugin)
+## Use With Claude Code (Plugin) — Recommended
 
-The [`plugin/`](plugin/) directory adds SignalPilot tools + dbt skills to Claude Code.
+The [`plugin/`](plugin/) directory adds SignalPilot tools + dbt skills to Claude Code. This is the supported path.
 
 ```bash
 # Add the marketplace and install
@@ -150,6 +162,8 @@ See [`plugin/README.md`](plugin/README.md) for full details on included skills a
 ---
 
 ## Use With Any MCP Client
+
+> ⚠️ **Experimental for non-Claude clients.** The 40 MCP tools work over `streamable-http` from any MCP client (Cursor, Codex, custom Agent SDK) — but the SignalPilot skills are Claude Code-specific and don't run outside it. You'll have the tools without skill orchestration. The Claude Code Plugin is the supported path; treat the configs below as best-effort.
 
 ### Claude Code / Claude Desktop
 


### PR DESCRIPTION
## Summary

Reframes the README around the actual story: SignalPilot is **one supported entrypoint (Claude Code)** with **three pieces of infrastructure** behind it — plugin (skill + tool), MCP server, and the observability platform (docker / web UI / cloud). Today the install sections read like three independent paths a reader chooses between, which doesn't match reality.

Also adds an explicit **experimental** marker for non-Claude MCP clients (Cursor, Codex, custom Agent SDK). Per Slack discussion: those clients *can* connect to the MCP server and call the 40 tools, but **Claude Code skills don't run there** — so the tools work, the orchestration doesn't, and we should set expectations.

## Changes

| # | Where | Change |
|---|-------|---|
| 1 | After the team intro | New \`## What SignalPilot Is\` section — 3-bullet framing of the infra components |
| 2 | Index nav row | Prepended \`What It Is\` link |
| 3 | \`## Use With Any MCP Client\` | Added a blockquote callout at the top: experimental, tools only, no skills |
| 4 | \`## Use With Claude Code (Plugin)\` | Heading bumped to \`— Recommended\`, lead now says \"This is the supported path.\" |

No new files. \`README.md\` only.

## Diff stats

\`+17 / -3\` lines.

## Test plan

- [ ] GitHub preview renders the new section as a numbered list
- [ ] Click \`What It Is\` in the Index → anchors to \`#what-signalpilot-is\`
- [ ] \`experimental\` and \`Experimental\` appear in 2 places with consistent wording (search confirms)
- [ ] No broken anchors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)