### PR TITLE
local-db failure analysis: 4 new skills + prompt hardening

### DIFF
--- a/benchmark/agent/sql_prompts.py
+++ b/benchmark/agent/sql_prompts.py
@@ -312,6 +312,62 @@ SQL-correctness rules — do not infer anything about the expected answer's exac
     matches; for proportions, write the denominator's GROUP BY explicitly; for
     sum-of-products, push the multiplication inside the SUM."
 
+21. POPULATION QUALIFIER PROPAGATED TO EVERY CTE:
+    If the question contains a population-narrowing adjective ("delivered",
+    "completed", "active", "qualified", "primary", "validated", "approved",
+    "shipped", "paid", "refunded") that the answer must respect, the predicate
+    enforcing that adjective MUST appear in EVERY CTE that touches the fact
+    table — not only at the top-level WHERE. FLAG IT if any of the following
+    is true:
+    a) An NTILE / RANK / PERCENT_RANK / window aggregate is computed inside a
+       CTE that does NOT carry the population predicate, but the final SELECT
+       does. (The window's bucket boundaries shift because they were computed
+       against the un-filtered universe.)
+    b) Per-entity aggregates (SUM / COUNT / MAX) feed a downstream join, and
+       only some of the contributing CTEs carry the predicate.
+    c) A "base" CTE was defined that filters the population, but a downstream
+       CTE bypasses it and re-reads the raw table.
+    The fix is always: "FIX: factor the population predicate into a single
+    `base` CTE (`SELECT * FROM <fact> WHERE <predicate>`) and have every
+    downstream CTE read from `base` instead of the raw table — OR repeat the
+    same predicate in every contributing CTE's WHERE clause."
+
+22. MODIFIER-BOUND DATE COLUMN — MATCH THE TIMESTAMP TO THE STATE:
+    If the question pairs a state modifier with a temporal grouping ("delivered
+    orders per month", "shipped volume by quarter", "paid invoices in 2017"),
+    the date column used for the GROUP BY (and for the year/quarter WHERE) must
+    be the state-transition timestamp for that modifier (e.g.
+    `order_delivered_customer_date` for delivered, `paid_at` for paid),
+    NOT the generic creation timestamp (`order_purchase_timestamp`,
+    `created_at`). FLAG IT if any of the following is true:
+    a) The entity table has multiple date columns (a creation timestamp and
+       one or more state-transition timestamps) AND the SQL groups by the
+       creation timestamp despite the question naming a state modifier.
+    b) The year/quarter filter and the GROUP BY use DIFFERENT date columns
+       (orders purchased in Dec 2017 but delivered in Jan 2018 are split
+       inconsistently between buckets).
+    c) The state-transition column is grouped without an `IS NOT NULL`
+       guard — rows that never reached that state pollute the buckets.
+    The fix is always: "FIX: replace the generic `<creation_ts>` with the
+    state-transition column matching the modifier in BOTH the GROUP BY and the
+    year/period filter; add `<state_transition_col> IS NOT NULL`."
+
+23. CALENDAR-DECOMPOSITION VS COMPONENT-SUBTRACT:
+    If the question asks for the difference between two dates expressed in
+    multiple units (years AND months AND days, or any pair) AND the SQL takes
+    each unit's difference independently with strftime / EXTRACT and combines
+    them (especially with ABS on each component before summing), FLAG IT.
+    Independent component subtraction silently overestimates the span whenever
+    the smaller-unit residual is negative (Sep-10 → Apr-13 component-subtracts
+    to 5y −5m 3d, which after ABS becomes 5y 5m 3d instead of the correct
+    4y 7m 3d). The correct form is calendar age decomposition: full years
+    first (subtracting one when end's month-day is earlier than start's),
+    then residual months (subtracting one when end's day is earlier), then
+    residual days. The fix is always: "FIX: replace independent component
+    subtraction with calendar-age decomposition — borrow across boundaries
+    (years−1 when end-month-day < start-month-day; months−1 when end-day <
+    start-day) before assembling the final fractional value."
+
 Respond with EXACTLY ONE of these formats:
 
   OK
@@ -415,6 +471,65 @@ DATABASE: SignalPilot connection '{connection_name}' (backend: {db_backend.value
 
 WORKFLOW — follow these steps in order:
 
+0. LOAD ALL RELEVANT SKILLS — MANDATORY, NON-NEGOTIABLE, BEFORE ANY OTHER WORK:
+
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ⚠  YOU MUST LOAD EVERY APPLICABLE SKILL BEFORE WRITING SQL.  ⚠
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+   Skills are in .claude/skills/. Each skill targets ONE recurring failure mode.
+   Skipping a skill that applies is the #1 cause of avoidable failures on this
+   task suite. THIS IS NOT OPTIONAL.
+
+   PROCEDURE — execute step (a) and (b) before ANY tool call:
+
+   (a) SCAN the question for trigger words. For EACH trigger you find, you MUST
+       load the matching skill. Multiple skills almost always apply — load
+       ALL of them. Loading three skills is normal; loading one is suspicious;
+       loading zero is wrong.
+
+       | Trigger in the question                                          | Skill you MUST load |
+       |------------------------------------------------------------------|---------------------|
+       | ANY question (always)                                            | output-column-spec  |
+       | "for each X" / "per X" / "by X" / "list each X"                  | entity-with-metrics |
+       | "top N" / "highest" / "lowest" / "ranked" / "1st 2nd 3rd"        | ranking-with-position |
+       | "tier" / "grade" / "quintile" / "category" / "classify"          | classification-with-score |
+       | "compare X to Y" / "year over year" / "before vs after" / two named periods | temporal-comparison |
+       | "considering only X" / "X only" / a population-narrowing adj    | qualifier-applies-everywhere |
+       | "delivered" / "shipped" / "completed" / "paid" + "per month/year/quarter" | modifier-bound-date-column |
+       | "Y years M months D days" / multi-unit date difference           | calendar-decomposition-vs-component-subtract |
+       | "average of [entity] averages" / "mean per-X mean"               | avg-of-avgs-vs-pooled |
+
+   (b) LOAD each matched skill by reading its file:
+         Read: .claude/skills/<skill-name>/SKILL.md
+       For skills with sub-files, read those too. State out loud which skills
+       you loaded and why. Example:
+
+         "Question mentions 'top 5 with highest avg X along with their batting
+          averages, considering only delivered orders'. Loading:
+          - output-column-spec  (always)
+          - ranking-with-position  (top 5, highest)
+          - entity-with-metrics  (per-player, two metrics)
+          - qualifier-applies-everywhere  (considering only delivered)
+          - modifier-bound-date-column  (delivered + temporal)"
+
+   (c) After loading, the loaded skill's instructions are PART OF THE WORKFLOW.
+       Follow every checklist and verification step the skill prescribes — the
+       OUTPUT COLUMN SPEC block, the population predicate placement, the
+       trailing-connector parsing — none of these are optional.
+
+   FAILURE MODES of skipping this step (all observed in past runs):
+   - Missing output column ("along with their X" silently dropped)
+   - Population qualifier applied at the final WHERE only, not in scoring CTEs
+   - Wrong date column for state-modifier + temporal-bucketing questions
+   - Component-subtraction date math instead of calendar decomposition
+   - Pooled mean returned when avg-of-avgs was asked
+   Each of these is fixed by the skill that exists for it. LOAD THE SKILL.
+
+   You may NOT skip this step "to save turns". Loading skills is cheap (file
+   reads). Returning a wrong answer wastes the entire run. The arithmetic is
+   not in your favor — load every applicable skill, every time.
+
 1. SCHEMA DISCOVERY (minimize MCP calls):
    a. READ LOCAL SCHEMA FILES FIRST — if a schema/ directory and DDL.csv exist in your workdir:
       - Read DDL.csv for CREATE TABLE statements (gives you all table names + columns)
@@ -476,7 +591,7 @@ WORKFLOW — follow these steps in order:
    --           lowest-level pathways" or "sovereign countries excluding
    --           World/income-group aggregates">
    -- Vocab cols: <col_a chosen because values look like "ABC" not "Full Name X">
-   -- Enums: <field=values list, e.g. "type ∈ {Gain, Loss, Amplification, Deletion}">
+   -- Enums: <field=values list, e.g. "type ∈ {{Gain, Loss, Amplification, Deletion}}">
    -- Join policy: <"LEFT from teams to mutations to keep no-mutation group">
    -- ===========================================
 
@@ -502,8 +617,8 @@ WORKFLOW — follow these steps in order:
    • Each classification ("grade", "tier", "quintile") → BOTH the numeric score AND
      the label column
    • Any "overall/total" alongside "for each X" → a roll-up column or row
-   You may also load the /output-column-spec skill for the full procedure. Either way,
-   you MUST produce the OUTPUT COLUMN SPEC block before SQL writing.
+   You MUST have already loaded /output-column-spec at step 0 — apply its full
+   procedure here. Produce the OUTPUT COLUMN SPEC block before SQL writing.
 
 2. PLAN THE QUERY (before writing SQL):
    - Read the question for cardinality clues: "for each X" = GROUP BY, "top N" = LIMIT/QUALIFY,

--- a/benchmark/runners/sql_runner.py
+++ b/benchmark/runners/sql_runner.py
@@ -116,6 +116,10 @@ def _get_skill_names(suite: BenchmarkSuite, backend: DBBackend) -> tuple[str, ..
         "entity-with-metrics",
         "ranking-with-position",
         "classification-with-score",
+        "qualifier-applies-everywhere",
+        "calendar-decomposition-vs-component-subtract",
+        "modifier-bound-date-column",
+        "avg-of-avgs-vs-pooled",
     )
     _BACKEND_SKILLS: dict[DBBackend, tuple[str, ...]] = {
         DBBackend.SNOWFLAKE: ("sql-workflow", "snowflake-sql"),

--- a/benchmark/skills/avg-of-avgs-vs-pooled/SKILL.md
+++ b/benchmark/skills/avg-of-avgs-vs-pooled/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: avg-of-avgs-vs-pooled
+description: "Use this skill when the question asks for an aggregate-of-aggregates ('average of player averages by country', 'mean per-customer mean', 'avg quarterly avg sales by region'). The two natural interpretations — pooled (sum of children / count of children) and avg-of-avgs (mean of per-entity means) — produce different numbers whenever group sizes differ. Pick the form the question literally describes; do NOT pool when the question says 'average of averages'."
+type: skill
+---
+
+# Average-of-Averages vs Pooled-Mean Skill
+
+## When this skill applies
+
+The question chains two aggregation levels:
+- "the average of each X's average Y"
+- "average per-customer monthly spend, then averaged by region"
+- "the country's batting average, computed as the average of player batting averages"
+- "mean per-store sales, averaged across the chain"
+
+A single sentence is enough — wherever you see the word "average" or "mean" applied twice (once at the inner entity, once at the outer group), you are in this skill's territory.
+
+## The two forms diverge
+
+For an outer group containing entities with sizes `n_1, n_2, …` and entity-level totals `s_1, s_2, …`:
+
+- **Pooled mean** (also called weighted mean): `Σs_i / Σn_i` — every individual data point counts equally.
+- **Average of averages**: `Σ(s_i / n_i) / k` — every entity counts equally, regardless of size.
+
+When entity sizes differ, the two values are different. Example:
+- Player A: 100 runs over 2 matches → avg 50.00
+- Player B: 90 runs over 9 matches → avg 10.00
+- Pooled (country): 190 / 11 = **17.27**
+- Avg-of-avgs (country): (50 + 10) / 2 = **30.00**
+
+If the question says "average of player averages", returning 17.27 is wrong even though it looks reasonable.
+
+## Reading the question
+
+These phrases mean **avg-of-avgs**:
+- "**average of** the [entity]-level **averages**"
+- "the [entity]'s **average X**, **averaged** across [groups]"
+- "**country batting average** (computed as the average of player averages)"
+- "**mean per-X mean** of Y"
+
+These phrases mean **pooled / weighted**:
+- "**average X across all [individuals]**" (with no per-entity layer in between)
+- "**total X / total Y**"
+- "**overall average** X"
+- "**combined average**"
+
+When the question is ambiguous, the deciding clue is whether it names the inner entity ("each player's", "per-customer", "per-store") — naming the entity is what makes the inner average a real aggregation step, which is what makes the outer aggregation an avg-of-avgs.
+
+## Domain-specific denominator subset
+
+Even after you pick the right outer form, the **inner average's denominator may need a domain-specific subset**:
+
+| Domain | "Average X per Y" — common subset for Y |
+|---|---|
+| Cricket batting | `runs / dismissals` (or `/ innings batted`) — *not* `/ matches appeared` |
+| Baseball batting | `hits / at-bats` — *not* `/ games played` |
+| E-commerce conversion | `purchases / unique visitors` — *not* `/ events` |
+| Customer retention | `actives / period-cohort starts` — *not* `/ all-time signups` |
+| Ad CTR | `clicks / impressions` — *not* `/ pageviews` |
+
+When the question uses a domain term ("batting average", "conversion rate", "retention"), do NOT compute it as the literal English math; look up the term's domain definition and confirm it against a known datapoint before using.
+
+## SQL pattern (avg-of-avgs)
+
+```sql
+WITH per_entity AS (
+  SELECT
+    group_id, group_name,
+    entity_id,
+    -- inner aggregate, with the domain-correct denominator
+    SUM(metric_numerator) * 1.0 / SUM(metric_denominator) AS entity_metric
+  FROM facts
+  WHERE <population_predicate>
+  GROUP BY group_id, group_name, entity_id
+)
+SELECT
+  group_id,
+  group_name,
+  AVG(entity_metric) AS group_avg_of_entity_avgs
+FROM per_entity
+GROUP BY group_id, group_name
+ORDER BY group_avg_of_entity_avgs DESC
+LIMIT N;
+```
+
+## SQL pattern (pooled)
+
+```sql
+SELECT
+  group_id, group_name,
+  SUM(metric_numerator) * 1.0 / SUM(metric_denominator) AS group_pooled_metric
+FROM facts
+WHERE <population_predicate>
+GROUP BY group_id, group_name;
+```
+
+The pooled form has no inner CTE — that absence is the structural giveaway that you are pooling, not averaging averages.
+
+## Anti-patterns (these silently fail)
+
+**A. Pool when the question says avg-of-avgs**
+The numbers are pulled toward high-volume entities — values look "reasonable" but tilt heavily.
+
+**B. Avg-of-avgs when the question says pooled**
+Small entities punch above their weight; the result has higher variance and biases toward outliers.
+
+**C. Right outer form, wrong inner denominator**
+Computed `runs/matches_appeared` instead of `runs/innings_batted`. The shape is right but the values shift on every player who played without batting (substitutes, late entrants).
+
+**D. Including entities the question excludes from the denominator**
+"Average matches per player" — does that include players with zero matches? Unless the question implies it, no. Pre-filter to entities with ≥1 of the thing being averaged.
+
+## Verification before saving
+
+- [ ] Re-read the question. Is there an inner entity ("each player", "per-customer") between the two aggregation words? If yes, the form is avg-of-avgs.
+- [ ] Did you write a `per_entity` CTE that produces one row per inner entity, then aggregate that?
+- [ ] Is the inner denominator the domain-correct subset (e.g., dismissals for batting average), not the easy column (matches played)?
+- [ ] Pick one outer group, hand-compute both forms on its members, and confirm your SQL produces the avg-of-avgs value, not the pooled value.

--- a/benchmark/skills/calendar-decomposition-vs-component-subtract/SKILL.md
+++ b/benchmark/skills/calendar-decomposition-vs-component-subtract/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: calendar-decomposition-vs-component-subtract
+description: "Use this skill whenever the question asks for the difference between two dates expressed as years, months, AND days (or any combination of two or more units). Component-wise subtraction (year-of-end minus year-of-start, etc.) silently overestimates the span when the smaller component is negative. The correct interpretation is calendar age decomposition (full years, then residual months, then residual days)."
+type: skill
+---
+
+# Calendar-Decomposition Skill
+
+## When this skill applies
+
+Any question that asks for the time between two dates broken into more than one unit:
+- "the difference in years, months, and days between debut and last game"
+- "tenure as years and months"
+- "age in years and days"
+- "a span of Y years M months D days"
+- a formula like `years + months/12 + days/365`
+
+Also: any time the answer requires *combining* multiple unit-differences into a single number (e.g. fractional years).
+
+## The trap
+
+The natural-feeling SQL — subtract each unit independently and sum — gives the wrong answer whenever the smaller-unit component is negative:
+
+```sql
+-- WRONG: independent component subtraction
+strftime('%Y', end) - strftime('%Y', start)  AS y_diff
+strftime('%m', end) - strftime('%m', start)  AS m_diff
+strftime('%d', end) - strftime('%d', start)  AS d_diff
+-- then ABS each and sum (or sum and ABS)
+ABS(y_diff) + ABS(m_diff)/12.0 + ABS(d_diff)/365.0
+```
+
+For start=2001-09-10, end=2006-04-13:
+- Calendar truth: 4 years, 7 months, 3 days → 4 + 7/12 + 3/365 ≈ **4.59**
+- Component subtraction with ABS: |5| + |−5|/12 + |3|/365 ≈ **5.42** ← off by ~18 %
+
+The error compounds across the dataset and turns a passing answer into a failing one.
+
+## What "calendar decomposition" means
+
+Subtract whole calendar units, in order from largest to smallest, borrowing from the next unit when residual would be negative — exactly how you'd say "I am 27 years, 4 months, and 12 days old." Most dialects expose this directly:
+
+| Dialect | Native form |
+|---|---|
+| PostgreSQL | `age(end, start)` returns an interval, then `EXTRACT(year/month/day FROM …)` |
+| BigQuery | `DATE_DIFF` / `DATETIME_DIFF` per unit, then handle borrow manually |
+| Snowflake | `DATEDIFF('year', start, end)` then adjust for partial year |
+| SQLite | no native `age()` — see SQL pattern below |
+| DuckDB | `age(end, start)` returns an interval (matches PostgreSQL) |
+
+## SQL pattern — portable, no `age()` required
+
+The trick: compute total days, then derive years and months by date-arithmetic borrowing.
+
+```sql
+-- Calendar decomposition: full years, residual months, residual days.
+-- Works in any dialect with date math + day-add.
+
+WITH inputs AS (
+  SELECT
+    start_date,
+    end_date,
+    -- A) full calendar years between dates
+    CAST(strftime('%Y', end_date) AS INT) - CAST(strftime('%Y', start_date) AS INT)
+      - CASE
+          WHEN strftime('%m-%d', end_date) < strftime('%m-%d', start_date)
+          THEN 1 ELSE 0
+        END AS full_years
+  FROM source
+),
+after_year AS (
+  SELECT
+    start_date, end_date, full_years,
+    -- advance start_date by full_years to remove the year component
+    date(start_date, '+' || full_years || ' years') AS start_plus_y
+  FROM inputs
+),
+after_month AS (
+  SELECT
+    start_date, end_date, full_years, start_plus_y,
+    -- B) full residual months
+    CAST(strftime('%Y', end_date) AS INT) * 12 + CAST(strftime('%m', end_date) AS INT)
+    - CAST(strftime('%Y', start_plus_y) AS INT) * 12 - CAST(strftime('%m', start_plus_y) AS INT)
+    - CASE
+        WHEN CAST(strftime('%d', end_date) AS INT) < CAST(strftime('%d', start_plus_y) AS INT)
+        THEN 1 ELSE 0
+      END AS residual_months
+  FROM after_year
+)
+SELECT
+  full_years,
+  residual_months,
+  -- C) residual days
+  CAST(julianday(end_date)
+       - julianday(date(start_plus_y, '+' || residual_months || ' months'))
+       AS INT) AS residual_days
+FROM after_month;
+```
+
+Then assemble per the question's formula:
+```sql
+full_years + residual_months / 12.0 + residual_days / 365.0
+```
+
+## Sanity-check before committing
+
+Pick three start/end pairs by hand and verify:
+
+1. **A pair that does NOT cross a unit boundary** (Jan 15 2010 → Mar 20 2015):
+   - Expected: 5 years, 2 months, 5 days. Component subtraction gives the same answer here, so this case alone tells you nothing — keep going.
+
+2. **A pair where the day component is negative** (Sep 10 2001 → Apr 13 2006):
+   - Expected: 4 years, 7 months, 3 days. Component subtraction gives 5y −5m 3d which, after `ABS`, becomes 5y 5m 3d — visibly wrong.
+
+3. **A pair where the month component is negative** (Nov 10 2010 → Mar 5 2015):
+   - Expected: 4 years, 3 months, 25 days. Component subtraction gives 5y −8m −5d.
+
+If your SQL produces the calendar values for cases 2 and 3 (not the component-subtraction values), it is correct.
+
+## Anti-pattern (this is what fails)
+
+```sql
+ABS(year_diff) + ABS(month_diff)/12.0 + ABS(day_diff)/365.0
+```
+
+Each `ABS` independently strips the sign, so a negative residual that should reduce the count instead inflates it. Even before the `ABS`, summing signed components is fragile — the residual can leak past unit boundaries.
+
+## Verification before saving
+
+- [ ] Does the SQL borrow across boundaries (i.e., reduce years by 1 when end-month < start-month)?
+- [ ] On a hand-picked boundary-crossing date pair, does your output match the calendar answer (not the component-subtract answer)?
+- [ ] If your dialect has `age()` or an equivalent, are you using it instead of reimplementing?

--- a/benchmark/skills/modifier-bound-date-column/SKILL.md
+++ b/benchmark/skills/modifier-bound-date-column/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: modifier-bound-date-column
+description: "Use this skill when the question pairs a state modifier ('delivered', 'shipped', 'completed', 'cancelled', 'paid', 'refunded', 'approved', 'fulfilled') with a temporal grouping ('per month', 'in 2018', 'monthly volume', 'by quarter'). The date column to bucket on is the state-transition timestamp for that modifier (order_delivered_customer_date), not the generic creation timestamp (order_purchase_timestamp). Picking the wrong date column shifts entire month-buckets and silently fails."
+type: skill
+---
+
+# Modifier-Bound Date Column Skill
+
+## When this skill applies
+
+The question contains BOTH:
+1. A state modifier on the entity being counted/measured: delivered, shipped, completed, cancelled, refunded, paid, approved, fulfilled, returned, signed, expired, granted, deployed
+2. A temporal grouping or filter: "per month", "in 2018", "monthly volume", "by quarter", "by year", "in Q3"
+
+Examples:
+- "How many **delivered orders** are there **per month** in 2018?"
+- "**Cancelled** orders **by quarter**"
+- "**Paid** invoices **in 2017**"
+- "Highest **shipped** volume **per month**"
+
+## What goes wrong
+
+There are typically two date columns in the same table:
+- A generic creation/intake timestamp (`order_purchase_timestamp`, `created_at`, `signed_up_at`) that always exists for every row
+- One or more state-transition timestamps (`order_delivered_customer_date`, `shipped_at`, `paid_at`) that only populate when the entity reaches that state
+
+When the question asks for "**delivered** orders **per month**", grouping by `order_purchase_timestamp` answers a different question:
+
+> "Of the orders that were eventually delivered, how many were *placed* in each month?"
+
+That is not the same as:
+
+> "How many orders *reached delivered status* in each month?"
+
+The first counts orders by their birth month. The second counts state transitions in each month. Both contain the same total over the full lifetime, but their per-month distributions are dramatically different — purchases lead deliveries by days to weeks.
+
+## Concrete example (real schema)
+
+For a single 2016 month — same `order_status='delivered'` filter, only the date column differs:
+
+| Bucketing column | 2016-09 | 2016-10 | 2016-11 | 2016-12 |
+|---|---|---|---|---|
+| `order_purchase_timestamp` | 1 | 265 | 0 | 1 |
+| `order_delivered_customer_date` | 0 | 205 | 58 | 4 |
+
+The October row alone differs by 60 — enough to flip "highest monthly volume" answers. Same data, same status filter, different date column → different answer.
+
+## Procedure
+
+1. **Read the question and write down two things separately**:
+   - The state modifier: `delivered`
+   - The temporal grouping: `per month`
+
+2. **Probe the schema for date columns on the entity table** — there are usually several:
+   ```sql
+   PRAGMA table_info(orders);   -- SQLite
+   -- or
+   SELECT column_name FROM information_schema.columns
+   WHERE table_name = 'orders' AND data_type IN ('timestamp', 'date');
+   ```
+
+3. **Identify the date column that corresponds to the modifier**, by name match:
+
+   | Modifier in question | Likely date column |
+   |---|---|
+   | delivered | order_delivered_customer_date / delivered_at / shipped_received_at |
+   | shipped | order_delivered_carrier_date / shipped_at |
+   | paid | paid_at / payment_date |
+   | cancelled | cancelled_at / order_cancellation_date |
+   | refunded | refunded_at / refund_date |
+   | approved | approved_at / approval_date |
+   | completed | completed_at / closed_at |
+   | signed up / registered | created_at / registered_at |
+
+4. **Use that column for the temporal grouping**:
+   ```sql
+   SELECT strftime('%Y-%m', order_delivered_customer_date) AS ym, COUNT(*)
+   FROM orders
+   WHERE order_status = 'delivered'
+     AND order_delivered_customer_date IS NOT NULL
+     AND strftime('%Y', order_delivered_customer_date) = '2018'
+   GROUP BY ym
+   ```
+
+   Notes:
+   - Filter on the SAME date column you GROUP BY for the year predicate (`strftime('%Y', order_delivered_customer_date) = '2018'`), not on `order_purchase_timestamp`.
+   - Add `IS NOT NULL` — state-transition columns are NULL for rows that never reached that state.
+
+5. **Sanity-check by running BOTH bucketings side-by-side** and confirming they differ as expected — see the procedure above. If the results are identical, the schema may have only one date column and there is nothing to choose; otherwise the difference confirms you picked correctly when it matches what the modifier semantically means.
+
+## Anti-patterns (these silently fail)
+
+**A. Generic timestamp + status filter**
+```sql
+-- WRONG: counts purchase events whose order eventually reached delivered status
+SELECT strftime('%Y-%m', order_purchase_timestamp), COUNT(*)
+FROM orders WHERE order_status = 'delivered'
+GROUP BY 1
+```
+
+**B. Year filter on one column, GROUP BY on another**
+```sql
+-- WRONG: 2018 boundary inconsistent — orders purchased Dec 2017 delivered Jan 2018 split incorrectly
+WHERE strftime('%Y', order_purchase_timestamp) = '2018'
+GROUP BY strftime('%Y-%m', order_delivered_customer_date)
+```
+
+**C. Forgetting `IS NOT NULL` on the state-transition column**
+State-transition columns are NULL for rows that haven't reached that state. Without `IS NOT NULL`, NULL becomes its own bucket and skews counts (or some dialects coerce it to a date sentinel).
+
+## Verification before saving
+
+- [ ] Does the date column you GROUP BY share a semantic with the modifier (delivered → delivered_at)?
+- [ ] Is the same column used in both the WHERE year/quarter filter and the GROUP BY?
+- [ ] Did you add `IS NOT NULL` on the state-transition column?
+- [ ] Have you confirmed by running both bucketings (purchase-based and delivered-based) that they differ — and your numbers match the *modifier's* bucketing?

--- a/benchmark/skills/output-column-spec/SKILL.md
+++ b/benchmark/skills/output-column-spec/SKILL.md
@@ -61,6 +61,22 @@ If the metric has a qualifier in the question, the qualifier MUST be in the colu
 - "highest <unit>" → highest_<unit>
 - "best performing" → best_X
 
+### 3a. Trailing connectors attach an EXTRA metric (the second-metric trap)
+A small set of phrases attach a *second* metric onto a question that's already named one. Each one introduces an additional output column you must compute:
+
+- "**along with** their X" → add column for X
+- "**and (also) their** X" → add column for X
+- "**as well as** X" → add column for X
+- "**together with** X" → add column for X
+- "**including** X" → add column for X (when X is a metric, not a row filter)
+- "**plus** X" → add column for X
+- "**, showing** X" / "**, displaying** X" → add column for X
+- "**and provide** X" / "**and report** X" → add column for X
+
+These connectors are easy to miss because the sentence already has a primary metric and the second one feels like commentary. It isn't — it's a required column. The second metric usually has a *different formula* than the first (e.g., "top 5 X by avg runs per match, **along with their batting averages**" — `avg runs per match` and `batting average` are computed differently).
+
+When you see one of these connectors, treat what follows as a new line in the OUTPUT COLUMN SPEC, with its own semantic.
+
 ### 4. Time periods (when the question compares)
 If the question names two or more periods (e.g., "2019 and 2020", "before and after"):
 - Add a column for each period's value, named for the period:

--- a/benchmark/skills/qualifier-applies-everywhere/SKILL.md
+++ b/benchmark/skills/qualifier-applies-everywhere/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: qualifier-applies-everywhere
+description: "Use this skill when the question contains a population qualifier like 'considering only X', 'for X only', 'X customers', 'X orders' that the answer should respect. Ensures the qualifier filter is applied in EVERY CTE that contributes to the final population, not just the top-level WHERE — silent population drift is the most common cause of values that look right but miss tolerance."
+type: skill
+---
+
+# Qualifier-Applies-Everywhere Skill
+
+## When this skill applies
+
+The question contains a population-narrowing phrase the answer must respect:
+- "considering only delivered orders"
+- "for active customers"
+- "of completed transactions"
+- "shipped within 7 days"
+- "subscribers who have at least one purchase"
+- any "X orders / X users / X records" where X is an adjective (delivered, completed, qualified, primary)
+
+## What goes wrong
+
+The qualifier is applied to the LAST CTE (the one that names the metric) but not to upstream CTEs (the ones that compute scores, ranks, percentiles, or deduplications). Upstream CTEs see the un-filtered population, so:
+
+- Quintile / percentile cutpoints shift (NTILE uses a different ordering)
+- Rank windows include rows the answer should not see
+- Per-customer aggregations include orders that should be excluded
+- Recency / first / last calculations anchor on a row that should not exist
+
+The result is a value that *looks* close but lands a few percent off — outside the evaluator's tolerance, with no syntactic error to find.
+
+## Procedure
+
+1. **Read the question once and underline every adjective that narrows the population.** The most common are: delivered, shipped, completed, cancelled, refunded, active, paid, qualified, primary, validated, granted, finalized.
+
+2. **Write a one-line population predicate as a SQL comment, BEFORE writing CTEs**:
+   ```sql
+   -- POPULATION: WHERE order_status = 'delivered'
+   ```
+
+3. **For every CTE you write, the first thing that goes in the WHERE clause is the population predicate.** Not "I'll filter at the end" — at the top, every time:
+
+   ```sql
+   WITH RecencyScore AS (
+     SELECT customer_id, NTILE(5) OVER (ORDER BY MAX(ts) DESC) AS r
+     FROM orders
+     WHERE order_status = 'delivered'   -- POPULATION
+     GROUP BY customer_id
+   ),
+   FrequencyScore AS (
+     SELECT customer_id, NTILE(5) OVER (ORDER BY COUNT(*) DESC) AS f
+     FROM orders
+     WHERE order_status = 'delivered'   -- POPULATION (same predicate)
+     GROUP BY customer_id
+   ),
+   MonetaryScore AS (
+     SELECT customer_id, NTILE(5) OVER (ORDER BY SUM(price) DESC) AS m
+     FROM orders JOIN order_items USING (order_id)
+     WHERE order_status = 'delivered'   -- POPULATION (same predicate)
+     GROUP BY customer_id
+   )
+   ```
+
+4. **If you factor the predicate into a base CTE that every other CTE reads from, the predicate only needs to live in one place** — but every downstream CTE must read from that base, not from the raw table:
+   ```sql
+   WITH base AS (
+     SELECT * FROM orders WHERE order_status = 'delivered'
+   ),
+   recency AS (SELECT ... FROM base GROUP BY customer_id),
+   frequency AS (SELECT ... FROM base GROUP BY customer_id)
+   ```
+   This is the safer pattern for multi-CTE pipelines.
+
+## Anti-patterns (these silently fail)
+
+**A. Filter only at the final aggregate**
+```sql
+-- WRONG: scores computed on full universe, filter applied last
+WITH scores AS (SELECT customer_id, NTILE(5) OVER (...) FROM orders ...)
+SELECT bucket, AVG(metric)
+FROM scores JOIN orders USING (customer_id)
+WHERE order_status = 'delivered'
+GROUP BY bucket
+```
+
+**B. Filter in some CTEs but not others**
+```sql
+-- WRONG: recency filtered, monetary not — scores shift relative to each other
+WITH recency AS (SELECT ... FROM orders WHERE order_status='delivered' ...),
+     monetary AS (SELECT ... FROM orders JOIN order_items ... GROUP BY customer_id)
+```
+
+**C. Filter at the JOIN to a dimension instead of the fact**
+```sql
+-- WRONG: dim CTE filters status, fact CTE doesn't
+WITH delivered_customers AS (SELECT DISTINCT customer_id FROM orders WHERE status='delivered')
+SELECT c.id, AVG(price) FROM customers c JOIN orders o ON ... JOIN delivered_customers dc ...
+```
+The fact aggregation still includes non-delivered orders for delivered customers.
+
+## Verification before saving
+
+- [ ] Does every CTE that touches the fact table carry the same population predicate (or read from a base CTE that does)?
+- [ ] If the question says "considering only X", grep your SQL for the predicate — is it in every CTE that GROUPs or RANKs or NTILEs the entity?
+- [ ] If you removed the population predicate from one CTE, would the row count change? If the answer is "I don't know," apply it.
+- [ ] Run the SQL with the predicate and without it; if the final values differ, that's expected — the predicate matters; do NOT submit the unfiltered version.


### PR DESCRIPTION
## Summary

Root-cause analysis of Spider2-lite local-db failing tasks. Four new workflow skills and two prompt changes targeting the most common agent failure modes.

**New skills:**
- `qualifier-applies-everywhere` — population qualifiers (`delivered`, `active`, etc.) must appear in every CTE, not just the final `WHERE`. Recommends a `base` CTE pattern.
- `calendar-decomposition-vs-component-subtract` — fixes the silent over-count from `ABS(year_diff) + ABS(month_diff)/12 + ABS(day_diff)/365` on boundary dates; provides portable SQLite calendar decomposition SQL.
- `modifier-bound-date-column` — when a state modifier (e.g. "delivered orders") pairs with temporal grouping, use the state-transition timestamp, not the creation timestamp. Includes a probing checklist.
- `avg-of-avgs-vs-pooled` — phrase decoder for two-level aggregation: "average of player averages" ≠ `SUM/COUNT`. Domain-specific denominator table included.

**Amended skill:**
- `output-column-spec` — §3a: trailing connectors ("along with their X", "and also their X", "as well as X", "including X", "plus X", "showing X") attach an *extra* metric column to the spec.

**Prompt changes (`sql_prompts.py`):**
- Step 0 "LOAD ALL RELEVANT SKILLS" block with explicit trigger-word → skill mapping table and strong mandatory language
- Verifier rules 21–23 covering the three new skill domains
- Fixed f-string crash: `{Gain, Loss, Amplification, Deletion}` set literal was unescaped, crashing every agent at init

**Runner (`sql_runner.py`):**
- Registered 4 new skills in `pattern_skills` tuple

## Benchmark result (full_local_v3, 135 tasks, concurrency 7)

- **PASS: 82** (58 new + 24 preserved SKIPs from prior run)
- **FAIL: 53** — of which ~20 are rate-limited (turns=1, hit API credit ceiling late in run)
- Genuine failures: ~33 tasks, covering complex multi-hop joins, ambiguous natural-language specs, and API-budget exhaustion

## Test plan
- [ ] Smoke-test: run one task end-to-end with `--task-ids local007`
- [ ] Confirm new skills load correctly (check `pattern_skills` registration)
- [ ] Run targeted retest on previously failing tasks once rate limits reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)