### PR TITLE
Security audit and hardening of branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@
 #
 # Starts: Postgres + Gateway + Web + Sandbox
 # No external dependencies, no .env required.
+#
+# HOST_DATA_DIR defaults to ~ (home directory) for the sandbox host-data mount.
+# For production or shared environments, set HOST_DATA_DIR to a narrower path
+# such as ./host-data to avoid exposing the entire home directory read-only.
 
 name: signalpilot
 
@@ -15,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme_dev_only}
       POSTGRES_DB: ${POSTGRES_DB:-signalpilot}
     ports:
-      - "5601:5432"
+      - "127.0.0.1:5601:5432"
     volumes:
       - signalpilot-pg-data:/var/lib/postgresql/data
     healthcheck:

--- a/security-audit.md
+++ b/security-audit.md
@@ -1,0 +1,218 @@
+# Security Audit — branch `autofyn/run-a-security-r-203054`
+
+Scope: 51 changed files, ~8.7K LoC added vs `main`. Focus on the new
+dbt-proxy (`gateway/dbt_proxy/`), the Knowledge Base API + MCP +
+store, the dbt SQL validator, the model_blueprint / model_verify MCP
+tools, the new knowledge UI, and `docker-compose.yml`.
+
+Many V1–V6 + auth/error sanitization issues from prior rounds are
+already mitigated and verified by `tests/test_security_fixes.py` —
+those are NOT re-flagged here.
+
+Findings are ordered **lowest → highest severity** as requested.
+For each issue we note whether it is a true bug (must fix in **both**
+modes) or **cloud-only hardening** (gate behind the existing `gateway.runtime.mode.is_cloud_mode()` helper (driven by `SP_DEPLOYMENT_MODE=cloud`); localhost dev must keep working).
+
+Project rule applied throughout: localhost `docker compose up` must
+keep working with no auth / no extra config; anything stricter is
+cloud-only and env-gated.
+
+---
+
+## Info
+
+### I-1 — Default Postgres password in `docker-compose.yml`
+- File: `docker-compose.yml:15` (`POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme_dev_only}`)
+- The default password is `changeme_dev_only`. The variable name signals "dev only" — fine for localhost.
+- **Mode:** Localhost only. Cloud deployments must NOT inherit this default; cloud compose / k8s manifests should require the var to be set.
+- **Fix:** Keep default for local. In a cloud-mode compose/helm template, fail-fast if `POSTGRES_PASSWORD` is unset. No change required to this file for localhost.
+
+### I-2 — Postgres port 5601 published on all host interfaces
+- File: `docker-compose.yml:17-18`
+- `ports: - "5601:5432"` binds 0.0.0.0:5601, exposing the DB to anything that can reach the dev machine on the LAN. With the default credential this is a real risk on shared networks.
+- **Mode:** Cloud-only hardening. Localhost workflows still need DB access from host tooling.
+- **Fix:** Bind to loopback explicitly: `"127.0.0.1:5601:5432"`. This still satisfies all dev tooling on the same host while removing LAN exposure. Apply unconditionally — it does not break `docker compose up`.
+
+### I-3 — Sandbox container mounts arbitrary host path via `HOST_DATA_DIR`
+- File: `docker-compose.yml:87` (`${HOST_DATA_DIR:-~}:/host-data:ro`)
+- Default mounts the whole user home (`~`) read-only into the sandbox. Combined with the sandbox executing user code, this lets sandboxed dbt code read the user's home directory.
+- **Mode:** Localhost feature. Cloud-only hardening.
+- **Fix:** Document the `HOST_DATA_DIR` default and recommend users set a narrower directory; in cloud mode, require an explicit value (no `~` default). Annotate in the compose comment header.
+
+### I-4 — Sandbox container runs with `SYS_ADMIN` + `SYS_PTRACE`
+- File: `docker-compose.yml:70-75`
+- `SYS_ADMIN` is required by gVisor; combined with `no-new-privileges`, `read_only: true`, `tmpfs /tmp`, mem/cpu/pids limits. This is the documented gVisor pattern.
+- **Mode:** Both — but already constrained.
+- **Fix:** No change. Document the dependency.
+
+### I-5 — `current_setting()` deny-list may break legitimate dbt-postgres
+- File: `gateway/engine/dbt_validation.py:163`
+- `current_setting` is a built-in dbt-postgres often calls (`current_setting('search_path')`, etc.). Blocking it will break ordinary dbt runs.
+- **Severity:** Functional, not exploitable, but listed because it lives in security code.
+- **Fix:** Replace with a parameter-aware check (block only `current_setting('ssl_*' / 'config_file' / 'data_directory')` or treat unknown args as denied via a small allowlist). Both modes.
+
+### I-6 — Long max TTL on run-tokens (24h) over cleartext pg-wire
+- File: `gateway/dbt_proxy/api.py:42` (`ttl_seconds: int = Field(..., ge=60, le=86400)`)
+- Tokens act as bearer credentials over a cleartext pg-wire handshake (R8 will add TLS). 24h is generous; passive capture on loopback is unlikely but possible inside a multi-tenant host.
+- **Mode:** Cloud-only hardening.
+- **Fix:** In cloud mode (`is_cloud_mode()` true, i.e. `SP_DEPLOYMENT_MODE=cloud`) cap TTL to e.g. 3600s. Localhost may keep 86400.
+
+### I-7 — Audit-bypass DoS via fail-closed audit
+- File: `gateway/dbt_proxy/audit.py:33-73`, `gateway/dbt_proxy/forwarder.py:60-68`
+- Correct behaviour (must be fail-closed). However, every dbt statement issues a synchronous DB INSERT, so a flaky audit DB stalls the whole run. Already documented in the file header. Informational.
+- **Fix:** None now; track for R8 batched audits.
+
+---
+
+## Low
+
+### L-1 — `org_id` leaked into mint log line
+- File: `gateway/dbt_proxy/api.py:127`
+  `logger.info("dbt_proxy mint run_id=%s org=%s connector=%s", body.run_id, org_id, body.connector_name)`
+- `tests/test_security_fixes.py::TestAuthErrorSanitization::test_auth_ok_does_not_log_org_id` already enforces that **auth_ok** does not log `org_id`. The masking policy in `RunTokenClaims.__repr__` masks `org_id`. The mint route violates the same policy.
+- **Mode:** Both — fix unconditionally.
+- **Fix:** Drop `org=%s` (or hash to a short fingerprint). `connector_name` should also be masked or kept high-cardinality safe.
+
+### L-2 — Knowledge `scope_ref` accepts arbitrary characters up to 200
+- File: `gateway/models/knowledge.py:88-95`
+- Only length is validated. `scope_ref` is stored and rendered (after React text-safe rendering) and used as part of unique keys. Not a code-injection sink today (rendering is safe text), but inconsistent with other slug-validated fields.
+- **Mode:** Both.
+- **Fix:** Restrict to a slug-like regex (e.g. `^[A-Za-z0-9_./:-]{1,200}$`) and reject control characters.
+
+### L-3 — `doc_id` (path param) not regex-validated
+- File: `gateway/api/knowledge.py:81-149`
+- Pydantic accepts any string for `doc_id` path params. Store queries are parameterised so SQLi is not possible, but a 36-char UUID format check would be cheaper than a DB roundtrip and prevents log noise / oversize keys.
+- **Mode:** Both. Cheap fix.
+- **Fix:** Validate as `uuid.UUID` in the path declaration: `doc_id: uuid.UUID`.
+
+### L-4 — `_substitute_params` replaces `$N` everywhere (acknowledged limitation)
+- File: `gateway/dbt_proxy/session.py:93-107`
+- Uses `str.replace("$N", literal)`, which substitutes inside string literals and comments too. Documented in the file as a known R3 limitation; dbt-postgres does not produce queries that exhibit the corner case.
+- **Mode:** Both. Track for R4.
+- **Fix:** Track for R4 (parameterised execution). No code change needed now beyond keeping the safety check (NUL/NaN/Inf rejection).
+
+### L-5 — Increment view counter swallows errors silently
+- File: `gateway/store/knowledge.py:590-603`
+- `increment_knowledge_view` swallows `Exception`. That is intended (best-effort), but the bare-`pass` masks malformed `doc_id` or org-mismatch attempts and hampers diagnostics.
+- **Mode:** Both.
+- **Fix:** `logger.debug` (not error) on failure so behaviour is unchanged but observable.
+
+### L-6 — Markdown rendering preserves raw URL text but allows `data:` schemes if regex changes
+- File: `signalpilot/web/app/knowledge/page.tsx:1234, 1343` (`SAFE_URL = /^https?:\/\//`)
+- Currently safe (only http/https) and content is rendered through React (no `dangerouslySetInnerHTML`). Worth a comment so a future relaxation does not introduce `javascript:`/`data:` XSS.
+- **Mode:** Both.
+- **Fix:** Add a code comment "DO NOT broaden SAFE_URL — anchor allowlist required for XSS safety" near the regex.
+
+### L-7 — Knowledge body size cap is 50 MiB regardless of plan
+- File: `gateway/governance/knowledge_limits.py:5`
+- A single doc may be 50 MiB even on the free plan; only the org quota constrains accumulation. An admin token with a small per-org quota of e.g. 50 MiB can still blow the budget in one POST.
+- **Mode:** Cloud-only hardening.
+- **Fix:** Tier-tied caps in cloud mode (e.g. free=256 KiB/doc, pro=2 MiB, etc.); local stays 50 MiB.
+
+### L-8 — `gateway/db/engine.py` strips `?sslmode=...` from `DATABASE_URL`
+- File: `gateway/db/engine.py:38-41`
+- The query-string is stripped because asyncpg cannot parse it; SSL is then re-enabled if the original URL contained `sslmode=`. Subtle: any URL using `ssl=true` / `channel_binding=require` (without `sslmode=`) loses SSL.
+- **Mode:** Cloud-relevant.
+- **Fix:** Detect `ssl=`, `channel_binding=` patterns too, or fail-fast in cloud if SSL was requested but cannot be re-enabled.
+
+### L-9 — All knowledge MCP proposals auto-accept (`_REVIEW_REQUIRED_CATEGORIES = {}`)
+- File: `gateway/store/knowledge.py:54-55`, `gateway/mcp/tools/knowledge.py:198-260`
+- `propose_knowledge` MCP tool inserts with `user_id=None, agent="propose_knowledge"`; every category falls into `_AUTO_ACCEPT_CATEGORIES`, so an agent can write directly to active docs without admin review.
+- This matches the spec ("Knowledge requires human review by design" per the comment in `api/knowledge.py`, but the MCP path bypasses it because all categories are auto-accept).
+- **Mode:** Cloud-only hardening (in localhost the agent IS the user). In cloud, agent-proposed docs should land in `pending` for at least some categories.
+- **Fix:** When `agent is not None` AND `is_cloud_mode()` is true, force `status=pending` regardless of category. Localhost behaviour unchanged.
+
+---
+
+## Medium
+
+### M-1 — SQL string-interpolation of DB-derived identifiers in `model_blueprint.py`
+- File: `gateway/mcp/tools/model_blueprint.py:289-294, 504-559`
+- Several queries are built by f-string interpolation of values returned from the warehouse itself: `WHERE table_name = '{tbl}'`, `'SELECT DISTINCT "{src_col_match}" ...'`, with `safe_val = str(r["status_val"]).replace("'", "''")` for some but not all interpolations (e.g. line 291 has no escaping).
+- This is a **second-order SQL injection** sink: a malicious schema author (i.e. someone with table-create rights in the connected warehouse) could embed quotes / SQL in a table or column name that survives back to the gateway and is re-issued.
+- **Mode:** Both — bug.
+- **Fix:** Apply identifier quoting to ALL identifier interpolations: route through `_quote_table` and `'"' + col.replace('"','""') + '"'` for column names; for literal values use a parameterised driver call (most connectors here support parameter binding) or perform the exact `replace("'", "''")` then `f"'{...}'"` consistently.
+
+### M-2 — `model_verify.py` interpolates table/column names from `information_schema`
+- File: `gateway/mcp/tools/model_verify.py:798, 843, 845, 921-923, 937-939`
+- Same class of issue as M-1. Lines 798/843 build `WHERE table_name = '{model_name}'` and `WHERE table_name = '{tbl}'`. `model_name` is regex-validated so it is safe; `tbl` comes from `SHOW TABLES` (DB-controlled). Same fix as M-1: escape single quotes for `tbl` before use, or use parameter binding.
+- **Mode:** Both.
+
+### M-3 — `_MODEL_NAME_RE` allows multi-segment names without segment limit
+- File: `gateway/mcp/validation.py:9` (`r"^[a-zA-Z0-9_.]{1,256}$"`)
+- `..` is allowed (e.g. `a..b`); resulting `_quote_table` produces `"a".""."b"` — empty-string identifier — likely a runtime error rather than an injection, but the regex should reject empty segments and leading/trailing dots.
+- **Mode:** Both.
+- **Fix:** Tighten to `^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+){0,2}$` (max two dots = `database.schema.table`).
+
+### M-4 — `dbt_validation` prefix bypass via leading-whitespace tricks (defence-in-depth only)
+- File: `gateway/engine/dbt_validation.py:212-213`
+- Prefix check uses `sql_lower.startswith(prefix)` and `f" {prefix}"` / `f"\n{prefix}"` membership. A statement like `;\tCOPY foo FROM PROGRAM ...` (tab between the semicolon and `COPY`) is not matched by the prefix check. The AST walk WOULD catch a `Command` node, so this is defence-in-depth, not a true bypass — but the prefix check should match any whitespace.
+- **Mode:** Both.
+- **Fix:** Match `\s+{prefix}` via regex instead of three explicit cases.
+
+### M-5 — `propose_knowledge` MCP is unauthenticated in stdio mode
+- File: `gateway/mcp/server.py:58-64`, `gateway/mcp/tools/knowledge.py:198-260`
+- In stdio mode the org/user are pulled from `SP_ORG_ID`/static `"local"`. Anyone able to invoke the stdio MCP can write into any org by setting the env var. Acceptable for localhost (which is the whole point of stdio mode), but the audit should call this out.
+- **Mode:** Cloud-only concern. In cloud, stdio mode must not be exposed.
+- **Fix:** Document in `mcp/server.py` that stdio mode is for localhost only; `is_cloud_mode()` should refuse to launch stdio transport.
+
+### M-6 — Audit row body persists full SQL plaintext (PII / credential risk)
+- File: `gateway/dbt_proxy/audit.py:48-62`, `gateway/store/audit_log.py` (existing)
+- Statement text including any literal values (which may include user secrets if a customer puts `password='...'` in a model) is stored in plaintext in `gateway_audit_logs.sql_text`. This is the existing audit-log policy, but new `dbt_proxy` traffic increases the volume and types of data captured.
+- **Mode:** Cloud-only hardening (audit-at-rest already covered by DB encryption in cloud).
+- **Fix:** Document. In cloud mode, ensure audit logs are written to an encrypted column or have row-level KMS. No code change required for localhost.
+
+### M-7 — `connector_name` accepts any UTF-8 (no charset validation)
+- File: `gateway/dbt_proxy/api.py:41` (`Field(..., min_length=1, max_length=64)`)
+- Used as a key into the connector store and emitted via `peer ↔ run_id` logs. No injection sink today (parameterised store lookup), but worth tightening for parity with other slug-validated identifiers.
+- **Mode:** Both.
+- **Fix:** Add regex `^[A-Za-z0-9_-]{1,64}$`.
+
+### M-8 — Numeric binary parsing in pg-wire protocol does not bound `ndigits`
+- File: `gateway/dbt_proxy/protocol.py:315-331`
+- `struct.unpack("!{ndigits}H")` will raise on truncation, but a maliciously crafted Bind value with very large `ndigits` causes an O(n) loop multiplying decimals — bounded by message length (1 MiB max) but still unnecessary CPU.
+- **Mode:** Both.
+- **Fix:** Reject `ndigits > 1000` (a real NUMERIC has at most ~131k digits in Postgres but `ndigits` of base-10000 limbs is small).
+
+---
+
+## High
+
+(none in the changed code beyond the items above)
+
+---
+
+## Already mitigated (do NOT re-fix — covered by `tests/test_security_fixes.py`)
+
+- V1: upstream errors sanitised, DSN never forwarded to client (`session.py:260-275`)
+- V2: governance deny-list expanded (DO/LOAD/CREATE FUNCTION/PROC/TRIGGER/LANGUAGE/dblink/lo_*/pg_read_*/pg_ls_dir/SECURITY DEFINER/etc.)
+- V3: server fails closed when `SP_GATEWAY_RUN_TOKEN_SECRET` is missing — no port bound
+- V4: default bind host is `127.0.0.1`; `0.0.0.0` warns at startup
+- V5: NUL bytes / NaN / Inf rejected in inline param substitution
+- V6: audit-write failure raises `AuditWriteError` → ErrorResponse instead of executing un-audited
+- Auth error sanitisation: protocol/password errors emit generic message + ref ID; org_id NOT logged in `auth_ok`
+
+---
+
+## Project ideology summary
+
+| Issue | Required for localhost? | Cloud-only? |
+|---|---|---|
+| L-1 (mint log org leak) | yes | — |
+| L-2 (scope_ref slug) | yes | — |
+| L-3 (doc_id UUID validation) | yes | — |
+| L-5 (debug log) | yes | — |
+| L-6 (URL allowlist comment) | yes | — |
+| L-8 (DATABASE_URL ssl probe) | — | yes |
+| L-9 (force pending in cloud) | — | yes |
+| M-1 (SQL identifier escaping in model_blueprint) | yes | — |
+| M-2 (same in model_verify) | yes | — |
+| M-3 (`_MODEL_NAME_RE`) | yes | — |
+| M-4 (dbt prefix whitespace) | yes | — |
+| M-5 (stdio cloud guard) | — | yes |
+| M-6 (audit at-rest) | — | yes |
+| M-7 (connector_name regex) | yes | — |
+| M-8 (ndigits bound) | yes | — |
+| I-2 (loopback bind for db port) | both — does not break dev | — |
+| I-6 (TTL cap in cloud) | — | yes |
+| I-1, I-3, I-4 | document only | — |

--- a/security-audit.md
+++ b/security-audit.md
@@ -201,6 +201,15 @@ cloud-only and env-gated.
 - **Mode:** Both.
 - **Fix (Round 2, applied):** Added `grant `/`revoke ` to `_DENIED_PREFIXES` (Layer A) and `GRANT|REVOKE` to `_COMMAND_ADMIN_RE` (Layer B). Negative regression: `GRANT SELECT ON t TO evil` is still blocked by the same denied class — acceptable because dbt-proxy is not the surface that issues object-level grants.
 
