### PR TITLE
Add list_notion_integrations MCP tool + sync benchmark prompts

### DIFF
--- a/benchmark/prompts/notion_verify_subagent.md
+++ b/benchmark/prompts/notion_verify_subagent.md
@@ -1,9 +1,10 @@
-You are a build traceability writer working in ${work_dir}.
+You are a build traceability verifier working in ${work_dir}.
 
 ## Inputs
 
 1. `${work_dir}/notion_context.md` — structured context gathered before build.
-   The `# Integration:` line contains the integration name for API calls.
+   The `# Integration:` line contains the integration name for API calls. Each
+   context item has a stable ID (DEF-1, DEC-1, CON-1, etc.).
 2. `${work_dir}/models/*.sql` — SQL files the agent wrote
 
 ## Step 1 — Read Context and Artifacts
@@ -12,90 +13,117 @@ Read `${work_dir}/notion_context.md`. Parse the `Integration:` line to get the
 integration name for `notion_create_page`.
 
 If the file says "No relevant Notion context found" -> write a minimal report
-noting no context was used, then skip to Step 3.
+(Step 4) noting no context was available, then go to Step 5.
+
+Collect all context items with their IDs into a checklist.
+
+## Step 2 — Scan SQL for Notion References
 
 For each model SQL file in `${work_dir}/models/`:
 1. Read the SQL
-2. Find `-- NOTION: <source>` comments the agent left
-3. Identify key decisions: grain (GROUP BY), joins, filters (WHERE), column expressions
-4. Match each decision to context items from `notion_context.md`
+2. Find all `-- NOTION: [<ID>] <reason>` comments
+3. For each comment, record: model name, SQL location (JOIN/WHERE/GROUP BY/SELECT),
+   the context item ID referenced, and the agent's stated reason
 
-## Step 2 — Build Traceability Matrix
+## Step 3 — Verify (4 checks)
 
-Classify every context item and every SQL decision:
+### CHECK 1 — Coverage
+Every context item from `notion_context.md` must be accounted for:
 
-| Context Item | Relevance | Applied To | How | Source |
-|---|---|---|---|---|
-| "active customer = 1+ orders in 90d" | DIRECT | `daily_shop.WHERE` | filter condition | Q1 Planning |
-| "grain is (shop_id, date)" | DIRECT | `daily_shop.GROUP BY` | grain decision | Data Model Review |
+| Status | Meaning |
+|---|---|
+| APPLIED | Item ID appears in a `-- NOTION:` comment in SQL |
+| ACKNOWLEDGED | Agent noted it as RELATED but not directly applicable |
+| MISSING | Item was DIRECT relevance but has no `-- NOTION:` reference |
 
-Classify SQL decisions without Notion backing:
+Flag every MISSING item.
 
-| SQL Decision | Model | Based On |
-|---|---|---|
-| `LEFT JOIN customers` | `daily_shop` | YML contract (ref dependency) |
-| `COALESCE(amount, 0)` | `daily_shop` | sibling model pattern |
+### CHECK 2 — Accuracy
+For each `-- NOTION:` comment in SQL, verify the SQL actually implements the
+context:
+- If context says "active customer = 1+ orders in 90 days", check that the
+  WHERE clause has a matching condition
+- If context says "grain is (shop_id, date)", check the GROUP BY matches
 
-## Step 3 — Write Report to Notion
+Mark each as CORRECT or MISMATCH with explanation.
+
+### CHECK 3 — Conflict Resolution
+If `notion_context.md` has a CONFLICTS section:
+- Check that the agent documented which side it chose in a `-- NOTION:` comment
+- If the agent silently picked one without documenting, flag as UNDOCUMENTED
+
+### CHECK 4 — Untraced Decisions
+Scan the SQL for business-logic decisions that have no `-- NOTION:` backing:
+- WHERE clauses with business filters
+- Specific GROUP BY choices (grain decisions)
+- JOIN conditions that imply business relationships
+
+Flag them as "decision based on: YML / schema / sibling model / agent reasoning".
+
+## Step 4 — Write Report to Notion
 
 Call `notion_create_page` via SignalPilot MCP:
 
 ```
 notion_create_page
   integration_name: "<from notion_context.md>"
-  title: "Build Report: <model names or task summary>"
-  content: "<report content below>"
+  title: "Build Report: <model names> — <date>"
+  content: "<report below>"
 ```
 
