### PR TITLE
Remove collapse sidebar button and reduce sidebar width

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -74,7 +74,7 @@ const config: Config = {
     },
     docs: {
       sidebar: {
-        hideable: true,
+        hideable: false,
       },
     },
     tableOfContents: {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -49,6 +49,7 @@
   --sp-heading-3: #000000;
   --sp-heading-4: #000000;
   --sp-text-dim: #999999;
+  --doc-sidebar-width: 270px;
 }
 
 /* ── Dark theme (canonical) ── */
@@ -93,6 +94,7 @@
   --sp-heading-3: #ffffff;
   --sp-heading-4: #ffffff;
   --sp-text-dim: #666666;
+  --doc-sidebar-width: 270px;
 }
 
 /* ── Typography hierarchy ── */


### PR DESCRIPTION
## Summary
- Disabled the "Collapse sidebar" button by setting `hideable: false` in Docusaurus config
- Reduced sidebar width by 10% (300px → 270px) via `--doc-sidebar-width` CSS variable in both light and dark themes

## Test plan
- [ ] Verify "Collapse sidebar" button no longer appears
- [ ] Verify sidebar is visibly narrower
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)