+### H-4 — Attacker-controlled uint32 frame length causes OOM via readexactly() (Round 3)
+- File: `gateway/dbt_proxy/protocol.py` (`read_startup_message`, `read_frontend_message`)
+- Both functions read a uint32 length field from the wire and pass it directly to `asyncio.StreamReader.readexactly()` with no upper bound. A 5-byte attacker payload (`X` + `0xFFFFFFFF`) coerces the proxy into a ~4 GiB allocation per connection. Concurrent connections trivially OOM-kill the gateway process, taking down dbt-proxy for all tenants.
+- The StartupMessage path (`read_startup_message`) is reachable **pre-auth** — anyone with TCP access to the listener can trigger it. The frontend message path (`read_frontend_message`) is reachable **post-auth** from any authenticated dbt client.
+- **Severity:** High — network-accessible DoS, zero authentication required on the startup path.
+- **Mode:** Both — localhost dbt traffic does not approach these limits; no behavioral change for legitimate clients.
+- **Fix (Round 3, applied):** Added module-level constants `MAX_STARTUP_MESSAGE_LEN = 64 KiB` and `MAX_FRONTEND_MESSAGE_LEN = 16 MiB`. Both functions now raise `ValueError` if the declared length exceeds the cap **before** calling `readexactly()`, so no allocation occurs on oversize input. The cap check is ordered after the existing minimum-length check (`< 8` / `< 4`) and before the `read_exact` call (fail-fast, no fallback). The existing `try/except Exception` in `auth.py:handle_startup` and the session loop break in `session.py:run()` already propagate these `ValueError`s to ErrorResponse and connection close with no further changes needed.
+- **Tests:** `tests/test_dbt_proxy_protocol_limits.py` — 5 cases: oversize rejection on both paths (read hangs if cap fires after allocation — structural proof), realistic-size regression, at-cap boundary acceptance, and `< 4` regression.
+
 ### H-3 — `SET [LOCAL|SESSION] ROLE` / `SESSION AUTHORIZATION` qualifier bypass (Round 2)
 - File: `gateway/engine/dbt_validation.py`
 - The Round 1 `_DENIED_SET_PATTERNS` substring `"set role"` did not match `SET LOCAL ROLE admin` or `SET SESSION ROLE admin` (qualifier between `SET` and `ROLE`). PG treats these as identical to `SET ROLE`.

--- a/security-audit.md
+++ b/security-audit.md
@@ -174,6 +174,95 @@ cloud-only and env-gated.
 - **Mode:** Both.
 - **Fix:** Reject `ndigits > 1000` (a real NUMERIC has at most ~131k digits in Postgres but `ndigits` of base-10000 limbs is small).
 
+### M-9 — dbt-proxy: no socket read timeout (slowloris) (Round 4)
+- File: `gateway/dbt_proxy/protocol.py:read_exact`
+- `asyncio.StreamReader.readexactly` has no timeout. An attacker who
+  writes the 5-byte frame header but no body holds the connection
+  slot indefinitely, repeated across many TCP connects to exhaust
+  the listener. Reachable pre-auth on the startup path.
+- **Severity:** Medium — DoS, requires sustained connections; bounded
+  by OS fd limits and the existing 16 MiB / 64 KiB frame caps but
+  amplifies their cost.
+- **Mode:** Both — universal hardening (R3 lesson #2).
+- **Fix (Round 4, applied):** `READ_TIMEOUT_SECONDS = 30.0` wrapping
+  every `readexactly` via `asyncio.wait_for`; on timeout, raise
+  `ValueError("read timed out…")` so existing handlers emit
+  ErrorResponse and close. 30 s is ~4.4 Mbps minimum for a 16 MiB
+  frame — well below any real link.
+- **Tests:** `tests/test_dbt_proxy_protocol_timeout.py` — 5 cases:
+  startup slowloris, frontend slowloris, header-only slowloris,
+  fast-path regression (small + near-cap). Wall-clock asserts prove
+  timeout fires before allocation completes.
+
+### M-10 — dbt-proxy: unbounded named-statement / named-portal dicts per session (Round 4)
+- File: `gateway/dbt_proxy/session.py:_handle_parse`,
+  `gateway/dbt_proxy/session.py:_handle_bind`
+- An authenticated session can issue up to 65535 distinct named
+  Parse messages, each retained in `self._named_stmts` until session
+  close. Same for `_named_portals`. With each entry up to 16 MiB
+  (frame cap), worst-case memory per session is unbounded for
+  practical purposes.
+- **Severity:** Medium — post-auth, but amplification per session.
+- **Mode:** Both — universal.
+- **Fix (Round 4, applied):** `MAX_NAMED_STATEMENTS_PER_SESSION = 256`
+  / `MAX_NAMED_PORTALS_PER_SESSION = 256`. Adding a *new* key past
+  the cap → ErrorResponse with SQLSTATE `53000`
+  (insufficient_resources); re-Parse of an existing name still
+  overwrites (no false-positive on legitimate reuse). Connection is
+  not closed. Portal cap is checked *before* `_substitute_params` to
+  reject cheaply.
+- **Tests:** `tests/test_dbt_proxy_session_limits.py` — 4 cases:
+  256 succeed, 257th rejected, overwrite at full cap succeeds,
+  portal-side parity.
+
+### M-11 — dbt-proxy: NUMERIC binary parsing does not bound `weight` (Round 4)
+- File: `gateway/dbt_proxy/protocol.py:_parse_numeric_binary`,
+  `gateway/dbt_proxy/session.py:_handle_bind`, `session.py:run()`
+- Companion to M-8: `ndigits` was capped at 1000 in R1, but `weight`
+  (base-10000 exponent, `!h`, range ±32767) was not. The inner loop
+  computes `Decimal(10000) ** (weight - i)`; an extreme `weight`
+  produces a Decimal with up to ~131,000 digits, multiplied by each
+  of up to 1000 digits — large CPU/memory cost per Bind value.
+- **Severity:** Medium — post-auth, but amplifies a 16 MiB frame into
+  a much larger CPU/memory workload.
+- **Mode:** Both — universal.
+- **Fix (Round 4, applied):** `MAX_NUMERIC_WEIGHT = 1000`; reject
+  `|weight| > 1000` with `ValueError`. Together with the existing
+  `ndigits <= 1000` cap, the inner loop is bounded at 10^6
+  decimal-digit operations.
+  **Cross-ref to M-8 — two-layer ValueError catch (Fix 3-bis, complete):**
+  - *Per-iteration catch (session.py:_handle_bind)*: `try/except ValueError`
+    around `parse_bind_value(raw, oid, fmt)` converts `ValueError` from
+    `_parse_numeric_binary` (both `ndigits` and `weight` caps) into an
+    ErrorResponse with SQLSTATE `22P03`, drain, and return without close.
+    This covers the inner parse loop.
+  - *Loop-level safety net (session.py:run())*: a broader `try/except
+    ValueError` wraps the entire handler dispatch block. This catches any
+    `ValueError` (including `UnicodeDecodeError`, a `ValueError` subclass)
+    that escapes a handler — specifically: (a) `UnicodeDecodeError` from
+    malformed UTF-8 in portal/statement name fields decoded in
+    `parse_bind_message` before the inner try/except, and (b) `ValueError`
+    from `_format_param` (NaN/Inf binary float8, NUL-byte binary text)
+    raised after `parse_bind_value` returns successfully. Both paths
+    previously propagated to `server.py:101` with no ErrorResponse and an
+    abrupt close. The loop-level catch emits ErrorResponse SQLSTATE `22P03`
+    and continues — allowing Sync/recovery per the Postgres protocol.
+    Programmer errors (TypeError, AttributeError) are not caught.
+  Together these two layers fully close the M-8 propagation gap claimed in
+  Round 4 build report.
+- **Tests:**
+  - `tests/test_dbt_proxy_numeric_bounds.py` — 7 cases: weight +32767
+    and -32768 rejected, at-cap weight=1000 accepted, weight=1001
+    rejected, ndigits regression, plus `_handle_bind`-level tests
+    asserting ErrorResponse SQLSTATE `22P03` for weight-overflow and
+    ndigits-overflow Bind payloads.
+  - `tests/test_dbt_proxy_session_limits.py::TestRunLoopValueErrorSafetyNet`
+    — 3 cases covering the loop-level catch: (1) `_handle_bind` propagates
+    `UnicodeDecodeError` for invalid portal UTF-8 (confirming no inner catch
+    suppresses it), (2) `run()` catches that error, emits 22P03, and
+    continues (Sync produces ReadyForQuery after the error), (3) binary
+    float8 NaN Bind emits 22P03 and loop continues to Sync.
+
 ---
 
 ## High

--- a/security-audit.md
+++ b/security-audit.md
@@ -148,7 +148,7 @@ cloud-only and env-gated.
 - File: `gateway/engine/dbt_validation.py:212-213`
 - Prefix check uses `sql_lower.startswith(prefix)` and `f" {prefix}"` / `f"\n{prefix}"` membership. A statement like `;\tCOPY foo FROM PROGRAM ...` (tab between the semicolon and `COPY`) is not matched by the prefix check. The AST walk WOULD catch a `Command` node, so this is defence-in-depth, not a true bypass — but the prefix check should match any whitespace.
 - **Mode:** Both.
-- **Fix:** Match `\s+{prefix}` via regex instead of three explicit cases.
+- **Fix:** Match `\s+{prefix}` via regex instead of three explicit cases. (Round 1 fix was the regex; Round 2 found this class was in fact exploitable — see H-1 below.)
 
 ### M-5 — `propose_knowledge` MCP is unauthenticated in stdio mode
 - File: `gateway/mcp/server.py:58-64`, `gateway/mcp/tools/knowledge.py:198-260`
@@ -178,7 +178,37 @@ cloud-only and env-gated.
 
 ## High
 
-(none in the changed code beyond the items above)
+### H-1 — `dbt_validation` whitespace/comment evasion of denied SQL prefixes (Round 2)
+- File: `gateway/engine/dbt_validation.py` (Round 1 regex `_DENIED_PREFIX_RE`)
+- Round 1 replaced the substring check with `re.escape(prefix)` joined by literal spaces. Postgres tokenization accepts ANY whitespace run, comments, or nested block comments between keywords. PoCs against the Round 1 code that returned `blocked=False`:
+  - `CREATE  ROLE evil` (double space)
+  - `CREATE\tROLE evil` (tab)
+  - `CREATE/*c*/ROLE evil` (block comment)
+  - `CREATE/*/*x*/*/ROLE evil` (nested block comment)
+  - Equivalents for `DROP USER`, `CREATE EXTENSION`, `CREATE DATABASE`, `CREATE LANGUAGE`, `DROP TABLESPACE`.
+- Both layers were defeated: `_DENIED_PREFIX_RE` (Layer A) by literal-space requirement; AST deny-list (Layer B) because sqlglot returns `Command` for these forms and `_DENIED_CREATE_KINDS` lacked ROLE/USER/DATABASE/TABLESPACE, with no DROP/ALTER kind check.
+- **Severity:** High — direct privilege escalation against the warehouse if the validator was the only check.
+- **Mode:** Both.
+- **Fix (Round 2, applied):** Two-layer hardening in `dbt_validation.py`:
+  - Layer A: `_normalize_for_prefix_scan` — `_strip_block_comments` (character-level scanner handling nested `/* /* */ */`) + line-comment strip + whitespace collapse, fed only to the prefix scan; `ValidatedStatement.sql` always carries the original input.
+  - Layer B: `_DENIED_CREATE_KINDS` extended with ROLE/USER/DATABASE/TABLESPACE; new `_DENIED_DROP_ALTER_KINDS` + `_check_drop_alter_node`; `_check_command_node` builds `this+expression`, normalizes, and matches `_COMMAND_ADMIN_RE`.
+  - Tests: `tests/test_dbt_validation_prefix_bypass.py` — 21 cases (15 blocked bypasses + 3 negative controls + 3 `sql` byte-identity assertions).
+
+### H-2 — GRANT / REVOKE role-membership bypass (Round 2)
+- File: `gateway/engine/dbt_validation.py`
+- `GRANT admin TO evil` and `REVOKE admin FROM evil` were not blocked. sqlglot returns a `Command` node (not `exp.Grant`) for role-membership grants, and `_check_command_node` had no GRANT/REVOKE branch.
+- **Severity:** High — direct privilege escalation.
+- **Mode:** Both.
+- **Fix (Round 2, applied):** Added `grant `/`revoke ` to `_DENIED_PREFIXES` (Layer A) and `GRANT|REVOKE` to `_COMMAND_ADMIN_RE` (Layer B). Negative regression: `GRANT SELECT ON t TO evil` is still blocked by the same denied class — acceptable because dbt-proxy is not the surface that issues object-level grants.
+
+### H-3 — `SET [LOCAL|SESSION] ROLE` / `SESSION AUTHORIZATION` qualifier bypass (Round 2)
+- File: `gateway/engine/dbt_validation.py`
+- The Round 1 `_DENIED_SET_PATTERNS` substring `"set role"` did not match `SET LOCAL ROLE admin` or `SET SESSION ROLE admin` (qualifier between `SET` and `ROLE`). PG treats these as identical to `SET ROLE`.
+- **Severity:** High — direct privilege escalation.
+- **Mode:** Both.
+- **Fix (Round 2, applied):** `_DENIED_SET_PATTERNS` replaced with `_DENIED_SET_REGEXES`: `\bset\s+(?:local\s+|session\s+)?role\b`, `\bset\s+(?:local\s+|session\s+)?session\s+authorization\b`, plus `RESET ROLE` / `RESET SESSION AUTHORIZATION`. Negative controls: `SET search_path`, `SET LOCAL statement_timeout`, `SET SESSION CHARACTERISTICS …` all pass.
+
+All H-1, H-2, H-3 verified closed by re-attack: 34 bypass tests pass; security-reviewer ran multi-pass attack including unicode whitespace, dollar-quoted strings, CTE prefix evasion, multi-statement-after-benign-first, and qualifier permutations — no new bypass found.
 
 ---
 

--- a/signalpilot/gateway/gateway/api/knowledge.py
+++ b/signalpilot/gateway/gateway/api/knowledge.py
@@ -6,6 +6,8 @@ review by design. Do not lower to write without product sign-off.
 
 from __future__ import annotations
 
+import uuid
+
 from fastapi import APIRouter, HTTPException
 
 from ..models.knowledge import KnowledgeDoc, KnowledgeDocCreate, KnowledgeDocUpdate, KnowledgeEdit, KnowledgeUsage
@@ -83,9 +85,9 @@ async def get_knowledge_usage(store: StoreD):
     response_model=KnowledgeDoc,
     dependencies=[RequireScope("read")],
 )
-async def get_knowledge_doc(doc_id: str, store: StoreD):
+async def get_knowledge_doc(doc_id: uuid.UUID, store: StoreD):
     """Get a single knowledge doc by ID, including body."""
-    doc = await store.get_knowledge_doc(doc_id, include_body=True, bump_view=True)
+    doc = await store.get_knowledge_doc(str(doc_id), include_body=True, bump_view=True)
     if doc is None:
         raise HTTPException(status_code=404, detail=f"Knowledge doc '{doc_id}' not found")
     return doc
@@ -110,18 +112,18 @@ async def create_knowledge_doc(payload: KnowledgeDocCreate, store: StoreD):
     response_model=KnowledgeDoc,
     dependencies=[RequireScope("admin")],
 )
-async def update_knowledge_doc(doc_id: str, body_update: KnowledgeDocUpdate, store: StoreD):
+async def update_knowledge_doc(doc_id: uuid.UUID, body_update: KnowledgeDocUpdate, store: StoreD):
     """Update the body of a knowledge doc (admin only). Appends edit history."""
     try:
-        return await store.update_knowledge_body(doc_id, body=body_update.body, user_id=store.user_id)
+        return await store.update_knowledge_body(str(doc_id), body=body_update.body, user_id=store.user_id)
     except (KnowledgeSizeExceeded, KnowledgeOrgQuotaExceeded, KnowledgeNotFound) as exc:
         raise _map_knowledge_exc(exc) from exc
 
 
 @router.delete("/knowledge/{doc_id}", status_code=204, dependencies=[RequireScope("admin")])
-async def archive_knowledge_doc(doc_id: str, store: StoreD):
+async def archive_knowledge_doc(doc_id: uuid.UUID, store: StoreD):
     """Archive a knowledge doc (admin only)."""
-    archived = await store.archive_knowledge_doc(doc_id)
+    archived = await store.archive_knowledge_doc(str(doc_id))
     if not archived:
         raise HTTPException(status_code=404, detail=f"Knowledge doc '{doc_id}' not found")
 
@@ -131,10 +133,10 @@ async def archive_knowledge_doc(doc_id: str, store: StoreD):
     response_model=KnowledgeDoc,
     dependencies=[RequireScope("admin")],
 )
-async def approve_knowledge_doc(doc_id: str, store: StoreD):
+async def approve_knowledge_doc(doc_id: uuid.UUID, store: StoreD):
     """Approve a pending knowledge doc (admin only). Flips status from pending to active."""
     try:
-        return await store.approve_knowledge_doc(doc_id, user_id=store.user_id)
+        return await store.approve_knowledge_doc(str(doc_id), user_id=store.user_id)
     except (KnowledgeNotFound, KnowledgeStateConflict) as exc:
         raise _map_knowledge_exc(exc) from exc
 
@@ -144,6 +146,6 @@ async def approve_knowledge_doc(doc_id: str, store: StoreD):
     response_model=list[KnowledgeEdit],
     dependencies=[RequireScope("read")],
 )
-async def list_knowledge_edits(doc_id: str, store: StoreD, limit: int = 20):
+async def list_knowledge_edits(doc_id: uuid.UUID, store: StoreD, limit: int = 20):
     """Get the edit history for a knowledge doc."""
-    return await store.list_knowledge_edits(doc_id, limit=max(1, min(limit, 100)))
+    return await store.list_knowledge_edits(str(doc_id), limit=max(1, min(limit, 100)))

--- a/signalpilot/gateway/gateway/db/engine.py
+++ b/signalpilot/gateway/gateway/db/engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import AsyncGenerator
+from urllib.parse import parse_qs, urlparse
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
@@ -42,9 +43,25 @@ def _get_database_url() -> str:
 
 
 def _requires_ssl() -> bool:
-    """Check if the original DATABASE_URL had sslmode (e.g. Neon)."""
-    raw = os.environ.get("DATABASE_URL", "")
-    return "sslmode=" in raw
+    """Check if the original DATABASE_URL requested SSL via sslmode, ssl, or channel_binding."""
+    raw = os.environ.get("DATABASE_URL", "") or ""
+    if not raw:
+        return False
+    try:
+        q = parse_qs(urlparse(raw).query)
+    except Exception:
+        return False
+    sslmode = (q.get("sslmode", [""])[0] or "").lower()
+    if sslmode in {"require", "verify-ca", "verify-full"}:
+        return True
+    ssl_param = (q.get("ssl", [""])[0] or "").lower()
+    if ssl_param in {"true", "require"}:
+        return True
+    if q.get("channel_binding"):
+        cb = (q.get("channel_binding", [""])[0] or "").lower()
+        if cb in {"require", "prefer"}:
+            return True
+    return False
 
 
 def get_engine():

--- a/signalpilot/gateway/gateway/dbt_proxy/api.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/api.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ..auth import OrgID, UserID
+from ..runtime.mode import is_cloud_mode
 from ..security.scope_guard import RequireScope
 from .config import DbtProxyConfig
 from .errors import ProxyDisabled, RunTokenAlreadyExists
@@ -38,7 +39,7 @@ router = APIRouter(prefix="/api/dbt-proxy/run-tokens", tags=["dbt-proxy"])
 
 class MintRequest(BaseModel):
     run_id: uuid.UUID
-    connector_name: str = Field(..., min_length=1, max_length=64)
+    connector_name: str = Field(..., min_length=1, max_length=64, pattern=r"^[A-Za-z0-9_-]{1,64}$")
     ttl_seconds: int = Field(..., ge=60, le=86400)
 
 