-### Report Template
+### Report Format
 
 ```
 Build Report: <model names or task summary>
 
 Task: <original task instruction from ${instruction}>
 
-Notion Context Used
+Verification Result: <PASS / FAIL>
 
-Definitions:
-- <term> = <definition> — <source page>
 
-Decisions:
-- <decision> — <source page>
+Context Coverage (CHECK 1)
 
-Constraints:
-- <constraint> — <source page>
+APPLIED:
+- [DEF-1] "<term>" = <definition> -> <model>.<location>
+- [DEC-1] <decision> -> <model>.<location>
 
-Models Built
+MISSING:
+- [CON-1] <constraint> — NOT FOUND in any SQL
 
-<model_name>:
-- Grain: <columns> — <source>
-- Joins: <join list> — <source for each>
-- Filters: <filter list> — <source for each>
-- Verification: PASS/FAIL
+(If no MISSING items: "All context items accounted for.")
 
-Traceability:
-Context Item | Source | Applied To | How
-<item> | <page title> | <model.decision> | <explanation>
 
-Unmatched:
-Context gathered, not applied:
-- <item> — <reason>
+Accuracy (CHECK 2)
 
-SQL decisions without Notion source:
-- <decision> — based on: <YML / schema / sibling model>
+- [DEF-1] in <model>.WHERE — CORRECT: filter matches definition
+- [DEC-1] in <model>.GROUP BY — CORRECT: grain matches decision
 
-Summary:
+
+Conflict Resolution (CHECK 3)
+
+- <description> — Agent chose <side>, documented in <model>
+(Or: "No conflicts." / "UNDOCUMENTED")
+
+
+Untraced Decisions (CHECK 4)
+
+- <model>.LEFT JOIN customers — based on: YML ref dependency
+- <model>.COALESCE(amount, 0) — based on: sibling model pattern
+
+
+Summary
 Models built: <N>
-Context items used: <N>
-Context items discarded: <N>
-Conflicts flagged: <N>
-Verification: all pass / N failures
+Context items: <N>
+Applied: <N>
+Missing: <N>
+Accuracy mismatches: <N>
+Result: PASS / FAIL
 
 ---
 Generated: <YYYY-MM-DD HH:MM UTC> | Task: ${instance_id}
 ```
 
-## Step 4 — Save Report Link
+## Step 5 — Save Report Link
 
 Write the Notion page URL to `${work_dir}/notion_report_url.txt`.
 
@@ -104,6 +132,8 @@ If `notion_create_page` fails -> write the full report content to
 
 ## Rules
 
-- NEVER fabricate traceability. No `-- NOTION:` comment in SQL = no link in matrix.
-- NEVER skip the report. No context gathered = minimal report documenting that.
+- NEVER fabricate traceability. No `-- NOTION:` comment = not applied.
+- NEVER skip the report. No context = minimal report documenting that.
+- NEVER mark CHECK 2 as CORRECT without reading the actual SQL logic.
+- FAIL the report if any CHECK 1 MISSING items exist.
 - Factual and concise. No commentary on context quality.

--- a/benchmark/skills/notion-context/SKILL.md
+++ b/benchmark/skills/notion-context/SKILL.md
@@ -9,17 +9,21 @@ Gather business context from Notion using SignalPilot's governed Notion tools.
 
 ## 1. Find the Integration
 
-Call `notion_search` with `integration_name` and a test query. If it fails with
-"integration not found", list available integrations:
+Call `list_database_connections` — this also lists Notion integrations. Pick
+the integration to use:
+
+- If the user named one in the task instruction, use that.
+- If only one Notion integration exists, use it.
+- If multiple exist and none was specified, list them and ask the user.
+- If none exist, skip — Notion context is optional. Do not block the workflow.
+
+Verify the integration works with a test search:
 
 ```
 notion_search
   integration_name: "<name>"
   query: "test"
 ```
-
-If no Notion integration exists, skip — Notion context is optional. Do not block
-the workflow.
 
 Save the working `integration_name` for all subsequent calls.
 
@@ -40,7 +44,7 @@ notion_search
 3. Individual terms
 
 If still nothing -> write `No relevant Notion context found.` to
-`notion_context.md` and return.
+`notion_context.md` (include the `# Integration:` header) and return.
 
 ## 3. Fetch and Navigate
 
@@ -71,6 +75,7 @@ Scan page content for three categories:
 For each item record:
 - Verbatim excerpt (under 200 chars) or paraphrase
 - Source page title and ID
+- Category tag (DEFINITION / DECISION / CONSTRAINT)
 
 Check for **contradictions** between items. If two sources disagree, flag both
 with `CONFLICT:`. Do NOT silently pick one.
@@ -86,15 +91,15 @@ Write `notion_context.md` in the working directory:
 # Sources: <N> pages searched, <M> items extracted
 
 ## DEFINITIONS
-- "<term>" = <definition>
+- [DEF-1] "<term>" = <definition>
   Source: <page_title> — https://notion.so/<page_id>
 
 ## DECISIONS
-- <decision statement>
+- [DEC-1] <decision statement>
   Source: <page_title> — https://notion.so/<page_id>
 
 ## CONSTRAINTS
-- <constraint>
+- [CON-1] <constraint>
   Source: <page_title> — https://notion.so/<page_id>
 
 ## CONFLICTS
