### PR TITLE
Fix Vercel deployment: dynamic baseUrl for Vercel vs GitHub Pages

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -11,8 +11,10 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://SignalPilot-Labs.github.io',
-  baseUrl: '/SignalPilot/',
+  url: process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'https://SignalPilot-Labs.github.io',
+  baseUrl: process.env.VERCEL ? '/' : '/SignalPilot/',
 
   organizationName: 'SignalPilot-Labs',
   projectName: 'SignalPilot',


### PR DESCRIPTION
Vercel serves from / while GitHub Pages serves from /SignalPilot/. Use VERCEL env var to detect platform and set baseUrl accordingly.