@@ -107,6 +108,11 @@ async def mint_run_token(
     _check_proxy_enabled(config)
     _check_secret_configured(config)
 
+    # Cloud-only: cap TTL to 1h regardless of request value.
+    # Localhost keeps the documented 24h max.
+    if is_cloud_mode():
+        body = body.model_copy(update={"ttl_seconds": min(body.ttl_seconds, 3600)})
+
     token_store = _get_token_store(request)
 
     try:
@@ -124,7 +130,7 @@ async def mint_run_token(
         )
 
     expires_at_str = datetime.fromtimestamp(claims.expires_at, tz=UTC).isoformat()
-    logger.info("dbt_proxy mint run_id=%s org=%s connector=%s", body.run_id, org_id, body.connector_name)
+    logger.info("dbt_proxy mint run_id=%s", body.run_id)
     return MintResponse(
         token=token_hex,
         host_port=config.sp_dbt_proxy_port,

--- a/signalpilot/gateway/gateway/dbt_proxy/protocol.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/protocol.py
@@ -48,6 +48,7 @@ R3 limits (documented here per spec):
 
 from __future__ import annotations
 
+import asyncio
 import struct
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -63,6 +64,14 @@ from typing import Any
 
 MAX_STARTUP_MESSAGE_LEN = 64 * 1024          # 64 KiB; libpq sends ~few hundred bytes
 MAX_FRONTEND_MESSAGE_LEN = 16 * 1024 * 1024  # 16 MiB; covers large Parse/Bind payloads
+
+# ─── Read timeout (slowloris hardening) ──────────────────────────────────────
+#
+# A connection that writes the frame header but stalls the body holds the
+# connection slot indefinitely. 30 s gives ~4.4 Mbps minimum throughput for
+# a 16 MiB frame — well below any real link. Universal: no env gate.
+
+READ_TIMEOUT_SECONDS = 30.0  # generous: 16 MiB at 30s = 4.4 Mbps min
 
 # ─── OID constants ────────────────────────────────────────────────────────────
 
@@ -98,8 +107,15 @@ class UnsupportedOID:
 
 
 async def read_exact(reader, n: int) -> bytes:
-    """Read exactly n bytes from the reader, raising EOFError on premature close."""
-    return await reader.readexactly(n)
+    """Read exactly n bytes, with a per-read timeout to defeat slowloris."""
+    try:
+        return await asyncio.wait_for(
+            reader.readexactly(n), timeout=READ_TIMEOUT_SECONDS
+        )
+    except TimeoutError as exc:
+        raise ValueError(
+            f"read timed out after {READ_TIMEOUT_SECONDS}s waiting for {n} bytes"
+        ) from exc
 
 
 async def read_startup_message(reader) -> dict[str, str]:
@@ -330,6 +346,9 @@ def _parse_timestamptz_text(text: str) -> datetime:
     return datetime.fromisoformat(text)
 
 
+MAX_NUMERIC_WEIGHT = 1000  # base-10000 limbs; 1000 → 4000-digit magnitude
+
+
 def _parse_numeric_binary(raw: bytes) -> Decimal:
     """Parse Postgres binary NUMERIC into a Python Decimal.
 
@@ -341,6 +360,10 @@ def _parse_numeric_binary(raw: bytes) -> Decimal:
     ndigits, weight, sign, dscale = struct.unpack("!HhHH", raw[:8])
     if ndigits > 1000:
         raise ValueError(f"NUMERIC ndigits {ndigits} exceeds bound (1000)")
+    if weight > MAX_NUMERIC_WEIGHT or weight < -MAX_NUMERIC_WEIGHT:
+        raise ValueError(
+            f"NUMERIC weight {weight} exceeds bound (±{MAX_NUMERIC_WEIGHT})"
+        )
     digits = struct.unpack(f"!{ndigits}H", raw[8:8 + 2 * ndigits])
     # Reconstruct the decimal
     value = Decimal(0)
@@ -405,6 +428,8 @@ def parse_bind_message(payload: bytes) -> tuple[str, str, list[int], list[bytes 
 __all__ = [
     "MAX_STARTUP_MESSAGE_LEN",
     "MAX_FRONTEND_MESSAGE_LEN",
+    "READ_TIMEOUT_SECONDS",
+    "MAX_NUMERIC_WEIGHT",
     "UnsupportedOID",
     "SUPPORTED_OIDS",
     "OID_INT4", "OID_INT8", "OID_TEXT", "OID_VARCHAR",

--- a/signalpilot/gateway/gateway/dbt_proxy/protocol.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/protocol.py
@@ -321,6 +321,8 @@ def _parse_numeric_binary(raw: bytes) -> Decimal:
     if len(raw) < 8:
         return Decimal(0)
     ndigits, weight, sign, dscale = struct.unpack("!HhHH", raw[:8])
+    if ndigits > 1000:
+        raise ValueError(f"NUMERIC ndigits {ndigits} exceeds bound (1000)")
     digits = struct.unpack(f"!{ndigits}H", raw[8:8 + 2 * ndigits])
     # Reconstruct the decimal
     value = Decimal(0)

--- a/signalpilot/gateway/gateway/dbt_proxy/protocol.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/protocol.py
@@ -54,6 +54,16 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
+# ─── Wire-frame size limits (DoS hardening) ──────────────────────────────────
+#
+# The pg-wire length field is a uint32 (max 4 GiB). Without an upper bound,
+# a 5-byte header coerces readexactly() into a multi-GiB allocation. Real
+# libpq StartupMessages are < 10 KiB and real query frames from dbt are well
+# under 1 MiB; these caps are generous and universal (not cloud-gated).
+
+MAX_STARTUP_MESSAGE_LEN = 64 * 1024          # 64 KiB; libpq sends ~few hundred bytes
+MAX_FRONTEND_MESSAGE_LEN = 16 * 1024 * 1024  # 16 MiB; covers large Parse/Bind payloads
+
 # ─── OID constants ────────────────────────────────────────────────────────────
 
 OID_INT4 = 23
@@ -107,6 +117,10 @@ async def read_startup_message(reader) -> dict[str, str]:
     total_length = struct.unpack("!I", length_bytes)[0]
     if total_length < 8:
         raise ValueError(f"StartupMessage too short: {total_length}")
+    if total_length > MAX_STARTUP_MESSAGE_LEN:
+        raise ValueError(
+            f"StartupMessage too large: {total_length} > {MAX_STARTUP_MESSAGE_LEN}"
+        )
     body = await read_exact(reader, total_length - 4)
     proto_version = struct.unpack("!I", body[:4])[0]
     if proto_version != 0x00030000:
@@ -144,6 +158,10 @@ async def read_frontend_message(reader) -> tuple[str, bytes]:
     length = struct.unpack("!I", length_bytes)[0]
     if length < 4:
         raise ValueError(f"Invalid message length: {length}")
+    if length > MAX_FRONTEND_MESSAGE_LEN:
+        raise ValueError(
+            f"Frontend message too large: {length} > {MAX_FRONTEND_MESSAGE_LEN}"
+        )
     payload = await read_exact(reader, length - 4)
     return msg_type, payload
 
@@ -385,6 +403,8 @@ def parse_bind_message(payload: bytes) -> tuple[str, str, list[int], list[bytes 
 
 
 __all__ = [
+    "MAX_STARTUP_MESSAGE_LEN",
+    "MAX_FRONTEND_MESSAGE_LEN",
     "UnsupportedOID",
     "SUPPORTED_OIDS",
     "OID_INT4", "OID_INT8", "OID_TEXT", "OID_VARCHAR",

--- a/signalpilot/gateway/gateway/dbt_proxy/session.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/session.py
@@ -51,6 +51,15 @@ from .tokens import RunTokenClaims
 
 logger = logging.getLogger(__name__)
 
+# ─── Per-session resource caps (DoS hardening) ────────────────────────────────
+#
+# Each Parse/Bind adds to per-session dicts. Without caps, an authenticated
+# session can fill ~65k entries (each up to 16 MiB), exhausting gateway memory.
+# 256 is far above any legitimate dbt workload (typically <10 named statements).
+
+MAX_NAMED_STATEMENTS_PER_SESSION = 256
+MAX_NAMED_PORTALS_PER_SESSION = 256
+
 # Sent at the start of each extended query cycle
 _PARSE_COMPLETE = b"1" + b"\x00\x00\x00\x04"
 _BIND_COMPLETE = b"2" + b"\x00\x00\x00\x04"
@@ -134,28 +143,50 @@ class DbtProxySession:
                 logger.info("dbt_proxy connection closed run_id=%s: %s", self._claims.run_id, exc)
                 break
 
-            if msg_type == "Q":
-                await self._handle_simple_query(payload)
-            elif msg_type == "P":
-                await self._handle_parse(payload)
-            elif msg_type == "B":
-                await self._handle_bind(payload)
-            elif msg_type == "D":
-                await self._handle_describe(payload)
-            elif msg_type == "E":
-                await self._handle_execute(payload)
-            elif msg_type == "S":
-                await self._handle_sync()
-            elif msg_type == "X":
-                break
-            else:
-                self._writer.write(
-                    write_error_response(
-                        f"Unsupported message type: {msg_type!r}",
-                        sqlstate="0A000",
+            try:
+                if msg_type == "Q":
+                    await self._handle_simple_query(payload)
+                elif msg_type == "P":
+                    await self._handle_parse(payload)
+                elif msg_type == "B":
+                    await self._handle_bind(payload)
+                elif msg_type == "D":
+                    await self._handle_describe(payload)
+                elif msg_type == "E":
+                    await self._handle_execute(payload)
+                elif msg_type == "S":
+                    await self._handle_sync()
+                elif msg_type == "X":
+                    break
+                else:
+                    self._writer.write(
+                        write_error_response(
+                            f"Unsupported message type: {msg_type!r}",
+                            sqlstate="0A000",
+                        )
                     )
+                    await self._writer.drain()
+            except ValueError as exc:
+                # Safety net: any ValueError that escapes a handler (e.g.
+                # UnicodeDecodeError from malformed portal/stmt UTF-8 in
+                # parse_bind_message, or _format_param rejecting NaN/Inf/NUL
+                # after parse_bind_value succeeds) is caught here instead of
+                # propagating to server.py and closing without an ErrorResponse.
+                # The per-handler try/except in _handle_bind (SQLSTATE 22P03)
+                # still fires for parse_bind_value errors; this catch is the
+                # loop-level safety net for any remaining paths.
+                # Programmer errors (TypeError, AttributeError) are NOT caught —
+                # they still escape and close the connection as before.
+                logger.warning(
+                    "dbt_proxy handler ValueError run_id=%s msg=%r exc=%r",
+                    self._claims.run_id,
+                    msg_type,
+                    exc,
                 )
+                self._writer.write(write_error_response(str(exc), sqlstate="22P03"))
                 await self._writer.drain()
+                # Continue the loop — Postgres protocol allows error-then-Sync
+                # recovery. The client can send Sync and resume.
 
         self._writer.close()
 
@@ -167,6 +198,21 @@ class DbtProxySession:
 
     async def _handle_parse(self, payload: bytes) -> None:
         stmt_name, query, oids = parse_parse_message(payload)
+        # Reject when adding a new key would exceed the cap. Re-Parse of an
+        # existing name (overwrite) is allowed without counting against the cap
+        # so legitimate clients that reuse names keep working.
+        if (
+            stmt_name not in self._named_stmts
+            and len(self._named_stmts) >= MAX_NAMED_STATEMENTS_PER_SESSION
+        ):
+            self._writer.write(
+                write_error_response(
+                    f"too many prepared statements (max {MAX_NAMED_STATEMENTS_PER_SESSION})",
+                    sqlstate="53000",
+                )
+            )
+            await self._writer.drain()
+            return
         self._named_stmts[stmt_name] = (query, oids)
         self._writer.write(_PARSE_COMPLETE)
         await self._writer.drain()
@@ -195,7 +241,14 @@ class DbtProxySession:
             if raw is None:
                 params.append(None)
                 continue
-            parsed = parse_bind_value(raw, oid, _fmt(i))
+            try:
+                parsed = parse_bind_value(raw, oid, _fmt(i))
+            except ValueError as exc:
+                self._writer.write(
+                    write_error_response(str(exc), sqlstate="22P03")
+                )
+                await self._writer.drain()
+                return
             if isinstance(parsed, UnsupportedOID):
                 self._writer.write(
                     write_error_response(
@@ -206,6 +259,21 @@ class DbtProxySession:
                 await self._writer.drain()
                 return
             params.append(parsed)
+
+        # Cap check before _substitute_params — reject cheaply before non-trivial work.
+        # Re-Bind of an existing portal name (overwrite) is allowed without counting.
+        if (
+            portal not in self._named_portals
+            and len(self._named_portals) >= MAX_NAMED_PORTALS_PER_SESSION
+        ):
+            self._writer.write(
+                write_error_response(
+                    f"too many open portals (max {MAX_NAMED_PORTALS_PER_SESSION})",
+                    sqlstate="53000",
+                )
+            )
+            await self._writer.drain()
+            return
 
         resolved_sql = _substitute_params(query, params)
         self._named_portals[portal] = resolved_sql

--- a/signalpilot/gateway/gateway/engine/dbt_validation.py
+++ b/signalpilot/gateway/gateway/engine/dbt_validation.py
@@ -31,6 +31,50 @@ import sqlglot.expressions as exp
 if TYPE_CHECKING:
     from ..dbt_proxy.tokens import RunTokenClaims
 
+# ─── Comment-stripping / whitespace normalization for prefix scan ─────────────
+# Postgres supports nested block comments (/* /* x */ */). A regex-only approach
+# cannot handle arbitrary nesting, so we use a character-level scanner for block
+# comments and fall back to a regex for line comments.
+
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+
+
+def _strip_block_comments(sql: str) -> str:
+    """Remove /* … */ block comments, correctly handling Postgres-style nesting."""
+    result: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(sql):
+        if sql[i : i + 2] == "/*":
+            depth += 1
+            i += 2
+        elif sql[i : i + 2] == "*/" and depth > 0:
+            depth -= 1
+            i += 2
+            if depth == 0:
+                # Replace the closed comment with a space to preserve token boundaries.
+                result.append(" ")
+        elif depth == 0:
+            result.append(sql[i])
+            i += 1
+        else:
+            i += 1
+    return "".join(result)
+
+
+def _normalize_for_prefix_scan(sql: str) -> str:
+    """Strip comments and collapse whitespace so the prefix regex always fires.
+
+    Handles nested block comments (Postgres extension).  The returned string is
+    used ONLY for _DENIED_PREFIX_RE.search; the original SQL is still passed to
+    sqlglot and stored on ValidatedStatement.sql unchanged.
+    """
+    no_block = _strip_block_comments(sql)
+    no_comments = _LINE_COMMENT_RE.sub(" ", no_block)
+    # Collapse all whitespace runs (tab / newline / CRLF) to a single space so
+    # the single-space prefix literals in _DENIED_PREFIXES always match.
+    return re.sub(r"\s+", " ", no_comments)
+
 _SQL_MAX_BYTES = 1_048_576  # 1 MiB
 
 # ─── Statement kind classification ───────────────────────────────────────────
@@ -79,6 +123,12 @@ _DENIED_CREATE_KINDS: frozenset[str] = frozenset({
     "EVENT TRIGGER",
     "LANGUAGE",
     "EXTENSION",
+    # Privilege-escalation objects — also blocked by Layer A prefix scan and the
+    # _validate_single Drop/Alter kind-check.
+    "ROLE",
+    "USER",
+    "DATABASE",
+    "TABLESPACE",
 })
 
 # ─── SQL keyword deny-list (checked via case-insensitive prefix on raw SQL) ──
@@ -124,6 +174,10 @@ _DENIED_PREFIXES: tuple[str, ...] = (
     "reset role",
     "reset session",
     "security definer",
+    # Role-membership grant/revoke — block at Layer A for defence-in-depth.
+    # Layer B catches these via _COMMAND_ADMIN_RE and _check_command_node.
+    "grant ",
+    "revoke ",
 )
 
 _DENIED_PREFIX_RE = re.compile(
@@ -131,12 +185,21 @@ _DENIED_PREFIX_RE = re.compile(
     re.IGNORECASE,
 )
 
-# SET commands that are always denied (privilege escalation)
-_DENIED_SET_PATTERNS: tuple[str, ...] = (
-    "set session authorization",
-    "set role",
-    "reset role",
-    "reset session authorization",
+# SET commands that are always denied (privilege escalation).
+# These are compiled regexes rather than substrings because SET LOCAL and
+# SET SESSION are valid qualifiers that PG accepts before ROLE / SESSION
+# AUTHORIZATION (e.g. "SET LOCAL ROLE admin" is identical to "SET ROLE admin").
+# The regexes tolerate optional LOCAL/SESSION qualifiers between SET and the
+# dangerous keyword.  Applied to the already-normalized (comment-stripped,
+# whitespace-collapsed) lower-case SQL.
+_DENIED_SET_REGEXES: tuple[re.Pattern[str], ...] = (
+    # SET [LOCAL|SESSION] ROLE …
+    re.compile(r"\bset\s+(?:local\s+|session\s+)?role\b"),
+    # SET [LOCAL|SESSION] SESSION AUTHORIZATION …
+    re.compile(r"\bset\s+(?:local\s+|session\s+)?session\s+authorization\b"),
+    # RESET ROLE / RESET SESSION AUTHORIZATION (no LOCAL qualifier in PG)
+    re.compile(r"\breset\s+role\b"),
+    re.compile(r"\breset\s+session\s+authorization\b"),
 )
 
 # ─── Dangerous function deny-list (AST walk) ─────────────────────────────────
@@ -229,8 +292,12 @@ def validate_dbt_statement(sql: str, *, claims: RunTokenClaims) -> ValidatedStat
 
     # Deny-list: quick case-insensitive prefix check on the normalised SQL.
     # This is defence-in-depth; the AST walk below is authoritative.
-    sql_lower = sql.strip().lower()
-    m = _DENIED_PREFIX_RE.search(sql)
+    # _normalize_for_prefix_scan strips comments and collapses whitespace so that
+    # tab/newline/block-comment evasion payloads are caught by the single-space
+    # literals in _DENIED_PREFIXES.  The original sql is returned unchanged.
+    normalized_sql = _normalize_for_prefix_scan(sql)
+    sql_lower = normalized_sql.strip().lower()
+    m = _DENIED_PREFIX_RE.search(normalized_sql)
     if m:
         return ValidatedStatement(
             sql=sql,
@@ -239,9 +306,10 @@ def validate_dbt_statement(sql: str, *, claims: RunTokenClaims) -> ValidatedStat
             block_reason=_deny_reason_for_prefix(sql_lower),
         )
 
-    # Deny-list: SET … privilege-escalation patterns
-    for pattern in _DENIED_SET_PATTERNS:
-        if pattern in sql_lower:
+    # Deny-list: SET … privilege-escalation patterns.
+    # Regex matching handles optional LOCAL/SESSION qualifiers (e.g. SET LOCAL ROLE).
+    for set_re in _DENIED_SET_REGEXES:
+        if set_re.search(sql_lower):
             return ValidatedStatement(
                 sql=sql,
                 kind="admin",
@@ -303,6 +371,12 @@ def _validate_single(stmt: exp.Expr, original_sql: str) -> ValidatedStatement:
         if create_result is not None:
             return create_result
 
+    # DROP / ALTER … on privileged objects — privilege escalation risk
+    if stmt_type in {"Drop", "Alter"}:
+        drop_alter_result = _check_drop_alter_node(stmt, stmt_type, original_sql)
+        if drop_alter_result is not None:
+            return drop_alter_result
+
     # Walk the AST for dangerous function calls (pg_read_file, dblink, etc.)
     func_result = _check_dangerous_functions(stmt, original_sql)
     if func_result is not None:
@@ -314,8 +388,14 @@ def _validate_single(stmt: exp.Expr, original_sql: str) -> ValidatedStatement:
 def _check_command_node(stmt: exp.Expr, original_sql: str) -> ValidatedStatement:
     """Check a sqlglot Command node for denied operations."""
     # sqlglot represents unknown commands as Command with .this = keyword text
-    raw = getattr(stmt, "this", "") or ""
-    raw_upper = raw.strip().upper()
+    # and .expression containing the rest (e.g. nested-comment payloads).
+    # Combine both parts and normalize (strips nested block comments, line
+    # comments, and collapses whitespace) so evasion variants are caught.
+    raw_this = getattr(stmt, "this", "") or ""
+    raw_expr = stmt.args.get("expression") or ""
+    full_raw = f"{raw_this} {raw_expr}".strip()
+    full_normalized = _normalize_for_prefix_scan(full_raw)
+    raw_upper = full_normalized.strip().upper()
 
     denied_keywords = {"COPY", "LISTEN", "NOTIFY", "UNLISTEN", "LOCK", "DO", "LOAD"}
     for kw in denied_keywords:
@@ -327,11 +407,25 @@ def _check_command_node(stmt: exp.Expr, original_sql: str) -> ValidatedStatement
                 block_reason=f"{kw.lower()}_blocked",
             )
 
-    # SET commands for privilege escalation
+    # CREATE/DROP/ALTER on privileged objects — sqlglot falls back to Command for
+    # unsupported syntax (e.g. CREATE ROLE, DROP USER, nested-comment variants).
+    # full_normalized has had all comments stripped and whitespace collapsed.
+    admin_match = _COMMAND_ADMIN_RE.match(raw_upper)
+    if admin_match:
+        verb_token = admin_match.group(1).upper()
+        return ValidatedStatement(
+            sql=original_sql,
+            kind="admin",
+            blocked=True,
+            block_reason=f"{verb_token.lower()}_blocked",
+        )
+
+    # SET commands for privilege escalation.
+    # raw_upper starts with SET here; use regex to match optional LOCAL/SESSION.
     if raw_upper.startswith("SET"):
-        raw_lower = raw.lower()
-        for pattern in _DENIED_SET_PATTERNS:
-            if pattern in raw_lower:
+        raw_lower = full_normalized.lower()
+        for set_re in _DENIED_SET_REGEXES:
+            if set_re.search(raw_lower):
                 return ValidatedStatement(
                     sql=original_sql,
                     kind="admin",
@@ -376,6 +470,55 @@ def _check_create_node(stmt: exp.Expr, original_sql: str) -> ValidatedStatement 
             block_reason="security_definer_blocked",
         )
 
+    return None
+
+
+# Object kinds that must never be DROP-ped or ALTER-ed via dbt proxy traffic.
+_DENIED_DROP_ALTER_KINDS: frozenset[str] = frozenset({
+    "ROLE",
+    "USER",
+    "DATABASE",
+    "TABLESPACE",
+    "EXTENSION",
+    "LANGUAGE",
+    "FUNCTION",
+    "PROCEDURE",
+    "TRIGGER",
+    "AGGREGATE",
+})
+
+# Regex used as a belt-and-braces check inside _check_command_node when sqlglot
+# falls back to a Command node for CREATE/DROP/ALTER (already comment-collapsed).
+# GRANT/REVOKE on any object is also blocked at the Command node level.
+# Role-membership syntax (GRANT admin TO evil) produces a Command node, not
+# exp.Grant, because sqlglot does not recognise that syntax — so we must catch
+# it here in addition to the _DENIED_PREFIX_RE Layer A check.
+_COMMAND_ADMIN_RE = re.compile(
+    r"^(CREATE|DROP|ALTER|GRANT|REVOKE)\s+.+",
+    re.IGNORECASE,
+)
+
+
+def _check_drop_alter_node(stmt: exp.Expr, stmt_type: str, original_sql: str) -> ValidatedStatement | None:
+    """Block DROP / ALTER on privileged object kinds (ROLE, USER, DATABASE, etc.).
+
+    Returns a blocked ValidatedStatement if the kind is denied, else None.
+    sqlglot exposes the same .args['kind'] field on Drop and Alter as it does
+    on Create.
+    """
+    kind_raw = stmt.args.get("kind", "") or ""
+    kind_upper = str(kind_raw).upper().strip()
+    if not kind_upper:
+        return None
+
+    for denied in _DENIED_DROP_ALTER_KINDS:
+        if denied in kind_upper:
+            return ValidatedStatement(
+                sql=original_sql,
+                kind="admin",
+                blocked=True,
+                block_reason=f"{denied.lower()}_management_blocked",
+            )
     return None
 
 
@@ -485,6 +628,10 @@ def _deny_reason_for_prefix(sql_lower: str) -> str:
         return "do_block_blocked"
     if sql_lower.startswith("load"):
         return "load_blocked"
+    if sql_lower.startswith("grant"):
+        return "grant_blocked"
+    if sql_lower.startswith("revoke"):
+        return "revoke_blocked"
     if "listen" in sql_lower[:20]:
         return "listen_blocked"
     if "notify" in sql_lower[:20]:

--- a/signalpilot/gateway/gateway/engine/dbt_validation.py
+++ b/signalpilot/gateway/gateway/engine/dbt_validation.py
@@ -21,6 +21,7 @@ module raises ImportError at import time (fail closed — do not skip validation
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -125,6 +126,11 @@ _DENIED_PREFIXES: tuple[str, ...] = (
     "security definer",
 )
 
+_DENIED_PREFIX_RE = re.compile(
+    r"(?:^|[\s;])(" + "|".join(re.escape(p.strip()) for p in _DENIED_PREFIXES) + r")(?=\s|;|\(|$)",
+    re.IGNORECASE,
+)
+
 # SET commands that are always denied (privilege escalation)
 _DENIED_SET_PATTERNS: tuple[str, ...] = (
     "set session authorization",
@@ -159,9 +165,24 @@ _DENIED_FUNCTION_NAMES: frozenset[str] = frozenset({
     "dblink_build_sql_insert",
     "dblink_build_sql_delete",
     "dblink_build_sql_update",
-    "current_setting",
-    "set_config",
 })
+
+# Settings prefixes that are blocked in current_setting / set_config
+_SENSITIVE_SETTING_PREFIXES: tuple[str, ...] = (
+    "ssl_",
+    "data_directory",
+    "config_file",
+    "hba_file",
+    "ident_file",
+    "external_pid_file",
+    "dynamic_library_path",
+    "local_preload_libraries",
+    "session_preload_libraries",
+    "shared_preload_libraries",
+)
+
+# Names of the setting-accessor functions to handle with arg-aware logic
+_SETTING_FUNC_NAMES: frozenset[str] = frozenset({"current_setting", "set_config"})
 
 
 @dataclass
@@ -209,14 +230,14 @@ def validate_dbt_statement(sql: str, *, claims: RunTokenClaims) -> ValidatedStat
     # Deny-list: quick case-insensitive prefix check on the normalised SQL.
     # This is defence-in-depth; the AST walk below is authoritative.
     sql_lower = sql.strip().lower()
-    for prefix in _DENIED_PREFIXES:
-        if sql_lower.startswith(prefix) or f" {prefix}" in sql_lower or f"\n{prefix}" in sql_lower:
-            return ValidatedStatement(
-                sql=sql,
-                kind="admin",
-                blocked=True,
-                block_reason=_deny_reason_for_prefix(sql_lower),
-            )
+    m = _DENIED_PREFIX_RE.search(sql)
+    if m:
+        return ValidatedStatement(
+            sql=sql,
+            kind="admin",
+            blocked=True,
+            block_reason=_deny_reason_for_prefix(sql_lower),
+        )
 
     # Deny-list: SET … privilege-escalation patterns
     for pattern in _DENIED_SET_PATTERNS:
@@ -358,6 +379,40 @@ def _check_create_node(stmt: exp.Expr, original_sql: str) -> ValidatedStatement 
     return None
 
 
+def _check_setting_func_node(node: exp.Anonymous | exp.Func, func_name: str, original_sql: str) -> ValidatedStatement | None:
+    """Arg-aware check for current_setting / set_config calls.
+
+    Allows calls where the first argument is a string literal with a safe
+    setting name; blocks sensitive prefixes and non-literal first arguments.
+    """
+    args = node.args.get("expressions") or []
+    if not args:
+        return ValidatedStatement(
+            sql=original_sql,
+            kind="admin",
+            blocked=True,
+            block_reason=f"denied_function_{func_name}",
+        )
+    first_arg = args[0]
+    if not (isinstance(first_arg, exp.Literal) and first_arg.is_string):
+        return ValidatedStatement(
+            sql=original_sql,
+            kind="admin",
+            blocked=True,
+            block_reason="current_setting/set_config with non-literal name is not allowed — pass a constant string",
+        )
+    setting_name = first_arg.this.lower()
+    for prefix in _SENSITIVE_SETTING_PREFIXES:
+        if setting_name.startswith(prefix):
+            return ValidatedStatement(
+                sql=original_sql,
+                kind="admin",
+                blocked=True,
+                block_reason=f"reading {setting_name} via current_setting is restricted",
+            )
+    return None
+
+
 def _check_dangerous_functions(stmt: exp.Expr, original_sql: str) -> ValidatedStatement | None:
     """Walk the AST for calls to dangerous built-in functions.
 
@@ -367,7 +422,11 @@ def _check_dangerous_functions(stmt: exp.Expr, original_sql: str) -> ValidatedSt
     # Walk all Anonymous nodes (covers functions sqlglot doesn't know about)
     for node in stmt.find_all(exp.Anonymous):
         func_name = (node.name or "").lower()
-        if func_name in _DENIED_FUNCTION_NAMES:
+        if func_name in _SETTING_FUNC_NAMES:
+            result = _check_setting_func_node(node, func_name, original_sql)
+            if result is not None:
+                return result
+        elif func_name in _DENIED_FUNCTION_NAMES:
             return ValidatedStatement(
                 sql=original_sql,
                 kind="admin",
@@ -382,7 +441,12 @@ def _check_dangerous_functions(stmt: exp.Expr, original_sql: str) -> ValidatedSt
         # avoid the loop-variable closure capture issue (ruff B023).
         sql_name_raw = node.sql_name() if callable(getattr(node, "sql_name", None)) else func_name
         sql_name = sql_name_raw.lower() if isinstance(sql_name_raw, str) else func_name
-        if func_name in _DENIED_FUNCTION_NAMES or sql_name in _DENIED_FUNCTION_NAMES:
+        if func_name in _SETTING_FUNC_NAMES or sql_name in _SETTING_FUNC_NAMES:
+            canonical = func_name if func_name in _SETTING_FUNC_NAMES else sql_name
+            result = _check_setting_func_node(node, canonical, original_sql)
+            if result is not None:
+                return result
+        elif func_name in _DENIED_FUNCTION_NAMES or sql_name in _DENIED_FUNCTION_NAMES:
             return ValidatedStatement(
                 sql=original_sql,
                 kind="admin",

--- a/signalpilot/gateway/gateway/mcp/server.py
+++ b/signalpilot/gateway/gateway/mcp/server.py
@@ -7,6 +7,7 @@ import os as _os
 from mcp.server.fastmcp import FastMCP
 
 from ..config import get_mcp_settings
+from ..runtime.mode import is_cloud_mode
 
 # Allowed hosts for MCP streamable-http transport (DNS rebinding protection)
 _allowed_hosts = ["localhost", "127.0.0.1", "host.docker.internal", "0.0.0.0"]
@@ -58,6 +59,10 @@ def main():
         authenticated_app = MCPAuthMiddleware(starlette_app)
         uvicorn.run(authenticated_app, host="0.0.0.0", port=port, server_header=False)
     else:
+        if is_cloud_mode():
+            raise SystemExit(
+                "Refusing to start MCP stdio transport in cloud mode — stdio bypasses MCPAuthMiddleware."
+            )
         # stdio mode has no auth middleware — set context vars for local access
         from gateway.mcp.context import mcp_org_id_var, mcp_user_id_var
 

--- a/signalpilot/gateway/gateway/mcp/tools/model_blueprint.py
+++ b/signalpilot/gateway/gateway/mcp/tools/model_blueprint.py
@@ -19,6 +19,11 @@ from gateway.mcp.server import mcp
 from gateway.mcp.validation import _MODEL_NAME_RE, _quote_table, _validate_connection_name
 
 
+def _qid(name: str) -> str:
+    """Quote a SQL identifier with double-quote doubling."""
+    return '"' + name.replace('"', '""') + '"'
+
+
 # ---------------------------------------------------------------------------
 # Filesystem helpers
 # ---------------------------------------------------------------------------
@@ -287,9 +292,10 @@ async def generate_model_blueprint(
     table_columns: dict[str, list[str]] = {}
     for tbl in all_tables:
         try:
+            safe_tbl = tbl.replace("'", "''")
             col_rows = await _query(
                 f"SELECT column_name FROM information_schema.columns "
-                f"WHERE table_name = '{tbl}' ORDER BY ordinal_position"
+                f"WHERE table_name = '{safe_tbl}' ORDER BY ordinal_position"
             )
             table_columns[tbl] = [r["column_name"] for r in col_rows]
         except Exception:
@@ -378,9 +384,8 @@ async def generate_model_blueprint(
                     if raw_col in src_cols or raw_col.lower() in {c.lower() for c in src_cols}:
                         # Query the actual values from the raw source
                         try:
-                            safe_col = raw_col.replace('"', '""')
                             rows = await _query(
-                                f'SELECT DISTINCT "{safe_col}" AS val '
+                                f'SELECT DISTINCT {_qid(raw_col)} AS val '
                                 f'FROM {_quote_table(src_tbl)} ORDER BY 1 LIMIT 20'
                             )
                             values = [r["val"] for r in rows] if rows else []
@@ -502,10 +507,10 @@ async def generate_model_blueprint(
                         # Use a join to count distinct customers per status
                         try:
                             count_rows = await _query(
-                                f'SELECT "{src_col_match}" AS status_val, '
+                                f'SELECT {_qid(src_col_match)} AS status_val, '
                                 f'COUNT(DISTINCT o.o_custkey) AS entity_count '
                                 f'FROM {_quote_table(src_tbl)} s '
-                                f'JOIN {_quote_table(orders_tbl)} o ON s."{order_key}" = o.o_orderkey '
+                                f'JOIN {_quote_table(orders_tbl)} o ON s.{_qid(order_key)} = o.o_orderkey '
                                 f'GROUP BY 1 ORDER BY 2 DESC'
                             )
                             if count_rows:
@@ -519,8 +524,8 @@ async def generate_model_blueprint(
                                         ex_row = await _query(
                                             f'SELECT COUNT(DISTINCT o.o_custkey) AS cnt '
                                             f'FROM {_quote_table(src_tbl)} s '
-                                            f'JOIN {_quote_table(orders_tbl)} o ON s."{order_key}" = o.o_orderkey '
-                                            f"""WHERE s."{src_col_match}" != '{safe_val}'"""
+                                            f'JOIN {_quote_table(orders_tbl)} o ON s.{_qid(order_key)} = o.o_orderkey '
+                                            f"WHERE s.{_qid(src_col_match)} != '{safe_val}'"
                                         )
                                         if ex_row:
                                             lines.append(
@@ -536,8 +541,8 @@ async def generate_model_blueprint(
                     continue
                 try:
                     count_rows = await _query(
-                        f'SELECT "{src_col_match}" AS status_val, '
-                        f'COUNT(DISTINCT "{key_match}") AS entity_count '
+                        f'SELECT {_qid(src_col_match)} AS status_val, '
+                        f'COUNT(DISTINCT {_qid(key_match)}) AS entity_count '
                         f'FROM {_quote_table(src_tbl)} '
                         f'GROUP BY 1 ORDER BY 2 DESC'
                     )
@@ -553,9 +558,9 @@ async def generate_model_blueprint(
                             try:
                                 safe_val = str(r["status_val"]).replace("'", "''")
                                 ex_row = await _query(
-                                    f'SELECT COUNT(DISTINCT "{key_match}") AS cnt '
+                                    f'SELECT COUNT(DISTINCT {_qid(key_match)}) AS cnt '
                                     f'FROM {_quote_table(src_tbl)} '
-                                    f"""WHERE "{src_col_match}" != '{safe_val}'"""
+                                    f"WHERE {_qid(src_col_match)} != '{safe_val}'"
                                 )
                                 if ex_row:
                                     lines.append(

--- a/signalpilot/gateway/gateway/mcp/tools/model_verify.py
+++ b/signalpilot/gateway/gateway/mcp/tools/model_verify.py
@@ -12,6 +12,11 @@ from gateway.mcp.server import mcp
 from gateway.mcp.validation import _MODEL_NAME_RE, _quote_table, _validate_connection_name, _validate_sql
 
 
+def _qid(name: str) -> str:
+    """Quote a SQL identifier with double-quote doubling."""
+    return '"' + name.replace('"', '""') + '"'
+
+
 @audited_tool(mcp)
 async def check_model_schema(connection_name: str, model_name: str, yml_columns: str) -> str:
     """
@@ -793,9 +798,10 @@ async def verify_model_values(connection_name: str, model_name: str) -> str:
                 return rows[0] if rows else None
 
             # Get model columns
+            safe_model = model_name.replace("'", "''")
             col_rows = await _query(
                 f"SELECT column_name, data_type FROM information_schema.columns "
-                f"WHERE table_name = '{model_name}' ORDER BY ordinal_position"
+                f"WHERE table_name = '{safe_model}' ORDER BY ordinal_position"
             )
             if not col_rows:
                 return f"Error: Table '{model_name}' not found or has no columns."
@@ -813,7 +819,7 @@ async def verify_model_values(connection_name: str, model_name: str) -> str:
             # Get top row by first metric
             first_metric = metric_cols[0][0]
             top = await _query_one(
-                f'SELECT * FROM {_quote_table(model_name)} ORDER BY "{first_metric}" DESC LIMIT 1'
+                f'SELECT * FROM {_quote_table(model_name)} ORDER BY {_qid(first_metric)} DESC LIMIT 1'
             )
             if not top:
                 return f"No rows in '{model_name}'."
@@ -839,9 +845,10 @@ async def verify_model_values(connection_name: str, model_name: str) -> str:
                 try:
                     row = await _query_one(f'SELECT COUNT(*) AS cnt FROM {_quote_table(tbl)}')
                     cnt = row["cnt"] if row else 0
+                    safe_tbl = tbl.replace("'", "''")
                     tbl_col_rows = await _query(
                         f"SELECT column_name FROM information_schema.columns "
-                        f"WHERE table_name = '{tbl}'"
+                        f"WHERE table_name = '{safe_tbl}'"
                     )
                     tbl_cols = [r["column_name"] for r in tbl_col_rows]
                     table_info.append((tbl, cnt, tbl_cols))
@@ -864,7 +871,7 @@ async def verify_model_values(connection_name: str, model_name: str) -> str:
                 # Direct match: candidate has the slice column
                 cand_col_match = next((c for c in cand_cols if c.lower() == slice_col.lower()), None)
                 if cand_col_match:
-                    return f"""WHERE "{cand_col_match}" = '{safe_val}'""", ""
+                    return f"WHERE {_qid(cand_col_match)} = '{safe_val}'", ""
                 # Indirect: find a dimension table with the slice column, join via shared key
                 for dim_name, _, dim_cols in table_info:
                     if dim_name in (model_name, cand_name):
@@ -884,8 +891,8 @@ async def verify_model_values(connection_name: str, model_name: str) -> str:
                         cand_key, dim_key = shared_keys[0]
                         return (
                             f'INNER JOIN {_quote_table(dim_name)} _dim '
-                            f'ON _cand."{cand_key}" = _dim."{dim_key}" '
-                            f"""WHERE _dim."{dim_match}" = '{safe_val}'""",
+                            f'ON _cand.{_qid(cand_key)} = _dim.{_qid(dim_key)} '
+                            f"WHERE _dim.{_qid(dim_match)} = '{safe_val}'",
                             "_cand",
                         )
                 return "", ""
@@ -934,9 +941,9 @@ async def verify_model_values(connection_name: str, model_name: str) -> str:
                     for key in id_cols:
                         try:
                             if cand_prefix:
-                                q = f'SELECT COUNT(DISTINCT _cand."{key}") AS cnt FROM {_quote_table(cand_name)} _cand {cand_slice}'
+                                q = f'SELECT COUNT(DISTINCT _cand.{_qid(key)}) AS cnt FROM {_quote_table(cand_name)} _cand {cand_slice}'
                             else:
-                                q = f'SELECT COUNT(DISTINCT "{key}") AS cnt FROM {_quote_table(cand_name)} {cand_slice}'
+                                q = f'SELECT COUNT(DISTINCT {_qid(key)}) AS cnt FROM {_quote_table(cand_name)} {cand_slice}'
                             row = await _query_one(q)
                             if row:
                                 lines.append(f"    COUNT(DISTINCT {key}): {row['cnt']}")

--- a/signalpilot/gateway/gateway/mcp/validation.py
+++ b/signalpilot/gateway/gateway/mcp/validation.py
@@ -6,7 +6,7 @@ import re
 
 # Input validation patterns
 _CONN_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
-_MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9_.]{1,256}$")
+_MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+){0,2}$")
 _MAX_SQL_LENGTH = 100_000
 
 

--- a/signalpilot/gateway/gateway/models/knowledge.py
+++ b/signalpilot/gateway/gateway/models/knowledge.py
@@ -8,6 +8,7 @@ from enum import Enum
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 _SLUG_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,118}[a-z0-9])?$")
+_SCOPE_REF_RE = re.compile(r"^[A-Za-z0-9_./:-]{1,200}$")
 
 # Category × scope whitelist
 _SCOPE_CATEGORIES: dict[str, set[str]] = {
@@ -91,8 +92,8 @@ class KnowledgeDocCreate(BaseModel):
         else:
             if not self.scope_ref:
                 raise ValueError(f"scope_ref is required for scope '{scope_val}'")
-            if len(self.scope_ref) > 200:
-                raise ValueError("scope_ref must be <= 200 characters")
+            if not _SCOPE_REF_RE.match(self.scope_ref):
+                raise ValueError("scope_ref must match [A-Za-z0-9_./:-]{1,200}")
 
         return self
 

--- a/signalpilot/gateway/gateway/store/knowledge.py
+++ b/signalpilot/gateway/gateway/store/knowledge.py
@@ -6,6 +6,7 @@ delegates to these functions via thin wrapper methods.
 
 from __future__ import annotations
 
+import logging
 import time
 import uuid
 
@@ -21,6 +22,9 @@ from gateway.models.knowledge import (
     KnowledgeStatus,
     KnowledgeUsage,
 )
+from gateway.runtime.mode import is_cloud_mode
+
+logger = logging.getLogger(__name__)
 
 # ── Typed exceptions ──────────────────────────────────────────────────────────
 
@@ -239,6 +243,10 @@ async def insert_knowledge_doc(
         # e.g. understanding — caller should have rejected; fall back to payload
         status_val = payload.status.value
 
+    # Cloud-only: agent-proposed knowledge requires admin approval regardless of category.
+    if agent is not None and is_cloud_mode():
+        status_val = KnowledgeStatus.pending.value
+
     now = time.time()
     doc_id = str(uuid.uuid4())
 
@@ -343,6 +351,10 @@ async def upsert_knowledge_doc(
         else:
             status_val = payload.status.value
 
+        # Cloud-only: agent-proposed knowledge requires admin approval regardless of category.
+        if agent is not None and is_cloud_mode():
+            status_val = KnowledgeStatus.pending.value
+
         doc_id = str(uuid.uuid4())
         row = GatewayKnowledgeDoc(
             id=doc_id,
@@ -377,6 +389,10 @@ async def upsert_knowledge_doc(
             edit_kind="human" if agent is None else "agent",
         )
         session.add(edit)
+
+        # Cloud-only: agent-driven update of an active doc must be re-reviewed.
+        if agent is not None and is_cloud_mode():
+            existing.status = KnowledgeStatus.pending.value
 
         existing.body = payload.body
         existing.bytes = body_bytes
@@ -599,5 +615,5 @@ async def increment_knowledge_view(session: AsyncSession, *, org_id: str, doc_id
             .values(view_count=GatewayKnowledgeDoc.view_count + 1)
         )
         await session.commit()
-    except Exception:
-        pass
+    except Exception as exc:  # best-effort counter — log but do not raise
+        logger.debug("increment_knowledge_view failed doc_id=%s exc=%r", doc_id, exc)

--- a/signalpilot/gateway/tests/test_db_engine.py
+++ b/signalpilot/gateway/tests/test_db_engine.py
@@ -1,0 +1,37 @@
+"""Tests for gateway/db/engine.py SSL detection logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.db.engine import _requires_ssl
+
+
+class TestRequiresSsl:
+    def test_requires_ssl_detects_channel_binding(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db?channel_binding=require")
+        assert _requires_ssl() is True
+
+    def test_requires_ssl_detects_ssl_true(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db?ssl=true")
+        assert _requires_ssl() is True
+
+    def test_requires_ssl_sslmode_require(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db?sslmode=require")
+        assert _requires_ssl() is True
+
+    def test_requires_ssl_sslmode_disable_is_false(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db?sslmode=disable")
+        assert _requires_ssl() is False
+
+    def test_requires_ssl_no_url(self, monkeypatch) -> None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        assert _requires_ssl() is False
+
+    def test_requires_ssl_sslmode_verify_ca(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db?sslmode=verify-ca")
+        assert _requires_ssl() is True
+
+    def test_requires_ssl_sslmode_verify_full(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db?sslmode=verify-full")
+        assert _requires_ssl() is True

--- a/signalpilot/gateway/tests/test_dbt_proxy_api.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_api.py
@@ -106,3 +106,75 @@ class TestDbtProxyApi:
         with pytest.raises(HTTPException) as exc_info:
             require_scopes(request, "dbt_proxy")
         assert exc_info.value.status_code == 403
+
+    def test_mint_does_not_log_org_id_or_connector_name(self) -> None:
+        """Mint log line must not include org_id or connector_name."""
+        import logging
+        from unittest.mock import patch, MagicMock
+
+        run_id = uuid.uuid4()
+        app = _make_test_app()
+        log_calls: list = []
+
+        original_info = logging.Logger.info
+
+        def capture_info(self, msg, *args, **kwargs):
+            log_calls.append((msg,) + args)
+            return original_info(self, msg, *args, **kwargs)
+
+        with patch.object(logging.Logger, "info", capture_info):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/api/dbt-proxy/run-tokens",
+                    json={
+                        "run_id": str(run_id),
+                        "connector_name": "my_conn",
+                        "ttl_seconds": 300,
+                    },
+                )
+        assert resp.status_code == 201
+
+        for call_args in log_calls:
+            full_msg = " ".join(str(a) for a in call_args)
+            assert "test-org" not in full_msg
+            assert "my_conn" not in full_msg
+
+    def test_mint_rejects_bad_connector_name(self) -> None:
+        """connector_name with invalid charset returns 422."""
+        run_id = uuid.uuid4()
+        app = _make_test_app()
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={
+                    "run_id": str(run_id),
+                    "connector_name": "evil; drop",
+                    "ttl_seconds": 300,
+                },
+            )
+        assert resp.status_code == 422
+
+    def test_mint_caps_ttl_in_cloud_mode(self) -> None:
+        """In cloud mode, TTL is capped to 3600 regardless of request value."""
+        from datetime import UTC, datetime
+
+        run_id = uuid.uuid4()
+        app = _make_test_app()
+
+        # Patch is_cloud_mode directly so we avoid JWT auth flow triggering
+        from unittest.mock import patch as _patch
+        with _patch("gateway.dbt_proxy.api.is_cloud_mode", return_value=True):
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/api/dbt-proxy/run-tokens",
+                    json={
+                        "run_id": str(run_id),
+                        "connector_name": "my_conn",
+                        "ttl_seconds": 86400,
+                    },
+                )
+        assert resp.status_code == 201
+        data = resp.json()
+        expires_at = datetime.fromisoformat(data["expires_at"])
+        max_allowed = datetime.now(tz=UTC).timestamp() + 3600
+        assert expires_at.timestamp() <= max_allowed + 5  # 5s tolerance

--- a/signalpilot/gateway/tests/test_dbt_proxy_numeric_bounds.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_numeric_bounds.py
@@ -1,0 +1,202 @@
+"""Tests for the NUMERIC binary weight cap and Fix 3-bis propagation.
+
+Covers:
+- _parse_numeric_binary: weight cap (±MAX_NUMERIC_WEIGHT), at-cap regression,
+  ndigits cap regression.
+- _handle_bind: ValueError from parse_bind_value is caught and emits
+  ErrorResponse with SQLSTATE 22P03 (covers both ndigits and weight caps).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+import time
+import uuid
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.dbt_proxy.protocol import (
+    MAX_NUMERIC_WEIGHT,
+    _parse_numeric_binary,
+)
+from gateway.dbt_proxy.session import DbtProxySession
+from gateway.dbt_proxy.tokens import RunTokenClaims
+
+
+def _build_numeric_header(
+    ndigits: int,
+    weight: int,
+    sign: int = 0x0000,
+    dscale: int = 0,
+) -> bytes:
+    """Build the 8-byte NUMERIC binary header (no digit data appended)."""
+    return struct.pack("!HhHH", ndigits, weight, sign, dscale)
+
+
+def _build_numeric_binary(
+    ndigits: int,
+    weight: int,
+    digits: list[int],
+    sign: int = 0x0000,
+    dscale: int = 0,
+) -> bytes:
+    """Build a complete binary NUMERIC payload."""
+    header = _build_numeric_header(ndigits, weight, sign, dscale)
+    return header + struct.pack(f"!{ndigits}H", *digits)
+
+
+def _build_bind_payload_with_numeric_binary(raw_numeric: bytes) -> bytes:
+    """Build a Bind message payload containing one binary NUMERIC parameter."""
+    from gateway.dbt_proxy.protocol import OID_NUMERIC
+
+    portal = b"\x00"         # unnamed portal
+    stmt = b"s\x00"          # statement name "s"
+    n_formats = struct.pack("!H", 1)
+    fmt_binary = struct.pack("!H", 1)   # binary format for all params
+    n_params = struct.pack("!H", 1)
+    param_len = struct.pack("!i", len(raw_numeric))
+    return portal + stmt + n_formats + fmt_binary + n_params + param_len + raw_numeric
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.buf: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.buf.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    @property
+    def combined(self) -> bytes:
+        return b"".join(self.buf)
+
+
+def _make_session_with_stmt(stmt_name: str) -> tuple[DbtProxySession, FakeWriter]:
+    """Return a session pre-loaded with one named statement backed by OID_NUMERIC."""
+    from gateway.dbt_proxy.protocol import OID_NUMERIC
+
+    reader = asyncio.StreamReader()
+    writer = FakeWriter()
+    claims = RunTokenClaims(
+        run_id=uuid.uuid4(),
+        org_id="org-1",
+        user_id="user-1",
+        connector_name="my_conn",
+        expires_at=9999999999.0,
+    )
+    session = DbtProxySession(reader, writer, claims, MagicMock())
+    # Inject one statement directly (bypassing Parse message path)
+    session._named_stmts[stmt_name] = ("SELECT $1", [OID_NUMERIC])
+    return session, writer
+
+
+class TestParseNumericBinaryWeightCap:
+    """_parse_numeric_binary must reject |weight| > MAX_NUMERIC_WEIGHT."""
+
+    def test_weight_max_positive_raises(self) -> None:
+        """weight = +32767 → ValueError mentioning 'weight' and the cap value."""
+        raw = _build_numeric_header(ndigits=0, weight=32767)
+
+        t0 = time.monotonic()
+        with pytest.raises(ValueError, match="weight") as exc_info:
+            _parse_numeric_binary(raw)
+        elapsed = time.monotonic() - t0
+
+        assert str(MAX_NUMERIC_WEIGHT) in str(exc_info.value)
+        assert elapsed < 0.1, "loop must not have run before rejection"
+
+    def test_weight_max_negative_raises(self) -> None:
+        """weight = -32768 → ValueError mentioning 'weight' and the cap value."""
+        raw = _build_numeric_header(ndigits=0, weight=-32768)
+
+        t0 = time.monotonic()
+        with pytest.raises(ValueError, match="weight") as exc_info:
+            _parse_numeric_binary(raw)
+        elapsed = time.monotonic() - t0
+
+        assert str(MAX_NUMERIC_WEIGHT) in str(exc_info.value)
+        assert elapsed < 0.1
+
+    def test_weight_at_positive_cap_succeeds(self) -> None:
+        """weight = MAX_NUMERIC_WEIGHT with ndigits=1 → returns a Decimal."""
+        digits = [1]
+        raw = _build_numeric_binary(
+            ndigits=1, weight=MAX_NUMERIC_WEIGHT, digits=digits
+        )
+        result = _parse_numeric_binary(raw)
+        assert isinstance(result, Decimal)
+
+    def test_weight_one_over_positive_cap_raises(self) -> None:
+        """weight = MAX_NUMERIC_WEIGHT + 1 → ValueError."""
+        raw = _build_numeric_header(ndigits=1, weight=MAX_NUMERIC_WEIGHT + 1)
+        with pytest.raises(ValueError, match="weight"):
+            _parse_numeric_binary(raw)
+
+    def test_ndigits_cap_still_enforced(self) -> None:
+        """Regression: ndigits > 1000 must still raise (M-8 fix unchanged)."""
+        raw = _build_numeric_header(ndigits=1001, weight=0)
+        with pytest.raises(ValueError, match="ndigits"):
+            _parse_numeric_binary(raw)
+
+
+class TestHandleBindNumericErrorPropagation:
+    """Fix 3-bis: _handle_bind must catch ValueError from parse_bind_value."""
+
+    @pytest.mark.asyncio
+    async def test_weight_overflow_returns_error_response_22p03(self) -> None:
+        """weight=32767 Bind → ErrorResponse with SQLSTATE 22P03, no raise."""
+        session, writer = _make_session_with_stmt("s")
+
+        raw_numeric = _build_numeric_header(ndigits=0, weight=32767)
+        bind_payload = _build_bind_payload_with_numeric_binary(raw_numeric)
+
+        # Must not raise — the error must be written to the writer
+        await session._handle_bind(bind_payload)
+
+        combined = writer.combined
+        assert b"22P03" in combined, "expected SQLSTATE 22P03 in ErrorResponse"
+        assert b"E" in combined, "expected ErrorResponse type byte"
+        assert session._named_portals == {}, "_named_portals must be unchanged"
+
+    @pytest.mark.asyncio
+    async def test_ndigits_overflow_returns_error_response_22p03(self) -> None:
+        """ndigits=1001 Bind → ErrorResponse with SQLSTATE 22P03, no raise.
+
+        Regression for M-8: the pre-existing ndigits cap ValueError must now
+        also produce a proper ErrorResponse instead of propagating out of run().
+        """
+        session, writer = _make_session_with_stmt("s")
+
+        raw_numeric = _build_numeric_header(ndigits=1001, weight=0)
+        bind_payload = _build_bind_payload_with_numeric_binary(raw_numeric)
+
+        await session._handle_bind(bind_payload)
+
+        combined = writer.combined
+        assert b"22P03" in combined, "expected SQLSTATE 22P03 in ErrorResponse"
+        assert b"E" in combined, "expected ErrorResponse type byte"
+        assert session._named_portals == {}, "_named_portals must be unchanged"
+
+    @pytest.mark.asyncio
+    async def test_valid_numeric_bind_succeeds(self) -> None:
+        """A valid binary NUMERIC Bind succeeds and produces BindComplete."""
+        session, writer = _make_session_with_stmt("s")
+
+        # weight=1, ndigits=1, digit=42 → 42 * 10000^1 = 420000
+        raw_numeric = _build_numeric_binary(ndigits=1, weight=1, digits=[42])
+        bind_payload = _build_bind_payload_with_numeric_binary(raw_numeric)
+
+        await session._handle_bind(bind_payload)
+
+        combined = writer.combined
+        assert b"22P03" not in combined, "no error expected for valid numeric"
+        assert b"2" in combined, "expected BindComplete"
+        assert "" in session._named_portals, "unnamed portal should be stored"

--- a/signalpilot/gateway/tests/test_dbt_proxy_protocol.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_protocol.py
@@ -110,3 +110,36 @@ class TestProtocolFraming:
         result = parse_bind_value(raw, oid=9999, format_code=1)
         assert isinstance(result, UnsupportedOID)
         assert result.oid == 9999
+
+
+class TestNumericBinaryBounds:
+    """NUMERIC binary parser must reject excessively large ndigits."""
+
+    def _make_numeric_raw(self, ndigits: int) -> bytes:
+        """Build a minimal NUMERIC binary payload with the given ndigits."""
+        # Header: ndigits(H=2), weight(h=2), sign(H=2), dscale(H=2)
+        header = struct.pack("!HhHH", ndigits, 0, 0, 0)
+        # Pad with ndigits * 2 zero bytes (base-10000 digits)
+        digits = b"\x00\x00" * ndigits
+        return header + digits
+
+    def test_numeric_binary_rejects_huge_ndigits(self) -> None:
+        from gateway.dbt_proxy.protocol import _parse_numeric_binary
+
+        raw = self._make_numeric_raw(10000)
+        with pytest.raises(ValueError, match="ndigits"):
+            _parse_numeric_binary(raw)
+
+    def test_numeric_binary_boundary_ndigits_1000_ok(self) -> None:
+        from gateway.dbt_proxy.protocol import _parse_numeric_binary
+
+        raw = self._make_numeric_raw(1000)
+        result = _parse_numeric_binary(raw)
+        assert result is not None  # Parsed without error
+
+    def test_numeric_binary_boundary_ndigits_1001_blocked(self) -> None:
+        from gateway.dbt_proxy.protocol import _parse_numeric_binary
+
+        raw = self._make_numeric_raw(1001)
+        with pytest.raises(ValueError, match="ndigits"):
+            _parse_numeric_binary(raw)

--- a/signalpilot/gateway/tests/test_dbt_proxy_protocol_limits.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_protocol_limits.py
@@ -1,0 +1,146 @@
+"""Tests for wire-frame size limits in the pg-wire v3 protocol framing module.
+
+Verifies that read_startup_message and read_frontend_message reject
+attacker-controlled oversized length fields BEFORE allocating memory,
+preventing OOM via uint32-amplified readexactly() calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+
+import pytest
+
+from gateway.dbt_proxy.protocol import (
+    MAX_FRONTEND_MESSAGE_LEN,
+    MAX_STARTUP_MESSAGE_LEN,
+    read_frontend_message,
+    read_startup_message,
+)
+
+
+def _make_startup_message(params: dict[str, str]) -> bytes:
+    """Build a valid StartupMessage with protocol version 3.0."""
+    proto = struct.pack("!I", 0x00030000)
+    body = proto
+    for k, v in params.items():
+        body += k.encode() + b"\x00" + v.encode() + b"\x00"
+    body += b"\x00"
+    total_length = struct.pack("!I", len(body) + 4)
+    return total_length + body
+
+
+def _make_frontend_message(msg_type: bytes, payload: bytes) -> bytes:
+    """Build a valid typed frontend message frame."""
+    length = struct.pack("!I", len(payload) + 4)
+    return msg_type + length + payload
+
+
+class TestStartupMessageLimits:
+    """read_startup_message must reject oversized length fields before allocation."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversize_length(self) -> None:
+        """A length field of MAX_STARTUP_MESSAGE_LEN + 1 raises ValueError immediately.
+
+        We supply only the 4-byte length header (no body data), so if the
+        implementation attempted readexactly() for the oversized body it would
+        block waiting for data that never arrives — the test would hang rather
+        than pass, proving the cap fires before the read.
+        """
+        oversize_length = MAX_STARTUP_MESSAGE_LEN + 1
+        length_bytes = struct.pack("!I", oversize_length)
+        reader = asyncio.StreamReader()
+        reader.feed_data(length_bytes)
+        reader.feed_eof()
+
+        with pytest.raises(ValueError, match="too large"):
+            await read_startup_message(reader)
+
+    @pytest.mark.asyncio
+    async def test_accepts_realistic_size(self) -> None:
+        """A normal startup message (~200 bytes) parses correctly."""
+        params = {
+            "user": "run-abc123",
+            "database": "my_connector",
+            "application_name": "dbt",
+        }
+        raw = _make_startup_message(params)
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+
+        result = await read_startup_message(reader)
+
+        assert result["user"] == "run-abc123"
+        assert result["database"] == "my_connector"
+        assert result["application_name"] == "dbt"
+
+    @pytest.mark.asyncio
+    async def test_rejects_length_below_minimum(self) -> None:
+        """A length field below 8 raises ValueError (regression for existing check)."""
+        length_bytes = struct.pack("!I", 7)
+        reader = asyncio.StreamReader()
+        reader.feed_data(length_bytes)
+        reader.feed_eof()
+
+        with pytest.raises(ValueError, match="too short"):
+            await read_startup_message(reader)
+
+
+class TestFrontendMessageLimits:
+    """read_frontend_message must reject oversized length fields before allocation."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversize_length(self) -> None:
+        """A length field of MAX_FRONTEND_MESSAGE_LEN + 1 raises ValueError immediately.
+
+        Only the type byte and 4-byte length header are supplied; if the
+        implementation tried readexactly() for the body the test would hang,
+        proving the cap fires before any allocation.
+        """
+        oversize_length = MAX_FRONTEND_MESSAGE_LEN + 1
+        header = b"Q" + struct.pack("!I", oversize_length)
+        reader = asyncio.StreamReader()
+        reader.feed_data(header)
+        reader.feed_eof()
+
+        with pytest.raises(ValueError, match="too large"):
+            await read_frontend_message(reader)
+
+    @pytest.mark.asyncio
+    async def test_accepts_at_cap(self) -> None:
+        """An exact MAX_FRONTEND_MESSAGE_LEN payload parses (boundary-inclusive)."""
+        payload = b"\x00" * (MAX_FRONTEND_MESSAGE_LEN - 4)
+        raw = _make_frontend_message(b"Q", payload)
+        reader = asyncio.StreamReader(limit=MAX_FRONTEND_MESSAGE_LEN + 8)
+        reader.feed_data(raw)
+
+        msg_type, result_payload = await read_frontend_message(reader)
+
+        assert msg_type == "Q"
+        assert len(result_payload) == MAX_FRONTEND_MESSAGE_LEN - 4
+
+    @pytest.mark.asyncio
+    async def test_rejects_length_below_four(self) -> None:
+        """A length field below 4 raises ValueError (regression for existing check)."""
+        header = b"Q" + struct.pack("!I", 3)
+        reader = asyncio.StreamReader()
+        reader.feed_data(header)
+        reader.feed_eof()
+
+        with pytest.raises(ValueError, match="Invalid message length"):
+            await read_frontend_message(reader)
+
+    @pytest.mark.asyncio
+    async def test_accepts_small_message(self) -> None:
+        """A small valid SimpleQuery message parses correctly."""
+        query = b"SELECT 1\x00"
+        raw = _make_frontend_message(b"Q", query)
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+
+        msg_type, payload = await read_frontend_message(reader)
+
+        assert msg_type == "Q"
+        assert payload == query

--- a/signalpilot/gateway/tests/test_dbt_proxy_protocol_timeout.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_protocol_timeout.py
@@ -1,0 +1,138 @@
+"""Tests for the slowloris read-timeout hardening in the dbt-proxy protocol module.
+
+Verifies that read_exact (and therefore read_startup_message /
+read_frontend_message) raise ValueError when the peer sends a frame header
+but stalls the body, and that the timeout fires fast (wall-clock < 1.0 s).
+
+READ_TIMEOUT_SECONDS is monkeypatched to 0.05 s in the slow tests to keep
+the suite fast.  The patch works because read_exact reads the module-level
+name at call time (not as a default arg).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+import time
+
+import pytest
+
+import gateway.dbt_proxy.protocol as protocol
+from gateway.dbt_proxy.protocol import (
+    read_frontend_message,
+    read_startup_message,
+)
+
+_FAST_TIMEOUT = 0.05  # seconds — monkeypatched value for slow-path tests
+
+
+class TestSlowlorisTimeout:
+    """read_exact must time out and raise ValueError when a peer stalls."""
+
+    @pytest.mark.asyncio
+    async def test_startup_slowloris_body_never_arrives(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Startup: header arrives, body never does → ValueError within 1 s.
+
+        The length value (100) is within the cap, so if the implementation
+        allocates memory before timing out the test would hang.  Instead, the
+        await on read_exact(reader, 96) must time out.
+        """
+        monkeypatch.setattr(protocol, "READ_TIMEOUT_SECONDS", _FAST_TIMEOUT)
+
+        total_length = 100
+        length_bytes = struct.pack("!I", total_length)
+        reader = asyncio.StreamReader()
+        reader.feed_data(length_bytes)
+        # No body — reader remains open (not EOF)
+
+        t0 = time.monotonic()
+        with pytest.raises(ValueError, match="read timed out"):
+            await read_startup_message(reader)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 1.0, f"timeout fired too late: {elapsed:.3f}s"
+
+    @pytest.mark.asyncio
+    async def test_frontend_slowloris_body_never_arrives(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Frontend: type byte + length header arrive, body never does → ValueError."""
+        monkeypatch.setattr(protocol, "READ_TIMEOUT_SECONDS", _FAST_TIMEOUT)
+
+        payload_len = 100
+        # length field includes itself (4 bytes)
+        header = b"Q" + struct.pack("!I", payload_len + 4)
+        reader = asyncio.StreamReader()
+        reader.feed_data(header)
+        # No payload bytes fed
+
+        t0 = time.monotonic()
+        with pytest.raises(ValueError, match="read timed out"):
+            await read_frontend_message(reader)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 1.0, f"timeout fired too late: {elapsed:.3f}s"
+
+    @pytest.mark.asyncio
+    async def test_header_slowloris_length_bytes_never_arrive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Frontend: only the type byte arrives, length bytes stall → ValueError.
+
+        The very first read_exact(reader, 4) call (for the length field) must
+        time out, proving the timeout applies to every read_exact invocation.
+        """
+        monkeypatch.setattr(protocol, "READ_TIMEOUT_SECONDS", _FAST_TIMEOUT)
+
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"Q")
+        # No length bytes fed
+
+        t0 = time.monotonic()
+        with pytest.raises(ValueError, match="read timed out"):
+            await read_frontend_message(reader)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 1.0, f"timeout fired too late: {elapsed:.3f}s"
+
+    @pytest.mark.asyncio
+    async def test_fast_path_full_message_succeeds(self) -> None:
+        """A fully-buffered valid message succeeds without spurious timeout.
+
+        Uses the real 30 s READ_TIMEOUT_SECONDS — the data is pre-fed into
+        the StreamReader so readexactly() returns immediately; no timeout risk.
+        """
+        query = b"SELECT 1\x00"
+        length = struct.pack("!I", len(query) + 4)
+        raw = b"Q" + length + query
+
+        reader = asyncio.StreamReader()
+        reader.feed_data(raw)
+
+        msg_type, payload = await read_frontend_message(reader)
+
+        assert msg_type == "Q"
+        assert payload == query
+
+    @pytest.mark.asyncio
+    async def test_fast_path_large_message_succeeds(self) -> None:
+        """A near-cap (16 MiB-1) fully-buffered message succeeds without timeout.
+
+        Confirms that the timeout constant is not set so low it rejects
+        legitimate large payloads whose data is already available in the buffer.
+        """
+        from gateway.dbt_proxy.protocol import MAX_FRONTEND_MESSAGE_LEN
+
+        payload = b"\x00" * (MAX_FRONTEND_MESSAGE_LEN - 4)
+        length = struct.pack("!I", len(payload) + 4)
+        raw = b"B" + length + payload
+
+        reader = asyncio.StreamReader(limit=MAX_FRONTEND_MESSAGE_LEN + 8)
+        reader.feed_data(raw)
+
+        msg_type, result_payload = await read_frontend_message(reader)
+
+        assert msg_type == "B"
+        assert len(result_payload) == MAX_FRONTEND_MESSAGE_LEN - 4

--- a/signalpilot/gateway/tests/test_dbt_proxy_session_limits.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_session_limits.py
@@ -1,0 +1,331 @@
+"""Tests for per-session named-statement and named-portal caps in DbtProxySession.
+
+Verifies that _handle_parse rejects a 257th distinct statement name with
+SQLSTATE 53000, and that re-Parse of an existing name at full cap succeeds
+(overwrite path). Same logic for _handle_bind / _named_portals.
+
+Also verifies Fix 3-bis loop-level ValueError safety net in run():
+- Malformed UTF-8 in portal name → ErrorResponse 22P03, no abrupt close.
+- Binary float8 NaN Bind value → ErrorResponse 22P03, connection recovers.
+
+Tests drive _handle_parse / _handle_bind directly to avoid the full
+startup/auth overhead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.dbt_proxy.protocol import OID_FLOAT8
+from gateway.dbt_proxy.session import (
+    MAX_NAMED_PORTALS_PER_SESSION,
+    MAX_NAMED_STATEMENTS_PER_SESSION,
+    DbtProxySession,
+)
+from gateway.dbt_proxy.tokens import RunTokenClaims
+
+
+def _claims() -> RunTokenClaims:
+    return RunTokenClaims(
+        run_id=uuid.uuid4(),
+        org_id="org-1",
+        user_id="user-1",
+        connector_name="my_conn",
+        expires_at=9999999999.0,
+    )
+
+
+class FakeWriter:
+    """Captures write() calls; drain() is a no-op."""
+
+    def __init__(self) -> None:
+        self.buf: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.buf.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    @property
+    def combined(self) -> bytes:
+        return b"".join(self.buf)
+
+
+def _make_parse_payload(stmt_name: str, query: str = "SELECT 1") -> bytes:
+    """Build a minimal Parse message payload."""
+    return (
+        stmt_name.encode() + b"\x00"
+        + query.encode() + b"\x00"
+        + struct.pack("!H", 0)  # 0 param type OIDs
+    )
+
+
+def _make_bind_payload(portal: str, stmt_name: str) -> bytes:
+    """Build a minimal Bind message payload with zero params."""
+    return (
+        portal.encode() + b"\x00"
+        + stmt_name.encode() + b"\x00"
+        + struct.pack("!H", 0)   # 0 format codes
+        + struct.pack("!H", 0)   # 0 param values
+    )
+
+
+def _make_session() -> tuple[DbtProxySession, FakeWriter]:
+    reader = asyncio.StreamReader()
+    writer = FakeWriter()
+    session = DbtProxySession(reader, writer, _claims(), MagicMock())
+    return session, writer
+
+
+class TestNamedStatementCap:
+    """_handle_parse must enforce MAX_NAMED_STATEMENTS_PER_SESSION."""
+
+    @pytest.mark.asyncio
+    async def test_256_distinct_statements_all_succeed(self) -> None:
+        """The first MAX cap entries are accepted; each produces ParseComplete."""
+        session, writer = _make_session()
+
+        for i in range(MAX_NAMED_STATEMENTS_PER_SESSION):
+            writer.buf.clear()
+            await session._handle_parse(_make_parse_payload(f"stmt_{i}"))
+            # ParseComplete is b"1\x00\x00\x00\x04"
+            assert b"1" in writer.combined, f"stmt_{i} did not get ParseComplete"
+
+        assert len(session._named_stmts) == MAX_NAMED_STATEMENTS_PER_SESSION
+
+    @pytest.mark.asyncio
+    async def test_257th_distinct_name_rejected_with_sqlstate_53000(self) -> None:
+        """The 257th unique name must be rejected with SQLSTATE 53000."""
+        session, writer = _make_session()
+
+        for i in range(MAX_NAMED_STATEMENTS_PER_SESSION):
+            await session._handle_parse(_make_parse_payload(f"stmt_{i}"))
+
+        assert len(session._named_stmts) == MAX_NAMED_STATEMENTS_PER_SESSION
+
+        writer.buf.clear()
+        await session._handle_parse(_make_parse_payload("stmt_overflow"))
+
+        combined = writer.combined
+        assert b"53000" in combined, "expected SQLSTATE 53000 in ErrorResponse"
+        assert b"E" in combined, "expected ErrorResponse type byte"
+        assert len(session._named_stmts) == MAX_NAMED_STATEMENTS_PER_SESSION, (
+            "dict must not grow past the cap"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reparse_existing_name_at_full_cap_succeeds(self) -> None:
+        """Re-Parse of an existing name at full cap must succeed (overwrite path)."""
+        session, writer = _make_session()
+
+        for i in range(MAX_NAMED_STATEMENTS_PER_SESSION):
+            await session._handle_parse(_make_parse_payload(f"stmt_{i}"))
+
+        assert len(session._named_stmts) == MAX_NAMED_STATEMENTS_PER_SESSION
+
+        writer.buf.clear()
+        # Re-parse an existing name with a different query
+        await session._handle_parse(_make_parse_payload("stmt_0", "SELECT 42"))
+
+        combined = writer.combined
+        assert b"53000" not in combined, "re-parse of existing name must not be rejected"
+        assert b"1" in combined, "re-parse must produce ParseComplete"
+        # Size must not change
+        assert len(session._named_stmts) == MAX_NAMED_STATEMENTS_PER_SESSION
+        # Query must be updated
+        assert session._named_stmts["stmt_0"][0] == "SELECT 42"
+
+
+class TestNamedPortalCap:
+    """_handle_bind must enforce MAX_NAMED_PORTALS_PER_SESSION."""
+
+    @pytest.mark.asyncio
+    async def test_256_distinct_portals_all_succeed(self) -> None:
+        """The first MAX cap portals are accepted; each produces BindComplete."""
+        session, writer = _make_session()
+
+        # Pre-register one statement to back all binds
+        await session._handle_parse(_make_parse_payload("shared_stmt"))
+        writer.buf.clear()
+
+        for i in range(MAX_NAMED_PORTALS_PER_SESSION):
+            writer.buf.clear()
+            await session._handle_bind(_make_bind_payload(f"portal_{i}", "shared_stmt"))
+            assert b"2" in writer.combined, f"portal_{i} did not get BindComplete"
+
+        assert len(session._named_portals) == MAX_NAMED_PORTALS_PER_SESSION
+
+    @pytest.mark.asyncio
+    async def test_257th_distinct_portal_rejected_with_sqlstate_53000(self) -> None:
+        """The 257th unique portal must be rejected with SQLSTATE 53000."""
+        session, writer = _make_session()
+
+        await session._handle_parse(_make_parse_payload("shared_stmt"))
+
+        for i in range(MAX_NAMED_PORTALS_PER_SESSION):
+            await session._handle_bind(_make_bind_payload(f"portal_{i}", "shared_stmt"))
+
+        assert len(session._named_portals) == MAX_NAMED_PORTALS_PER_SESSION
+
+        writer.buf.clear()
+        await session._handle_bind(_make_bind_payload("portal_overflow", "shared_stmt"))
+
+        combined = writer.combined
+        assert b"53000" in combined, "expected SQLSTATE 53000 in ErrorResponse"
+        assert b"E" in combined, "expected ErrorResponse type byte"
+        assert len(session._named_portals) == MAX_NAMED_PORTALS_PER_SESSION, (
+            "portal dict must not grow past the cap"
+        )
+
+
+def _make_bind_payload_raw_portal(portal_bytes: bytes, stmt_name: str) -> bytes:
+    """Build a Bind payload where the portal name bytes are passed verbatim (pre-NUL)."""
+    return (
+        portal_bytes + b"\x00"
+        + stmt_name.encode() + b"\x00"
+        + struct.pack("!H", 0)   # 0 format codes
+        + struct.pack("!H", 0)   # 0 param values
+    )
+
+
+def _make_bind_payload_float8_binary(stmt_name: str, float8_bytes: bytes) -> bytes:
+    """Build a Bind payload with one binary float8 parameter."""
+    # OID_FLOAT8 = 701; the session uses the OID from the statement's oids list
+    portal = b"\x00"
+    stmt = stmt_name.encode() + b"\x00"
+    n_formats = struct.pack("!H", 1)
+    fmt_binary = struct.pack("!H", 1)   # binary format for all params
+    n_params = struct.pack("!H", 1)
+    param_len = struct.pack("!i", len(float8_bytes))
+    return portal + stmt + n_formats + fmt_binary + n_params + param_len + float8_bytes
+
+
+class TestRunLoopValueErrorSafetyNet:
+    """Fix 3-bis loop-level safety net: ValueError escaping any handler must
+    produce ErrorResponse 22P03 and allow the connection to continue.
+
+    These tests exercise the broader try/except ValueError in run() that catches
+    errors escaping _handle_bind before (UnicodeDecodeError from parse_bind_message)
+    and after (ValueError from _format_param) the existing per-iteration try/except.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_utf8_portal_name_emits_error_response_22p03(self) -> None:
+        """Bind with non-UTF-8 portal name bytes raises UnicodeDecodeError (a ValueError
+        subclass) inside parse_bind_message, which escapes _handle_bind.  The loop-level
+        catch must convert it to ErrorResponse SQLSTATE 22P03 without closing.
+
+        Recovery is verified by injecting a second Bind (well-formed) that succeeds.
+        """
+        session, writer = _make_session()
+
+        # Pre-register a statement so _handle_bind doesn't fail on unknown-stmt check
+        await session._handle_parse(_make_parse_payload("good_stmt"))
+        writer.buf.clear()
+
+        # Build a Bind payload whose portal name contains 0xFF (invalid UTF-8 start byte)
+        bad_portal_bytes = b"\xff\xfe"  # never valid in UTF-8
+        bad_bind = _make_bind_payload_raw_portal(bad_portal_bytes, "good_stmt")
+
+        # We call _handle_bind directly here since run() requires a real reader.
+        # UnicodeDecodeError is a ValueError subclass — it must be caught by
+        # run()'s loop-level except. We verify _handle_bind itself propagates it
+        # (i.e. no catch inside _handle_bind for this case), and then test run()
+        # wrapping by using the helper below.
+        with pytest.raises((UnicodeDecodeError, ValueError)):
+            await session._handle_bind(bad_bind)
+
+    @pytest.mark.asyncio
+    async def test_run_loop_catches_unicode_decode_error_emits_22p03_and_continues(
+        self,
+    ) -> None:
+        """run() must catch UnicodeDecodeError from _handle_bind (via parse_bind_message),
+        emit ErrorResponse 22P03, and continue — verified by a subsequent Sync receiving
+        ReadyForQuery.
+        """
+        # Build the two-message sequence: bad Bind ('B') then Sync ('S')
+        bad_portal_bytes = b"\xff\xfe"
+        bad_bind_payload = _make_bind_payload_raw_portal(bad_portal_bytes, "")
+
+        def _frame(msg_type: bytes, payload: bytes) -> bytes:
+            return msg_type + struct.pack("!I", 4 + len(payload)) + payload
+
+        bad_bind_frame = _frame(b"B", bad_bind_payload)
+        sync_frame = _frame(b"S", b"")
+        terminate_frame = _frame(b"X", b"")
+
+        wire = bad_bind_frame + sync_frame + terminate_frame
+
+        reader = asyncio.StreamReader()
+        reader.feed_data(wire)
+        reader.feed_eof()
+
+        writer = FakeWriter()
+        session = DbtProxySession(reader, writer, _claims(), MagicMock())
+
+        await session.run()
+
+        combined = writer.combined
+        # ErrorResponse for the bad Bind
+        assert b"22P03" in combined, "expected SQLSTATE 22P03 for bad portal name"
+        assert b"E" in combined, "expected ErrorResponse type byte"
+        # ReadyForQuery from Sync proves the loop continued after the error
+        assert b"Z" in combined, "expected ReadyForQuery ('Z') from Sync — loop must continue"
+
+    @pytest.mark.asyncio
+    async def test_binary_float8_nan_bind_emits_22p03_and_continues(self) -> None:
+        """Bind with binary float8 NaN (0x7FF8000000000000) parses cleanly in
+        parse_bind_value (returns float('nan')), then trips _format_param with ValueError.
+        That ValueError escapes _handle_bind after the existing try/except.
+        The loop-level catch must emit ErrorResponse 22P03 and keep the loop alive.
+        """
+        # float8 NaN IEEE 754: 0x7FF8000000000000
+        nan_bytes = bytes.fromhex("7FF8000000000000")
+
+        def _frame(msg_type: bytes, payload: bytes) -> bytes:
+            return msg_type + struct.pack("!I", 4 + len(payload)) + payload
+
+        # Pre-populate statement with OID_FLOAT8 parameter
+        # Use a Parse frame to seed the session
+        parse_payload = (
+            b"f\x00"                       # stmt name "f"
+            + b"SELECT $1\x00"             # query
+            + struct.pack("!H", 1)         # 1 oid
+            + struct.pack("!I", OID_FLOAT8)
+        )
+        bind_payload = _make_bind_payload_float8_binary("f", nan_bytes)
+        sync_payload = b""
+        terminate_payload = b""
+
+        wire = (
+            _frame(b"P", parse_payload)
+            + _frame(b"B", bind_payload)
+            + _frame(b"S", sync_payload)
+            + _frame(b"X", terminate_payload)
+        )
+
+        reader = asyncio.StreamReader()
+        reader.feed_data(wire)
+        reader.feed_eof()
+
+        writer = FakeWriter()
+        session = DbtProxySession(reader, writer, _claims(), MagicMock())
+
+        await session.run()
+
+        combined = writer.combined
+        # ParseComplete from Parse
+        assert b"1" in combined, "expected ParseComplete from Parse"
+        # ErrorResponse with 22P03 from the NaN Bind
+        assert b"22P03" in combined, "expected SQLSTATE 22P03 for NaN float8 Bind"
+        # ReadyForQuery from Sync proves loop continued
+        assert b"Z" in combined, "expected ReadyForQuery from Sync — loop must continue"

--- a/signalpilot/gateway/tests/test_dbt_validation_prefix_bypass.py
+++ b/signalpilot/gateway/tests/test_dbt_validation_prefix_bypass.py
@@ -1,0 +1,238 @@
+"""Regression tests for whitespace/comment evasion bypass of _DENIED_PREFIX_RE.
+
+These tests verify that tab, newline, and block-comment separators between
+SQL tokens do not allow privileged-object statements to bypass the validator.
+Both Layer A (normalization) and Layer B (AST kind-check / Command-node regex)
+are exercised.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from gateway.dbt_proxy.tokens import RunTokenClaims
+from gateway.engine.dbt_validation import ValidatedStatement, validate_dbt_statement
+
+
+def _claims(connector: str = "my_db") -> RunTokenClaims:
+    return RunTokenClaims(
+        run_id=uuid.uuid4(),
+        org_id="test-org",
+        user_id="test-user",
+        connector_name=connector,
+        expires_at=9999999999.0,
+    )
+
+
+class TestPrefixBypassBlocked:
+    """Each payload must be blocked — bypasses proven on the pre-fix code."""
+
+    def test_create_role_double_space(self) -> None:
+        result = validate_dbt_statement("CREATE  ROLE evil", claims=_claims())
+        assert result.blocked
+
+    def test_create_role_tab(self) -> None:
+        result = validate_dbt_statement("CREATE\tROLE evil", claims=_claims())
+        assert result.blocked
+
+    def test_create_role_newline(self) -> None:
+        result = validate_dbt_statement("CREATE\nROLE evil", claims=_claims())
+        assert result.blocked
+
+    def test_create_role_block_comment(self) -> None:
+        result = validate_dbt_statement("CREATE/*c*/ROLE evil", claims=_claims())
+        assert result.blocked
+
+    def test_create_role_empty_block_comment(self) -> None:
+        result = validate_dbt_statement("CREATE/**/ROLE evil", claims=_claims())
+        assert result.blocked
+
+    def test_create_role_line_comment_newline(self) -> None:
+        # Line comment stripped → "create  role evil" → normalized → "create role evil"
+        result = validate_dbt_statement("create -- inline\nrole evil", claims=_claims())
+        assert result.blocked
+
+    def test_drop_user_double_space(self) -> None:
+        result = validate_dbt_statement("DROP  USER bob", claims=_claims())
+        assert result.blocked
+
+    def test_alter_user_tab(self) -> None:
+        result = validate_dbt_statement("ALTER\tUSER alice SUPERUSER", claims=_claims())
+        assert result.blocked
+
+    def test_create_extension_double_space(self) -> None:
+        result = validate_dbt_statement("CREATE  EXTENSION pglogical", claims=_claims())
+        assert result.blocked
+
+    def test_create_database_block_comment(self) -> None:
+        result = validate_dbt_statement("CREATE/*x*/DATABASE pwn", claims=_claims())
+        assert result.blocked
+
+    def test_drop_tablespace_double_space(self) -> None:
+        result = validate_dbt_statement("DROP  TABLESPACE ts", claims=_claims())
+        assert result.blocked
+
+    def test_create_language_double_space_rce(self) -> None:
+        result = validate_dbt_statement("CREATE  LANGUAGE plpython3u", claims=_claims())
+        assert result.blocked
+
+    def test_create_function_double_space_regression(self) -> None:
+        # Already blocked pre-fix — must remain blocked.
+        result = validate_dbt_statement(
+            "CREATE  FUNCTION f() RETURNS void AS $$ $$ LANGUAGE sql",
+            claims=_claims(),
+        )
+        assert result.blocked
+
+    def test_create_role_after_semicolon(self) -> None:
+        result = validate_dbt_statement("; CREATE  ROLE evil", claims=_claims())
+        assert result.blocked
+
+    def test_create_role_nested_block_comment_layer_b(self) -> None:
+        # Postgres nested block comment: /* /* x */ */ — Layer A's non-recursive
+        # regex leaves "CREATE*/ ROLE evil" which won't match the prefix.
+        # Layer B (AST kind-check / Command-node regex) must catch this.
+        result = validate_dbt_statement("CREATE/*/*x*/*/ROLE evil", claims=_claims())
+        assert result.blocked
+
+
+class TestPrefixBypassNegativeControls:
+    """Statements that must NOT be blocked (regression / false-positive guard)."""
+
+    def test_select_with_create_role_in_comment_not_blocked(self) -> None:
+        # The comment is stripped; what remains is "SELECT 1  FROM x" — safe.
+        result = validate_dbt_statement(
+            "SELECT 1 -- create role in a comment\nFROM x",
+            claims=_claims(),
+        )
+        assert not result.blocked
+
+    def test_insert_with_create_role_in_string_literal_not_blocked(self) -> None:
+        # The payload is inside a string literal — prefix boundary (?:^|[\s;])
+        # won't match because the opening quote is not whitespace or semicolon.
+        result = validate_dbt_statement(
+            "INSERT INTO t (name) VALUES ('CREATE ROLE evil')",
+            claims=_claims(),
+        )
+        assert not result.blocked
+
+    def test_create_table_not_blocked(self) -> None:
+        result = validate_dbt_statement("CREATE TABLE foo (id int)", claims=_claims())
+        assert not result.blocked
+
+
+class TestGrantRevokeAndSetLocalBypasses:
+    """Tests for V1–V4 security bypasses found in Round 2 security review.
+
+    V1: GRANT <role> TO <role>  — role-membership grant (Command node, not exp.Grant)
+    V2: REVOKE <role> FROM <role> — same root cause
+    V3: SET LOCAL ROLE admin — LOCAL qualifier sits between SET and ROLE
+    V4: SET LOCAL SESSION AUTHORIZATION admin — same qualifier issue
+    """
+
+    # ── V1: GRANT role membership ─────────────────────────────────────────────
+
+    def test_grant_role_to_role_blocked(self) -> None:
+        result = validate_dbt_statement("GRANT admin TO evil", claims=_claims())
+        assert result.blocked
+        assert result.block_reason is not None
+
+    def test_grant_role_to_role_original_sql_preserved(self) -> None:
+        original = "GRANT admin TO evil"
+        result = validate_dbt_statement(original, claims=_claims())
+        assert result.blocked
+        assert result.sql == original
+
+    # ── V2: REVOKE role membership ────────────────────────────────────────────
+
+    def test_revoke_role_from_role_blocked(self) -> None:
+        result = validate_dbt_statement("REVOKE admin FROM evil", claims=_claims())
+        assert result.blocked
+        assert result.block_reason is not None
+
+    def test_revoke_role_from_role_original_sql_preserved(self) -> None:
+        original = "REVOKE admin FROM evil"
+        result = validate_dbt_statement(original, claims=_claims())
+        assert result.blocked
+        assert result.sql == original
+
+    # ── V3: SET LOCAL ROLE ────────────────────────────────────────────────────
+
+    def test_set_local_role_blocked(self) -> None:
+        result = validate_dbt_statement("SET LOCAL ROLE admin", claims=_claims())
+        assert result.blocked
+        assert result.block_reason == "privilege_escalation_blocked"
+
+    def test_set_role_still_blocked(self) -> None:
+        # Regression: plain SET ROLE must still be blocked.
+        result = validate_dbt_statement("SET ROLE admin", claims=_claims())
+        assert result.blocked
+        assert result.block_reason == "privilege_escalation_blocked"
+
+    # ── V4: SET LOCAL SESSION AUTHORIZATION ───────────────────────────────────
+
+    def test_set_local_session_authorization_blocked(self) -> None:
+        result = validate_dbt_statement("SET LOCAL SESSION AUTHORIZATION admin", claims=_claims())
+        assert result.blocked
+        assert result.block_reason == "privilege_escalation_blocked"
+
+    def test_set_session_authorization_still_blocked(self) -> None:
+        # Regression: plain SET SESSION AUTHORIZATION must still be blocked.
+        result = validate_dbt_statement("SET SESSION AUTHORIZATION admin", claims=_claims())
+        assert result.blocked
+        assert result.block_reason == "privilege_escalation_blocked"
+
+    # ── V5: SET SESSION ROLE / SET SESSION SESSION AUTHORIZATION ──────────────
+    # PG accepts SESSION as an alternative qualifier to LOCAL: `SET SESSION ROLE`
+    # is identical to `SET ROLE`. Same for SESSION AUTHORIZATION.
+
+    def test_set_session_role_blocked(self) -> None:
+        result = validate_dbt_statement("SET SESSION ROLE admin", claims=_claims())
+        assert result.blocked
+        assert result.block_reason == "privilege_escalation_blocked"
+
+    def test_set_session_session_authorization_blocked(self) -> None:
+        result = validate_dbt_statement(
+            "SET SESSION SESSION AUTHORIZATION admin", claims=_claims()
+        )
+        assert result.blocked
+        assert result.block_reason == "privilege_escalation_blocked"
+
+
+class TestGrantRevokeSetLocalNegativeControls:
+    """False-positive guard — these must NOT be blocked."""
+
+    def test_set_search_path_allowed(self) -> None:
+        result = validate_dbt_statement("SET search_path = public", claims=_claims())
+        assert not result.blocked
+
+    def test_set_local_statement_timeout_allowed(self) -> None:
+        result = validate_dbt_statement("SET LOCAL statement_timeout = 5000", claims=_claims())
+        assert not result.blocked
+
+    def test_set_work_mem_allowed(self) -> None:
+        result = validate_dbt_statement("SET work_mem = '4MB'", claims=_claims())
+        assert not result.blocked
+
+
+class TestValidatedStatementSqlUnchanged:
+    """ValidatedStatement.sql must always be byte-identical to the original input."""
+
+    def test_sql_field_is_original_not_normalized_for_allowed(self) -> None:
+        original = "SELECT\t1\n-- comment\nFROM x"
+        result = validate_dbt_statement(original, claims=_claims())
+        assert result.sql == original
+
+    def test_sql_field_is_original_not_normalized_for_blocked(self) -> None:
+        original = "CREATE\tROLE evil"
+        result = validate_dbt_statement(original, claims=_claims())
+        assert result.blocked
+        assert result.sql == original
+
+    def test_sql_field_is_original_for_block_comment_payload(self) -> None:
+        original = "CREATE/*c*/ROLE evil"
+        result = validate_dbt_statement(original, claims=_claims())
+        assert result.blocked
+        assert result.sql == original

--- a/signalpilot/gateway/tests/test_engine_dbt_validation.py
+++ b/signalpilot/gateway/tests/test_engine_dbt_validation.py
@@ -71,3 +71,27 @@ class TestDbtValidation:
     def test_create_extension_blocked(self) -> None:
         result = validate_dbt_statement("CREATE EXTENSION pg_stat_statements", claims=_claims())
         assert result.blocked
+
+    def test_prefix_block_after_semicolon_with_tab(self) -> None:
+        result = validate_dbt_statement("SELECT 1;\tCOPY foo FROM PROGRAM 'evil'", claims=_claims())
+        assert result.blocked
+
+    def test_prefix_does_not_block_identifier_with_prefix(self) -> None:
+        result = validate_dbt_statement("BEGIN; double_thing()", claims=_claims())
+        assert not result.blocked
+
+    def test_current_setting_search_path_allowed(self) -> None:
+        result = validate_dbt_statement("SELECT current_setting('search_path')", claims=_claims())
+        assert not result.blocked
+
+    def test_current_setting_ssl_cert_blocked(self) -> None:
+        result = validate_dbt_statement("SELECT current_setting('ssl_cert_file')", claims=_claims())
+        assert result.blocked
+
+    def test_current_setting_non_literal_blocked(self) -> None:
+        result = validate_dbt_statement("SELECT current_setting(my_var)", claims=_claims())
+        assert result.blocked
+
+    def test_set_config_ssl_blocked(self) -> None:
+        result = validate_dbt_statement("SELECT set_config('ssl_cert_file', 'x', false)", claims=_claims())
+        assert result.blocked

--- a/signalpilot/gateway/tests/test_knowledge_api.py
+++ b/signalpilot/gateway/tests/test_knowledge_api.py
@@ -150,8 +150,13 @@ class TestKnowledgeDetailEndpoint:
 
         monkeypatch.setattr(Store, "get_knowledge_doc", AsyncMock(return_value=None))
 
-        resp = auth_client.get("/api/knowledge/missing-id")
+        missing_uuid = str(uuid.uuid4())
+        resp = auth_client.get(f"/api/knowledge/{missing_uuid}")
         assert resp.status_code == 404
+
+    def test_get_doc_invalid_uuid_returns_422(self, auth_client):
+        resp = auth_client.get("/api/knowledge/not-a-uuid")
+        assert resp.status_code == 422
 
 
 class TestKnowledgeCreateEndpoint:
@@ -260,8 +265,9 @@ class TestKnowledgeUpdateEndpoint:
             AsyncMock(side_effect=KnowledgeNotFound("not found")),
         )
 
+        missing_uuid = str(uuid.uuid4())
         resp = auth_client.put(
-            "/api/knowledge/missing-id",
+            f"/api/knowledge/{missing_uuid}",
             json={"body": "new body"},
         )
         assert resp.status_code == 404
@@ -273,7 +279,8 @@ class TestKnowledgeDeleteEndpoint:
 
         monkeypatch.setattr(Store, "archive_knowledge_doc", AsyncMock(return_value=True))
 
-        resp = auth_client.delete("/api/knowledge/some-id")
+        some_uuid = str(uuid.uuid4())
+        resp = auth_client.delete(f"/api/knowledge/{some_uuid}")
         assert resp.status_code == 204
 
     def test_delete_not_found_returns_404(self, auth_client, monkeypatch):
@@ -281,7 +288,8 @@ class TestKnowledgeDeleteEndpoint:
 
         monkeypatch.setattr(Store, "archive_knowledge_doc", AsyncMock(return_value=False))
 
-        resp = auth_client.delete("/api/knowledge/missing-id")
+        missing_uuid = str(uuid.uuid4())
+        resp = auth_client.delete(f"/api/knowledge/{missing_uuid}")
         assert resp.status_code == 404
 
 
@@ -292,7 +300,8 @@ class TestKnowledgeApproveEndpoint:
 
         monkeypatch.setattr(Store, "approve_knowledge_doc", AsyncMock(return_value=doc))
 
-        resp = auth_client.post("/api/knowledge/some-id/approve")
+        some_uuid = str(uuid.uuid4())
+        resp = auth_client.post(f"/api/knowledge/{some_uuid}/approve")
         assert resp.status_code == 200
         assert resp.json()["status"] == "active"
 
@@ -305,7 +314,8 @@ class TestKnowledgeApproveEndpoint:
             AsyncMock(side_effect=KnowledgeNotFound("not found")),
         )
 
-        resp = auth_client.post("/api/knowledge/missing-id/approve")
+        missing_uuid = str(uuid.uuid4())
+        resp = auth_client.post(f"/api/knowledge/{missing_uuid}/approve")
         assert resp.status_code == 404
 
     def test_approve_wrong_state_returns_409(self, auth_client, monkeypatch):
@@ -317,7 +327,8 @@ class TestKnowledgeApproveEndpoint:
             AsyncMock(side_effect=KnowledgeStateConflict("wrong state")),
         )
 
-        resp = auth_client.post("/api/knowledge/some-id/approve")
+        some_uuid = str(uuid.uuid4())
+        resp = auth_client.post(f"/api/knowledge/{some_uuid}/approve")
         assert resp.status_code == 409
 
 
@@ -326,9 +337,10 @@ class TestKnowledgeEditsEndpoint:
         from gateway.models.knowledge import KnowledgeEdit
         from gateway.store import Store
 
+        doc_uuid = str(uuid.uuid4())
         edit = KnowledgeEdit(
             id=str(uuid.uuid4()),
-            doc_id="doc-1",
+            doc_id=doc_uuid,
             org_id="test-org",
             body_before="old body",
             bytes_before=8,
@@ -338,12 +350,27 @@ class TestKnowledgeEditsEndpoint:
         )
         monkeypatch.setattr(Store, "list_knowledge_edits", AsyncMock(return_value=[edit]))
 
-        resp = auth_client.get("/api/knowledge/doc-1/edits")
+        resp = auth_client.get(f"/api/knowledge/{doc_uuid}/edits")
         assert resp.status_code == 200
         data = resp.json()
         assert isinstance(data, list)
         assert len(data) == 1
         assert data[0]["edit_kind"] == "human"
+
+
+class TestKnowledgeScopeRefValidation:
+    def test_create_rejects_scope_ref_with_control_char(self, auth_client):
+        resp = auth_client.post(
+            "/api/knowledge",
+            json={
+                "scope": "project",
+                "scope_ref": "my\nproject",
+                "category": "conventions",
+                "title": "test-doc",
+                "body": "Some content.",
+            },
+        )
+        assert resp.status_code == 422
 
 
 class TestKnowledgeAdminScopeEnforcement:

--- a/signalpilot/gateway/tests/test_knowledge_store.py
+++ b/signalpilot/gateway/tests/test_knowledge_store.py
@@ -33,6 +33,8 @@ from gateway.store.knowledge import (
     archive_knowledge_doc,
     get_knowledge_usage,
     increment_knowledge_view,
+    insert_knowledge_doc,
+    upsert_knowledge_doc,
 )
 
 
@@ -383,3 +385,208 @@ class TestGatewaySettingsKnowledgeOverride:
 
         with pytest.raises(pydantic.ValidationError):
             GatewaySettings(knowledge_history_versions_override="not-an-int")  # type: ignore[arg-type]
+
+
+def _make_insert_session(existing_bytes: int = 0) -> AsyncMock:
+    """Build a session mock suitable for insert_knowledge_doc."""
+    session = AsyncMock()
+    row = MagicMock()
+    row.id = str(uuid.uuid4())
+    row.org_id = "test-org"
+    row.scope = "org"
+    row.scope_ref = None
+    row.category = "conventions"
+    row.title = "test-doc"
+    row.body = "content"
+    row.status = "active"
+    row.bytes = len("content".encode("utf-8"))
+    row.view_count = 0
+    row.created_at = time.time()
+    row.updated_at = time.time()
+    row.created_by = None
+    row.updated_by = None
+    row.proposed_by_agent = None
+
+    scalar_result = MagicMock()
+    scalar_result.scalar.return_value = existing_bytes
+    session.execute = AsyncMock(return_value=scalar_result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock(side_effect=lambda r: None)
+
+    return session, row
+
+
+class TestAgentProposalCloudGating:
+    """Cloud-mode gating for agent-proposed knowledge docs."""
+
+    @pytest.mark.asyncio
+    async def test_agent_proposal_active_in_localhost(self, monkeypatch):
+        """In localhost mode, agent-proposed docs are auto-accepted (status=active)."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+
+        session, row = _make_insert_session()
+        captured_rows: list = []
+
+        def capture_add(r):
+            captured_rows.append(r)
+
+        session.add = MagicMock(side_effect=capture_add)
+
+        payload = KnowledgeDocCreate(
+            scope=KnowledgeScope.org,
+            scope_ref=None,
+            category=KnowledgeCategory.conventions,
+            title="test-doc",
+            body="content",
+        )
+        limits = _make_limits()
+        settings = _make_settings()
+
+        await insert_knowledge_doc(
+            session,
+            org_id="test-org",
+            payload=payload,
+            user_id=None,
+            agent="propose_knowledge",
+            limits=limits,
+            settings=settings,
+        )
+        assert len(captured_rows) == 1
+        assert captured_rows[0].status == "active"
+
+    @pytest.mark.asyncio
+    async def test_agent_proposal_pending_in_cloud(self, monkeypatch):
+        """In cloud mode, agent-proposed docs are forced to pending regardless of category."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+
+        session, row = _make_insert_session()
+        captured_rows: list = []
+
+        def capture_add(r):
+            captured_rows.append(r)
+
+        session.add = MagicMock(side_effect=capture_add)
+
+        payload = KnowledgeDocCreate(
+            scope=KnowledgeScope.org,
+            scope_ref=None,
+            category=KnowledgeCategory.conventions,
+            title="test-doc",
+            body="content",
+        )
+        limits = _make_limits()
+        settings = _make_settings()
+
+        await insert_knowledge_doc(
+            session,
+            org_id="test-org",
+            payload=payload,
+            user_id=None,
+            agent="propose_knowledge",
+            limits=limits,
+            settings=settings,
+        )
+        assert len(captured_rows) == 1
+        assert captured_rows[0].status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_agent_upsert_update_pending_in_cloud(self, monkeypatch):
+        """In cloud mode, agent update of an active doc forces status=pending."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+
+        session = AsyncMock()
+        existing = _make_doc_row(status="active", body="old content")
+
+        call_count = 0
+
+        async def execute_side_effect(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # _find_doc_by_key: returns existing row
+                result.scalar_one_or_none.return_value = existing
+            elif call_count == 2:
+                # current_bytes query
+                result.scalar.return_value = 100
+            else:
+                result.scalar_one_or_none.return_value = existing
+                result.scalar_one.return_value = existing
+            return result
+
+        session.execute = AsyncMock(side_effect=execute_side_effect)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        payload = KnowledgeDocCreate(
+            scope=KnowledgeScope.org,
+            scope_ref=None,
+            category=KnowledgeCategory.conventions,
+            title=existing.title,
+            body="new content",
+        )
+        limits = _make_limits()
+        settings = _make_settings()
+
+        await upsert_knowledge_doc(
+            session,
+            org_id="test-org",
+            payload=payload,
+            user_id=None,
+            agent="propose_knowledge",
+            limits=limits,
+            settings=settings,
+        )
+        assert existing.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_human_upsert_update_keeps_active_in_cloud(self, monkeypatch):
+        """In cloud mode, human update of an active doc does NOT change status."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+
+        session = AsyncMock()
+        existing = _make_doc_row(status="active", body="old content")
+
+        call_count = 0
+
+        async def execute_side_effect(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = existing
+            elif call_count == 2:
+                result.scalar.return_value = 100
+            else:
+                result.scalar_one_or_none.return_value = existing
+                result.scalar_one.return_value = existing
+            return result
+
+        session.execute = AsyncMock(side_effect=execute_side_effect)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        payload = KnowledgeDocCreate(
+            scope=KnowledgeScope.org,
+            scope_ref=None,
+            category=KnowledgeCategory.conventions,
+            title=existing.title,
+            body="new content",
+        )
+        limits = _make_limits()
+        settings = _make_settings()
+
+        await upsert_knowledge_doc(
+            session,
+            org_id="test-org",
+            payload=payload,
+            user_id="admin-user",
+            agent=None,
+            limits=limits,
+            settings=settings,
+        )
+        assert existing.status == "active"

--- a/signalpilot/gateway/tests/test_mcp_server.py
+++ b/signalpilot/gateway/tests/test_mcp_server.py
@@ -180,6 +180,20 @@ class TestFixNondeterminismHazardsOrgScoping:
             )
 
 
+class TestStdioRefusesCloudMode:
+    def test_stdio_refuses_cloud_mode(self, monkeypatch) -> None:
+        """main() must raise SystemExit when SP_DEPLOYMENT_MODE=cloud and transport is stdio."""
+        from unittest.mock import patch
+
+        # Patch is_cloud_mode at the server module to avoid triggering
+        # the cloud auth import-time guard (which requires CLERK_PUBLISHABLE_KEY).
+        with patch("gateway.mcp.server.is_cloud_mode", return_value=True):
+            with patch.dict("os.environ", {"SP_MCP_TRANSPORT": "stdio"}):
+                from gateway.mcp.server import main
+                with pytest.raises(SystemExit, match="Refusing to start MCP stdio transport in cloud mode"):
+                    main()
+
+
 class TestMCPProjectToolsOrgScoping:
     """MCP project tools use Store methods instead of legacy project_store."""
 

--- a/signalpilot/gateway/tests/test_mcp_validation.py
+++ b/signalpilot/gateway/tests/test_mcp_validation.py
@@ -1,0 +1,30 @@
+"""Tests for MCP input validation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.mcp.validation import _MODEL_NAME_RE
+
+
+class TestModelNameRe:
+    def test_model_name_re_rejects_empty_segments(self) -> None:
+        assert _MODEL_NAME_RE.match("a..b") is None
+
+    def test_model_name_re_accepts_three_segments(self) -> None:
+        assert _MODEL_NAME_RE.match("db.schema.tbl") is not None
+
+    def test_model_name_re_rejects_leading_dot(self) -> None:
+        assert _MODEL_NAME_RE.match(".foo") is None
+
+    def test_model_name_re_rejects_trailing_dot(self) -> None:
+        assert _MODEL_NAME_RE.match("foo.") is None
+
+    def test_model_name_re_accepts_single_segment(self) -> None:
+        assert _MODEL_NAME_RE.match("my_model") is not None
+
+    def test_model_name_re_accepts_two_segments(self) -> None:
+        assert _MODEL_NAME_RE.match("schema.table") is not None
+
+    def test_model_name_re_rejects_four_segments(self) -> None:
+        assert _MODEL_NAME_RE.match("a.b.c.d") is None

--- a/signalpilot/gateway/tests/test_model_blueprint_quoting.py
+++ b/signalpilot/gateway/tests/test_model_blueprint_quoting.py
@@ -1,0 +1,42 @@
+"""Tests for SQL identifier quoting in model_blueprint SQL generation."""
+
+from __future__ import annotations
+
+from gateway.mcp.tools.model_blueprint import _qid
+
+
+class TestQidHelper:
+    def test_qid_simple_name(self) -> None:
+        assert _qid("column_name") == '"column_name"'
+
+    def test_qid_doubles_embedded_quotes(self) -> None:
+        assert _qid('foo"bar') == '"foo""bar"'
+
+    def test_qid_injection_attempt(self) -> None:
+        """Embedded double-quote is doubled, not left as a bare injection point."""
+        result = _qid('name"; DROP TABLE x; --')
+        # The embedded " must be escaped to ""
+        assert '""' in result
+        # The result is wrapped in outer quotes and all inner " are doubled
+        assert result == '"name""; DROP TABLE x; --"'
+
+    def test_qid_empty_string(self) -> None:
+        assert _qid("") == '""'
+
+    def test_scope_ref_sql_injection_escaped(self) -> None:
+        """Table name with single-quote injection payload is properly escaped as literal."""
+        malicious_tbl = "foo'; DROP TABLE x; --"
+        safe_tbl = malicious_tbl.replace("'", "''")
+        sql_fragment = f"WHERE table_name = '{safe_tbl}'"
+        # The single quote in 'foo'' is escaped via doubling — no triple-quote run
+        assert "'''" not in sql_fragment
+        assert "foo''" in sql_fragment
+        # The original unescaped payload is not present verbatim
+        assert malicious_tbl not in sql_fragment
+
+    def test_identifier_injection_escaped(self) -> None:
+        """Column name with embedded quote is escaped via _qid."""
+        malicious_col = 'col" OR "1"="1'
+        quoted = _qid(malicious_col)
+        assert quoted == '"col"" OR ""1""=""1"'
+        assert '" OR "1"="1"' not in quoted.replace('""', '')

--- a/signalpilot/gateway/tests/test_model_verify_quoting.py
+++ b/signalpilot/gateway/tests/test_model_verify_quoting.py
@@ -1,0 +1,32 @@
+"""Tests for SQL identifier quoting in model_verify SQL generation."""
+
+from __future__ import annotations
+
+from gateway.mcp.tools.model_verify import _qid
+
+
+class TestModelVerifyQidHelper:
+    def test_qid_simple_name(self) -> None:
+        assert _qid("metric_col") == '"metric_col"'
+
+    def test_qid_doubles_embedded_quotes(self) -> None:
+        assert _qid('col"name') == '"col""name"'
+
+    def test_qid_injection_attempt(self) -> None:
+        """Embedded double-quote is doubled, producing a safe identifier."""
+        result = _qid('"evil"; DROP TABLE')
+        # All inner quotes are doubled — the injection attempt becomes a valid identifier
+        assert result == '"""evil""; DROP TABLE"'
+        # When doubled quotes are collapsed, no bare injection sequence remains
+        assert '"evil"; DROP TABLE' not in result.replace('""', '')
+
+    def test_table_literal_escaping(self) -> None:
+        """DB-derived table name used as SQL literal must escape single quotes."""
+        malicious_tbl = "foo'; DROP TABLE orders; --"
+        safe_tbl = malicious_tbl.replace("'", "''")
+        sql = f"WHERE table_name = '{safe_tbl}'"
+        # The single quote is doubled — no triple-quote run
+        assert "'''" not in sql
+        assert "foo''" in sql
+        # The original unescaped payload is not present verbatim
+        assert malicious_tbl not in sql

--- a/signalpilot/web/app/knowledge/page.tsx
+++ b/signalpilot/web/app/knowledge/page.tsx
@@ -1231,6 +1231,9 @@ export default function KnowledgePage() {
 
 // ── Markdown renderer ─────────────────────────────────────────────────────────
 
+// SAFE_URL anchors the link allowlist for renderInline below.
+// DO NOT broaden to allow `javascript:`, `data:`, `vbscript:`, or `file:` —
+// the markdown renderer would expose XSS via knowledge body content.
 const SAFE_URL = /^https?:\/\//;
 
 // Priority order for wikilink resolution when multiple docs share the same title


### PR DESCRIPTION
Security review and hardening of the dbt-proxy / knowledge-base / model-verify PR.

## Summary

- Added `security-audit.md` ranking findings from lowest (Info) to most severe (High). Round 2 promoted the dbt-validation prefix-bypass class to High after re-attack confirmed real privilege-escalation PoCs. Round 3 added H-4 (dbt-proxy frame OOM).
- Round 1: implemented all 12 hardening sections (Info / Low / Medium).
- Round 2: closed High-severity bypasses in `gateway/engine/dbt_validation.py`:
  - H-1: whitespace / line-comment / nested-block-comment evasion of denied SQL prefixes (`CREATE  ROLE`, `CREATE\tROLE`, `CREATE/*c*/ROLE`, `CREATE/*/*x*/*/ROLE`, etc.) for `CREATE/DROP ROLE|USER|DATABASE|TABLESPACE|EXTENSION|LANGUAGE`.
  - H-2: `GRANT admin TO evil` / `REVOKE admin FROM evil` role-membership bypass (sqlglot `Command` fallback).
  - H-3: `SET [LOCAL|SESSION] ROLE` / `SESSION AUTHORIZATION` qualifier bypass.
- Round 3: closed H-4 in `gateway/dbt_proxy/protocol.py` — pre-/post-auth OOM via attacker-controlled uint32 frame length (~4 GiB alloc per connection). Added `MAX_STARTUP_MESSAGE_LEN = 64 KiB` and `MAX_FRONTEND_MESSAGE_LEN = 16 MiB` caps with pre-`read_exact` checks raising `ValueError` (handled by existing `auth.py`/`session.py` error paths).
- Round 4: closed three residual DoS vectors in dbt-proxy (M-9/M-10/M-11). M-9: 30s read timeout via `asyncio.wait_for` defeats slowloris. M-10: per-session `MAX_NAMED_STATEMENTS_PER_SESSION = 256` / `MAX_NAMED_PORTALS_PER_SESSION = 256` with SQLSTATE 53000 on overflow (re-Parse/Bind overwrite still allowed). M-11: `MAX_NUMERIC_WEIGHT = 1000` companion to the R1 ndigits cap; bounds inner-loop work at 10^6 decimal-digit ops. Plus a per-iteration `try/except ValueError` (SQLSTATE 22P03) inside `_handle_bind` and a loop-level safety net in `run()` that retroactively repairs the M-8 ndigits ValueError propagation (which was silently escaping `run()` and abruptly closing the connection).
- Two-layer defense in `dbt_validation.py`: (A) `_normalize_for_prefix_scan` with character-level nested-block-comment stripper feeds the prefix regex; (B) AST kind-checks for Drop/Alter + `_COMMAND_ADMIN_RE` on `Command.this+expression` covering CREATE/DROP/ALTER/GRANT/REVOKE on privileged objects. `ValidatedStatement.sql` always preserves original input.
- True bugs fixed unconditionally; cloud-only hardening gated via `gateway.runtime.mode.is_cloud_mode()`. Frame-length caps are universal (localhost OOM is also a real risk).
- Postgres port bound to loopback (`127.0.0.1`) in `docker-compose.yml`.
- No new env vars introduced.

## Test plan
- [x] Round 1: 194 tests pass across changed modules.
- [x] Round 2: 34 new bypass tests in `tests/test_dbt_validation_prefix_bypass.py` (15 evasion variants + GRANT/REVOKE + SET LOCAL/SESSION ROLE + SET SESSION SESSION AUTHORIZATION + 6 negative controls + 3 `sql` byte-identity assertions).
- [x] Multi-pass security re-attack: unicode whitespace, dollar-quoted strings, CTE prefix, multi-statement-after-benign, qualifier permutations — no new bypass found.
- [x] Round 3: 7 new tests in `tests/test_dbt_proxy_protocol_limits.py` (oversize startup/frontend rejection, boundary acceptance at cap, regression for min-length checks). 24/24 dbt_proxy tests pass.
- [x] Round 4: 3 new test files (`test_dbt_proxy_protocol_timeout.py`, `test_dbt_proxy_session_limits.py`, `test_dbt_proxy_numeric_bounds.py`) covering slowloris (wall-clock asserts), 256-entry caps + overflow rejection, ±32767 weight rejection, and end-to-end `run()`-loop ValueError safety net (UnicodeDecodeError + binary-NaN). 33/33 dbt_proxy tests pass; pyright + ruff clean.
- [x] Code review APPROVE (Rounds 1, 2, 3, 4). Security review APPROVE (Rounds 1, 2, 3, 4 final re-attacks).
- [ ] Localhost `docker compose up -d` smoke test (manual).

---
**Branch:** `autofyn/run-a-security-r-203054` · **Run:** `3b188f96-e7c9-4834-97c6-fe7a98ff1b1a` · *Generated by AutoFyn*