@@ -104,14 +109,17 @@ Write `notion_context.md` in the working directory:
 - <page_title> — https://notion.so/<page_id> — <N> items extracted
 ```
 
-This file is read by the notion-verify subagent after the build.
+Each item gets a stable ID (DEF-1, DEC-1, CON-1, etc.) so the verify agent can
+reference them in the traceability matrix. This file is read by the notion-verify
+subagent after the build.
 
 ## 6. Return to Agent
 
 Return DEFINITIONS, DECISIONS, and CONSTRAINTS to the calling agent. The agent
 MUST:
 - Reference items when making grain, join, filter, and column decisions
-- Write `-- NOTION: <source>` comments in SQL for decisions influenced by context
+- Write `-- NOTION: [DEF-1] <brief reason>` comments in SQL for every decision
+  influenced by Notion context. Use the item ID from `notion_context.md`.
 - Flag CONFLICT items and explain which side was chosen
 
 ## Rules

--- a/docs/docs/reference/tools-overview.md
+++ b/docs/docs/reference/tools-overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Tools Reference
 
-All 35 SignalPilot MCP tools, grouped by category. Click a category for full parameter and example documentation.
+All 36 SignalPilot MCP tools, grouped by category. Click a category for full parameter and example documentation.
 
 ## Data Exploration (9 tools)
 
@@ -71,11 +71,12 @@ See [Operational tools](/docs/reference/tools-ops).
 | `connector_capabilities` | Connector tier classification (Tier 1/2/3) and available features |
 | `check_budget` | Remaining query budget for a session |
 
-## Notion Integration (3 tools)
+## Notion Integration (4 tools)
 
 | Tool | Description |
 |------|-------------|
-| `notion_search` | Search Notion pages within configured search scope (root pages) |
+| `list_notion_integrations` | List all configured Notion integrations with search scope and report destination |
+| `notion_search` | Search Notion pages visible to an integration's access token |
 | `notion_fetch_page` | Fetch full content of a Notion page by ID |
 | `notion_create_page` | Create a page under the configured report destination |
 

--- a/signalpilot/gateway/gateway/mcp/tools/notion.py
+++ b/signalpilot/gateway/gateway/mcp/tools/notion.py
@@ -1,4 +1,4 @@
-"""Notion integration tools: notion_search, notion_fetch_page, notion_create_page."""
+"""Notion integration tools: list, search, fetch, create."""
 
 from __future__ import annotations
 
@@ -30,12 +30,40 @@ async def _resolve_integration(store: object, integration_name: str) -> _Resolve
 
 
 @audited_tool(mcp)
+async def list_notion_integrations() -> str:
+    """
+    List all configured Notion integrations.
+
+    Returns integration names and their configuration (search scope count,
+    report destination). Use the integration name with notion_search,
+    notion_fetch_page, and notion_create_page.
+
+    Returns:
+        Integration names and config as formatted text, or a message if none exist.
+    """
+    async with _store_session() as store:
+        integrations = await store.list_notion_integrations()  # type: ignore[union-attr]
+
+    if not integrations:
+        return "No Notion integrations configured. Add one via the SignalPilot UI at /integrations"
+
+    lines: list[str] = []
+    for i in integrations:
+        search_count = len(i.search_page_ids)
+        report = "configured" if i.report_parent_page_id else "not set"
+        lines.append(f"- {i.name}")
+        lines.append(f"  search scope: {search_count} page{'s' if search_count != 1 else ''}")
+        lines.append(f"  report destination: {report}")
+    return "\n".join(lines)
+
+
+@audited_tool(mcp)
 async def notion_search(integration_name: str, query: str) -> str:
     """
     Search Notion pages within the configured search scope.
 
-    Searches pages under the root pages configured for this integration.
-    Use list_database_connections to see available Notion integrations.
+    Searches pages visible to this integration's access token.
+    Use list_notion_integrations to see available integrations.
 
     Args:
         integration_name: Name of a configured Notion integration


### PR DESCRIPTION
## Summary
- Adds `list_notion_integrations` MCP tool so agents can discover available Notion integrations without guessing names
- Syncs benchmark prompts with strengthened 4-check verification protocol and stable context item IDs

## Changes
- **Gateway**: New `list_notion_integrations` tool returning names, search scope count, report destination status
- **Docs**: Tool count 35 → 36, updated Notion section
- **Benchmark**: notion-verify prompt with 4 checks (coverage, accuracy, conflict resolution, untraced decisions)
- **Benchmark**: notion-context skill with `list_database_connections` discovery and stable IDs

## Test plan
- [ ] `list_notion_integrations` returns configured integrations with scope/report info
- [ ] `list_notion_integrations` returns helpful message when none configured
- [ ] Other Notion tools' docstrings reference `list_notion_integrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)