### PR TITLE
Security audit fixes: CSRF, SSH/SSRF, dbt_proxy, OAuth, CSV, cloud hardening, scoped pod JWT

### DIFF
--- a/signalpilot/gateway/gateway/api/_oauth_state.py
+++ b/signalpilot/gateway/gateway/api/_oauth_state.py
@@ -1,0 +1,273 @@
+"""OAuth state token generation and verification for GitHub App installs.
+
+This module owns the HMAC key resolution, state encode/decode, and the nonce
+TTL store.  It is a pure module — no FastAPI imports, no ``gateway.api.*`` or
+``gateway.store.*`` imports.  The only intra-gateway import is
+``gateway.runtime.mode.is_cloud_mode``.
+
+Design decisions:
+
+State format (v2)::
+
+    payload = f"v2:{org_id}:{nonce_hex}:{issued_at_unix_int}"
+    sig     = hmac_sha256(key, payload.encode()).hexdigest()   # 64 hex chars
+    state   = f"{payload}.{sig}"
+
+The ``v2:`` prefix gates future migrations.  Any state missing the prefix is
+rejected.  Timestamp is *inside* the signed payload so tampering the timestamp
+breaks the HMAC.  Full SHA-256 hex (64 chars) — no truncation, no off-by-one
+risk.
+
+Nonce store trade-offs:
+
+The ``_NonceStore`` is a process-local in-memory dict.  This is acceptable
+because:
+
+- The gateway runs as a single process per pod for the OAuth callback path.
+- The TTL is short (10 minutes); states do not survive restart.
+- 128-bit nonces over a 10-minute window have negligible accidental collision
+  probability.
+- Only states that pass HMAC + expiry checks reach ``reserve``, so an
+  unauthenticated attacker cannot stuff the dict.
+
+This mirrors the ``dbt_proxy/tokens.py`` in-memory pattern already in the
+codebase.  For multi-replica deployments a shared store (Redis, DB) would be
+needed; document as a known gap if you move to active-active.
+
+Key resolution (local mode):
+
+In local mode with no ``SP_ENCRYPTION_KEY`` set, ``get_state_hmac_key()``
+generates a random 32-byte key per process and caches it.  States minted before
+a pod restart are therefore unverifiable after restart.  This is acceptable for
+local development — users simply retry the GitHub install flow.  Mention this
+in release notes when deploying to a shared dev environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+import threading
+import time
+
+from ..runtime.mode import is_cloud_mode
+
+logger = logging.getLogger(__name__)
+
+# ─── Constants ───────────────────────────────────────────────────────────────
+
+STATE_TTL_SECONDS: int = 600   # 10 minutes — GitHub-recommended OAuth state window
+NONCE_BYTES: int = 16          # 128-bit nonce, hex-encoded → 32 hex chars
+
+# ─── HMAC Key (lazy, cached) ─────────────────────────────────────────────────
+
+_HMAC_KEY: bytes | None = None
+_KEY_LOCK: threading.Lock = threading.Lock()
+
+
+def get_state_hmac_key() -> bytes:
+    """Return the HMAC key for OAuth state signing.
+
+    Resolution order:
+
+    1. Cached value — returned immediately on subsequent calls.
+    2. ``SP_ENCRYPTION_KEY`` env var — derives a 32-byte key via SHA-256.
+    3. Cloud mode + key absent — raises ``RuntimeError``.  Do NOT cache.
+    4. Local mode + key absent — generates ``secrets.token_bytes(32)`` once,
+       caches it, and returns it.  Dev-UX note: the random key is not persisted;
+       in-flight OAuth flows started before a pod restart will fail verification
+       after the restart.  Users must retry the install flow.
+    """
+    global _HMAC_KEY
+
+    # Fast path — already resolved.
+    if _HMAC_KEY is not None:
+        return _HMAC_KEY
+
+    with _KEY_LOCK:
+        # Double-checked locking — another thread may have resolved between the
+        # global read and lock acquisition.
+        if _HMAC_KEY is not None:
+            return _HMAC_KEY
+
+        raw = os.getenv("SP_ENCRYPTION_KEY")
+
+        if raw is not None:
+            derived = hashlib.sha256(raw.encode()).digest()
+            _HMAC_KEY = derived
+            return _HMAC_KEY
+
+        if is_cloud_mode():
+            raise RuntimeError(
+                "SP_ENCRYPTION_KEY required in cloud mode for OAuth state signing"
+            )
+
+        # Local mode — generate a random key once per process.
+        _HMAC_KEY = secrets.token_bytes(32)
+        return _HMAC_KEY
+
+
+# ─── Nonce Store ─────────────────────────────────────────────────────────────
+
+
+class _NonceStore:
+    """In-process nonce TTL store for OAuth state replay prevention.
+
+    Guarded by ``threading.Lock``; FastAPI handlers may run on the threadpool
+    for non-async paths.  ``reserve`` returns ``True`` on first insertion and
+    ``False`` on replay (nonce already present).  ``_gc`` purges expired entries
+    and is called opportunistically on every ``reserve`` call — cheap given the
+    low call rate and short TTL.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, float] = {}   # nonce_hex → expires_at_unix
+        self._lock: threading.Lock = threading.Lock()
+
+    def reserve(self, nonce_hex: str, expires_at: float) -> bool:
+        """Insert *nonce_hex* with expiry *expires_at*.
+
+        Returns ``True`` if newly inserted (first use), ``False`` if already
+        present (replay attack).
+        """
+        with self._lock:
+            self._gc()
+            if nonce_hex in self._entries:
+                return False
+            self._entries[nonce_hex] = expires_at
+            return True
+
+    def _gc(self) -> None:
+        """Remove expired entries from the store (called under lock)."""
+        now = time.time()
+        expired = [k for k, v in self._entries.items() if v <= now]
+        for k in expired:
+            del self._entries[k]
+
+
+# Module-level singleton — one nonce store per process.
+_NONCE_STORE: _NonceStore = _NonceStore()
+
+# ─── State Encoding ───────────────────────────────────────────────────────────
+
+
+def make_state(org_id: str) -> str:
+    """Mint a signed OAuth state token for *org_id*.
+
+    Format::
+
+        state = f"v2:{org_id}:{nonce_hex}:{issued_at_unix_int}.{sig_hex}"
+
+    The timestamp and nonce are embedded *inside* the signed payload so any
+    tampering invalidates the HMAC.
+    """
+    key = get_state_hmac_key()
+    nonce_hex = secrets.token_hex(NONCE_BYTES)
+    issued_at = int(time.time())
+    payload = f"v2:{org_id}:{nonce_hex}:{issued_at}"
+    sig = hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{sig}"
+
+
+# ─── State Verification ──────────────────────────────────────────────────────
+
+
+def verify_state(state: str | None) -> str | None:
+    """Verify a signed OAuth state token and return *org_id* on success.
+
+    Returns ``None`` on any failure.  The caller must NOT differentiate the
+    failure reason in user-facing messages — return a single generic 400.
+
+    Verification order (LOAD-BEARING — do NOT reorder):
+
+    1. Empty/None guard.
+    2. Format split (last ``.``).
+    3. HMAC constant-time compare.
+    4. Prefix + field parse (``v2:``).
+    5. Expiry check.
+    6. Nonce reserve (replay prevention) — LAST, only after all other checks.
+    7. Return *org_id*.
+    """
+    # Step 1 — empty/None guard.  Fail closed before any other check.
+    if not state:
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "empty", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    # Step 2 — format: split on the LAST dot.
+    dot_idx = state.rfind(".")
+    if dot_idx == -1:
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "format", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    payload = state[:dot_idx]
+    sig = state[dot_idx + 1:]
+
+    if not payload or not sig:
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "format", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    # Step 3 — HMAC verification (constant-time).
+    key = get_state_hmac_key()
+    expected_sig = hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected_sig):
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "signature", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    # Step 4 — prefix + field parse.
+    fields = payload.split(":")
+    if len(fields) != 4 or fields[0] != "v2":
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "format", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    _, org_id, nonce_hex, issued_at_str = fields
+
+    # Step 5 — expiry.
+    try:
+        issued_at = int(issued_at_str)
+    except ValueError:
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "format", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    if time.time() - issued_at > STATE_TTL_SECONDS:
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "expired", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    # Step 6 — nonce reserve (replay prevention).  Only reached after all
+    # other checks pass, so garbage inputs cannot grow the dict.
+    expires_at = issued_at + STATE_TTL_SECONDS
+    if not _NONCE_STORE.reserve(nonce_hex, float(expires_at)):
+        logger.warning(
+            "oauth_state_rejected",
+            extra={"reason": "replay", "remote_ip": None, "org_id_hint": None},
+        )
+        return None
+
+    # Step 7 — success.
+    return org_id
+
+
+__all__ = ["STATE_TTL_SECONDS", "NONCE_BYTES", "get_state_hmac_key", "make_state", "verify_state"]

--- a/signalpilot/gateway/gateway/api/audit.py
+++ b/signalpilot/gateway/gateway/api/audit.py
@@ -17,6 +17,27 @@ from .deps import StoreD
 
 MAX_EXPORT_ROWS = get_governance_settings().sp_max_export_rows
 
+_CSV_FORMULA_TRIGGERS = frozenset({"=", "+", "-", "@", "\t", "\r"})
+
+
+def _csv_safe(value: object) -> str:
+    """OWASP-recommended CSV-injection mitigation.
+
+    Coerces value to str (None -> ""). If the resulting string starts with a
+    formula-trigger character, prepend a single apostrophe so spreadsheet apps
+    treat the cell as literal text rather than a formula.
+    """
+    if value is None:
+        s = ""
+    elif isinstance(value, str):
+        s = value
+    else:
+        s = str(value)
+    if s and s[0] in _CSV_FORMULA_TRIGGERS:
+        return "'" + s
+    return s
+
+
 router = APIRouter(prefix="/api")
 
 
@@ -126,18 +147,18 @@ async def export_audit(
             e = entry if isinstance(entry, dict) else entry.__dict__
             writer.writerow(
                 [
-                    e.get("id", ""),
-                    e.get("timestamp", ""),
-                    e.get("event_type", ""),
-                    e.get("connection_name", ""),
-                    e.get("sql", ""),
-                    ";".join(e.get("tables", [])),
-                    e.get("rows_returned", ""),
-                    e.get("duration_ms", ""),
-                    e.get("blocked", False),
-                    e.get("block_reason", ""),
-                    e.get("agent_id", ""),
-                    json.dumps(e.get("metadata", {})),
+                    _csv_safe(e.get("id", "")),
+                    _csv_safe(e.get("timestamp", "")),
+                    _csv_safe(e.get("event_type", "")),
+                    _csv_safe(e.get("connection_name", "")),
+                    _csv_safe(e.get("sql", "")),
+                    _csv_safe(";".join(e.get("tables", []))),
+                    _csv_safe(e.get("rows_returned", "")),
+                    _csv_safe(e.get("duration_ms", "")),
+                    _csv_safe(e.get("blocked", False)),
+                    _csv_safe(e.get("block_reason", "")),
+                    _csv_safe(e.get("agent_id", "")),
+                    _csv_safe(json.dumps(e.get("metadata", {}))),
                 ]
             )
         content = output.getvalue()

--- a/signalpilot/gateway/gateway/api/byok.py
+++ b/signalpilot/gateway/gateway/api/byok.py
@@ -24,6 +24,7 @@ from ..byok import (
     revert_to_managed,
     rotate_byok_key,
 )
+from ..common.ip import request_meta
 from ..db.models import GatewayBYOKKey, GatewayConnection, GatewayCredential, GatewayOrg
 from ..models import (
     AuditEntry,
@@ -45,15 +46,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api")
 
 BYOK_HEALTH_CHECK_PLAINTEXT = "byok-health-check"
-
-
-def _extract_request_meta(request: Request) -> tuple[str | None, str | None]:
-    """Extract client_ip and user_agent from the incoming HTTP request."""
-    client_ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip() or (
-        request.client.host if request.client else None
-    )
-    user_agent = request.headers.get("user-agent")
-    return client_ip, user_agent
 
 
 def _key_to_response(key: GatewayBYOKKey) -> BYOKKeyResponse:
@@ -135,7 +127,7 @@ async def create_byok_key(
         provider.register_key(org_id, body.key_alias)
         logger.info("Local BYOK key registered in-memory for org=%s alias=%s", org_id, body.key_alias)
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the successful key creation; best-effort observability.
     try:
         await store.append_audit(
@@ -297,7 +289,7 @@ async def validate_byok_key(
     """Round-trip encrypt/decrypt test for a BYOK key, scoped to the org from JWT."""
     from ..store.byok_state import _byok_provider as provider
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
 
     if provider is None:
         metadata = {
@@ -444,7 +436,7 @@ async def migrate_credentials_to_byok(
         managed_decrypt=_decrypt_with_migration,
     )
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed migration; best-effort observability.
     try:
         await store.append_audit(
@@ -497,7 +489,7 @@ async def revert_credentials_to_managed(
         cache=cache,
     )
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed revert; best-effort observability.
     try:
         await store.append_audit(
@@ -581,7 +573,7 @@ async def rotate_byok_key_endpoint(
         await store.session.commit()
         raise
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed rotation; best-effort observability.
     try:
         await store.append_audit(

--- a/signalpilot/gateway/gateway/api/connections/_validation.py
+++ b/signalpilot/gateway/gateway/api/connections/_validation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from gateway.models import ConnectionCreate
-from gateway.network import validate_cloud_warehouse_params, validate_connection_params
+from gateway.network import validate_cloud_warehouse_params, validate_connection_host, validate_connection_params
 
 
 def _validate_connection_params(conn: ConnectionCreate) -> list[str]:
@@ -98,5 +98,22 @@ def _validate_connection_params(conn: ConnectionCreate) -> list[str]:
             errors.append("SSH tunnel with password auth requires a password")
         if db not in ("postgres", "mysql", "redshift", "clickhouse", "mssql", "trino"):
             errors.append(f"SSH tunnels are not supported for {db} (only host:port databases)")
+
+        # Cloud-mode SSRF: validate bastion and HTTP-proxy hosts against the
+        # denylist (loopback, link-local, IMDS, CGNAT, RFC1918).
+        # validate_connection_host does NOT gate on SP_DEPLOYMENT_MODE itself —
+        # that gating lives here, mirroring the existing validate_connection_params
+        # pattern. Local-mode users with private bastions must not be broken.
+        if is_cloud_mode():
+            if conn.ssh_tunnel.host:
+                try:
+                    validate_connection_host(conn.ssh_tunnel.host)
+                except ValueError as e:
+                    errors.append(f"SSH bastion host failed validation: {e}")
+            if conn.ssh_tunnel.proxy_host:
+                try:
+                    validate_connection_host(conn.ssh_tunnel.proxy_host)
+                except ValueError as e:
+                    errors.append(f"SSH HTTP proxy host failed validation: {e}")
 
     return errors

--- a/signalpilot/gateway/gateway/api/connections/crud.py
+++ b/signalpilot/gateway/gateway/api/connections/crud.py
@@ -13,6 +13,7 @@ from gateway.api.connections._router import router
 from gateway.api.connections._validation import _validate_connection_params
 from gateway.api.deps import StoreD
 from gateway.auth import OrgAdmin
+from gateway.common.ip import request_meta
 from gateway.connectors.pool_manager import pool_manager
 from gateway.connectors.schema_cache import schema_cache
 from gateway.models import AuditEntry, ConnectionCreate, ConnectionUpdate
@@ -35,15 +36,6 @@ _SECRET_FIELDS: frozenset[str] = frozenset({
     "private_key_passphrase",
     "ssh_tunnel",
 })
-
-
-def _extract_request_meta(request: Request) -> tuple[str | None, str | None]:
-    """Extract client_ip and user_agent from the incoming HTTP request."""
-    client_ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip() or (
-        request.client.host if request.client else None
-    )
-    user_agent = request.headers.get("user-agent")
-    return client_ip, user_agent
 
 
 @router.get("/connections", dependencies=[RequireScope("read")])
@@ -86,7 +78,7 @@ async def remove_connection(name: str, store: StoreD, _role: OrgAdmin, request: 
         raise HTTPException(status_code=404, detail=f"Connection '{name}' not found")
     schema_cache.invalidate(name)
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed deletion; best-effort observability.
     try:
         await store.append_audit(
@@ -143,7 +135,7 @@ async def edit_connection(name: str, update: ConnectionUpdate, store: StoreD, _r
     if old_conn_str:
         await pool_manager.close_pool(old_conn_str)
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed update; best-effort observability.
     try:
         await store.append_audit(

--- a/signalpilot/gateway/gateway/api/connections/porting.py
+++ b/signalpilot/gateway/gateway/api/connections/porting.py
@@ -11,20 +11,12 @@ from pydantic import BaseModel
 from gateway.api.connections._router import router
 from gateway.api.connections._validation import _validate_connection_params
 from gateway.api.deps import StoreD
+from gateway.common.ip import request_meta
 from gateway.models import AuditEntry, ConnectionCreate
 from gateway.security.scope_guard import RequireScope, require_scopes
 from gateway.store import CredentialEncryptionError
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_request_meta(request: Request) -> tuple[str | None, str | None]:
-    """Extract client_ip and user_agent from the incoming HTTP request."""
-    client_ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip() or (
-        request.client.host if request.client else None
-    )
-    user_agent = request.headers.get("user-agent")
-    return client_ip, user_agent
 
 
 class ExportRequest(BaseModel):
@@ -112,7 +104,7 @@ async def export_connections(
 
         exported.append(entry)
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed export; best-effort observability.
     try:
         await store.append_audit(
@@ -166,7 +158,7 @@ async def import_connections(manifest: dict, store: StoreD, request: Request):
         except Exception:
             results["errors"].append({"name": name, "error": "Failed to import connection"})
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the completed import; best-effort observability.
     try:
         await store.append_audit(

--- a/signalpilot/gateway/gateway/api/github.py
+++ b/signalpilot/gateway/gateway/api/github.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
-import secrets
 import time
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -19,44 +16,14 @@ from ..models.github import (
     GitHubRepoLinkCreate,
     GitHubRepoLinkInfo,
 )
+from ..runtime.mode import is_cloud_mode
 from ..security.scope_guard import RequireScope
+from ._oauth_state import make_state, verify_state
 from .deps import StoreD
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-# ─── OAuth State ──────────────────────────────────────────────────────────
-
-_HMAC_KEY: bytes | None = None
-
-
-def _get_hmac_key() -> bytes:
-    global _HMAC_KEY
-    if _HMAC_KEY is None:
-        import os
-        raw = os.getenv("SP_ENCRYPTION_KEY", "github-oauth-state-key")
-        _HMAC_KEY = hashlib.sha256(raw.encode()).digest()
-    return _HMAC_KEY
-
-
-def _make_state(org_id: str) -> str:
-    nonce = secrets.token_hex(16)
-    payload = f"{org_id}:{nonce}"
-    sig = hmac.new(_get_hmac_key(), payload.encode(), hashlib.sha256).hexdigest()[:16]
-    return f"{payload}.{sig}"
-
-
-def _verify_state(state: str) -> str | None:
-    parts = state.rsplit(".", 1)
-    if len(parts) != 2:
-        return None
-    payload, sig = parts
-    expected = hmac.new(_get_hmac_key(), payload.encode(), hashlib.sha256).hexdigest()[:16]
-    if not hmac.compare_digest(sig, expected):
-        return None
-    org_id = payload.split(":", 1)[0]
-    return org_id
 
 
 # ─── OAuth Flow ──────────────────────────────────────────────────────────
@@ -75,7 +42,7 @@ async def github_install_url(store: StoreD):
         raise HTTPException(status_code=503, detail="GitHub App not configured")
 
     org_id = store.org_id or "local"
-    state = _make_state(org_id)
+    state = make_state(org_id)
     install_url = f"https://github.com/apps/{settings.sp_github_app_slug}/installations/new?state={state}"
     return {"install_url": install_url}
 
@@ -87,11 +54,10 @@ async def github_oauth_start(request: Request):
     if not settings.is_configured:
         raise HTTPException(status_code=503, detail="GitHub App not configured")
 
-    from ..runtime.mode import is_cloud_mode
     if is_cloud_mode():
         raise HTTPException(status_code=400, detail="Use GET /api/github/install-url instead")
 
-    state = _make_state("local")
+    state = make_state("local")
     install_url = f"https://github.com/apps/{settings.sp_github_app_slug}/installations/new?state={state}"
     return RedirectResponse(url=install_url, status_code=302)
 
@@ -107,9 +73,26 @@ async def github_oauth_callback(
     if not settings.is_configured:
         raise HTTPException(status_code=503, detail="GitHub App not configured")
 
-    org_id = _verify_state(state) if state else "local"
-    if org_id is None:
-        org_id = "local"
+    if is_cloud_mode():
+        if not state:
+            raise HTTPException(
+                status_code=400,
+                detail="OAuth state invalid. Please retry the GitHub install from the SignalPilot UI.",
+            )
+        org_id = verify_state(state)
+        if org_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="OAuth state invalid. Please retry the GitHub install from the SignalPilot UI.",
+            )
+    else:
+        # Local mode: empty state falls back to "local", non-empty state is verified
+        if state:
+            org_id = verify_state(state)
+            if org_id is None:
+                org_id = "local"
+        else:
+            org_id = "local"
 
     from ..github_client import (
         create_installation_token,

--- a/signalpilot/gateway/gateway/api/keys.py
+++ b/signalpilot/gateway/gateway/api/keys.py
@@ -7,6 +7,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Request, Response
 
 from ..auth import OrgAdmin, OrgID, UserID
+from ..common.ip import request_meta
 from ..models import ApiKeyCreate, ApiKeyCreatedResponse, ApiKeyResponse, AuditEntry
 from ..security.scope_guard import RequireScope
 from .deps import StoreD
@@ -14,15 +15,6 @@ from .deps import StoreD
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
-
-
-def _extract_request_meta(request: Request) -> tuple[str | None, str | None]:
-    """Extract client_ip and user_agent from the incoming HTTP request."""
-    client_ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip() or (
-        request.client.host if request.client else None
-    )
-    user_agent = request.headers.get("user-agent")
-    return client_ip, user_agent
 
 
 @router.get("/keys", dependencies=[RequireScope("admin")])
@@ -42,7 +34,7 @@ async def create_key(body: ApiKeyCreate, store: StoreD, _role: OrgAdmin, request
 
     record, raw_key = await store.create_api_key(body.name, body.scopes, expires_at=body.expires_at)
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the successful key creation; best-effort observability.
     try:
         await store.append_audit(
@@ -69,7 +61,7 @@ async def delete_key(key_id: str, store: StoreD, _role: OrgAdmin, request: Reque
     if not await store.delete_api_key(key_id):
         raise HTTPException(status_code=404, detail="API key not found")
 
-    client_ip, user_agent = _extract_request_meta(request)
+    client_ip, user_agent = request_meta(request)
     # Audit-DB failure must not block the successful key deletion; best-effort observability.
     try:
         await store.append_audit(

--- a/signalpilot/gateway/gateway/api/notebook_sessions.py
+++ b/signalpilot/gateway/gateway/api/notebook_sessions.py
@@ -69,10 +69,10 @@ async def create_session(body: NotebookSessionCreate, store: StoreD):
         if await orch.is_pod_alive(existing.pod_name, org_id=org_id):
             return existing
         # Pod is dead — clean up stale session
-        await ns.mark_stopped(store.session, session_id=existing.id)
+        await ns.mark_stopped(store.session, session_id=existing.id, org_id=existing.org_id)
     elif existing:
         # creating state or no pod_ip — mark stopped and recreate
-        await ns.mark_stopped(store.session, session_id=existing.id)
+        await ns.mark_stopped(store.session, session_id=existing.id, org_id=existing.org_id)
 
     await ns.delete_stopped(store.session, org_id=org_id, user_id=user_id)
 
@@ -93,6 +93,7 @@ async def create_session(body: NotebookSessionCreate, store: StoreD):
         await ns.update_session_status(
             store.session,
             session_id=session_info.id,
+            org_id=org_id,
             status="running",
             pod_ip=host_port,
             pod_ip_internal=host_port,
@@ -188,6 +189,7 @@ async def create_session(body: NotebookSessionCreate, store: StoreD):
         await ns.update_session_status(
             store.session,
             session_id=session_info.id,
+            org_id=org_id,
             status="running",
             pod_ip=pod_info.ip,
             pod_ip_internal=pod_info.internal_ip,
@@ -200,15 +202,15 @@ async def create_session(body: NotebookSessionCreate, store: StoreD):
 
     except ValueError as e:
         logger.warning("Invalid org_id for notebook session: %s", e)
-        await ns.update_session_status(store.session, session_id=session_info.id, status="error")
+        await ns.update_session_status(store.session, session_id=session_info.id, org_id=org_id, status="error")
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         if _is_quota_exceeded_error(e):
             logger.warning("Org quota exhausted for org %s: %s", org_id, e)
-            await ns.update_session_status(store.session, session_id=session_info.id, status="error")
+            await ns.update_session_status(store.session, session_id=session_info.id, org_id=org_id, status="error")
             raise HTTPException(status_code=429, detail="Org quota exhausted")
         logger.error("Failed to create notebook pod %s: %s: %s", pod, type(e).__name__, e)
-        await ns.update_session_status(store.session, session_id=session_info.id, status="error")
+        await ns.update_session_status(store.session, session_id=session_info.id, org_id=org_id, status="error")
         # Best-effort pod cleanup on failure.
         try:
             await orch.delete_pod(pod, org_id=org_id)
@@ -272,7 +274,7 @@ async def delete_session(store: StoreD):
     direct_url = os.getenv("SP_NOTEBOOK_DIRECT_URL", "")
     if not direct_url and session.pod_name:
         await orch.delete_pod(session.pod_name, org_id=org_id or "")
-    await ns.mark_stopped(store.session, session_id=session.id)
+    await ns.mark_stopped(store.session, session_id=session.id, org_id=session.org_id)
 
 
 @router.delete("/{session_id}", status_code=204, response_model=None, dependencies=[RequireScope("write")])
@@ -302,7 +304,7 @@ async def delete_session_by_id(session_id: str, store: StoreD):
 
     if session.pod_name:
         await orch.delete_pod(session.pod_name, org_id=org_id)
-    await ns.mark_stopped(store.session, session_id=session.id)
+    await ns.mark_stopped(store.session, session_id=session.id, org_id=session.org_id)
 
 
 @router.post("/{session_id}/ping", response_model=NotebookSessionInfo | None, dependencies=[RequireScope("read")])

--- a/signalpilot/gateway/gateway/api/projects.py
+++ b/signalpilot/gateway/gateway/api/projects.py
@@ -9,6 +9,8 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from ..models import ProjectCreate, ProjectUpdate
+from ..network.validation import validate_connection_host
+from ..runtime.mode import is_cloud_mode
 from ..security.scope_guard import RequireScope
 from .deps import StoreD
 
@@ -93,6 +95,14 @@ class DbtCloudDiscoverRequest(BaseModel):
 @router.post("/dbt-cloud/projects", dependencies=[RequireScope("admin")])
 async def discover_dbt_cloud_projects(req: DbtCloudDiscoverRequest):
     """Fetch project list from dbt Cloud API (proxied to avoid CORS)."""
+    # Cloud-mode SSRF: admin-controlled `host` must not resolve to
+    # loopback/link-local/IMDS/CGNAT/RFC1918. Local mode keeps free-form host
+    # for private dbt Cloud installations, mirroring the connections pattern.
+    if is_cloud_mode():
+        try:
+            validate_connection_host(req.host)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid dbt Cloud host: {e}")
     url = f"https://{req.host}/api/v2/accounts/{req.account_id}/projects/"
     try:
         async with httpx.AsyncClient(timeout=15) as client:

--- a/signalpilot/gateway/gateway/api/query.py
+++ b/signalpilot/gateway/gateway/api/query.py
@@ -8,6 +8,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from ..common.ip import request_meta
 from ..connectors.health_monitor import health_monitor
 from ..connectors.pool_manager import pool_manager
 from ..engine import inject_limit, validate_sql
@@ -31,10 +32,7 @@ class DirectQueryRequest(BaseModel):
 
 @router.post("/query", dependencies=[RequireScope("query")])
 async def query_database(req: DirectQueryRequest, store: StoreD, request: Request):
-    _client_ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip() or (
-        request.client.host if request.client else None
-    )
-    _user_agent = request.headers.get("user-agent")
+    _client_ip, _user_agent = request_meta(request)
 
     # Enforce daily query limit based on org's plan tier
     plan = await get_org_limits(store.org_id)

--- a/signalpilot/gateway/gateway/api/security.py
+++ b/signalpilot/gateway/gateway/api/security.py
@@ -49,8 +49,8 @@ async def security_status(store: StoreD, org_id: OrgID, _role: OrgAdmin):
     )
     credentials_encrypted = result.scalar_one()
 
-    # Global count across all users (admin view)
-    total_pending_rotation = await store.get_credentials_needing_rotation()
+    # Current org's credentials pending key rotation
+    org_pending_rotation = await store.get_credentials_needing_rotation()
 
     # ─── BYOK provider info ───────────────────────────────────────────────────
 
@@ -118,7 +118,7 @@ async def security_status(store: StoreD, org_id: OrgID, _role: OrgAdmin):
         store.user_id,
         encryption_healthy,
         credentials_encrypted,
-        total_pending_rotation,
+        org_pending_rotation,
         byok_provider_type,
         byok_keys_total,
     )
@@ -129,7 +129,7 @@ async def security_status(store: StoreD, org_id: OrgID, _role: OrgAdmin):
         "encryption_healthy": encryption_healthy,
         "credentials_encrypted": credentials_encrypted,
         "current_key_version": CURRENT_KEY_VERSION,
-        "total_credentials_pending_rotation": total_pending_rotation,
+        "total_credentials_pending_rotation": org_pending_rotation,
         "byok_provider": byok_provider_type,
         "byok_keys_total": byok_keys_total,
         "byok_keys_active": byok_keys_active,

--- a/signalpilot/gateway/gateway/api/user_secrets.py
+++ b/signalpilot/gateway/gateway/api/user_secrets.py
@@ -15,6 +15,11 @@ from .deps import StoreD
 router = APIRouter(prefix="/api/user")
 
 
+def _mask_preview(key: str) -> str:
+    """Return a safe prefix-only preview of an API key — never the trailing chars."""
+    return f"{key[:8]}..." if len(key) >= 8 else "****"
+
+
 class UserSecretsUpdate(BaseModel):
     anthropic_api_key: str | None = None
 
@@ -52,7 +57,7 @@ async def get_secrets(store: StoreD):
         if needs_migration:
             row.anthropic_api_key_enc = _encrypt(key)
             await store.session.commit()
-        preview = f"{key[:8]}...{key[-4:]}" if len(key) > 12 else "****"
+        preview = _mask_preview(key)
     except Exception:
         preview = "****"
 
@@ -104,7 +109,7 @@ async def update_secrets(body: UserSecretsUpdate, store: StoreD):
             if needs_migration:
                 row.anthropic_api_key_enc = _encrypt(key)
                 await store.session.commit()
-            preview = f"{key[:8]}...{key[-4:]}" if len(key) > 12 else "****"
+            preview = _mask_preview(key)
         except Exception:
             preview = "****"
 

--- a/signalpilot/gateway/gateway/auth/user.py
+++ b/signalpilot/gateway/gateway/auth/user.py
@@ -35,6 +35,9 @@ if is_cloud_mode() and not os.environ.get("CLERK_PUBLISHABLE_KEY"):
 
 _auth_cfg = get_auth_settings()
 EXPECTED_AUDIENCE = _auth_cfg.clerk_jwt_audience
+EXPECTED_AZP: frozenset[str] = frozenset(
+    p.strip() for p in _auth_cfg.sp_expected_azp.split(",") if p.strip()
+)
 JWT_LEEWAY_SECONDS = _auth_cfg.sp_jwt_leeway
 
 
@@ -153,6 +156,9 @@ async def _resolve_via_clerk(connection: HTTPConnection, token: str) -> str:
             options["verify_aud"] = False
         decode_kwargs["options"] = options
         claims = jwt.decode(token, signing_key.key, **decode_kwargs)
+        if EXPECTED_AZP and claims.get("azp") not in EXPECTED_AZP:
+            logger.warning("Clerk JWT azp mismatch")
+            raise HTTPException(status_code=401, detail="Invalid authentication token")
         user_id = claims.get("sub")
         if not user_id:
             raise HTTPException(status_code=401, detail="Token missing sub claim")

--- a/signalpilot/gateway/gateway/auth/user.py
+++ b/signalpilot/gateway/gateway/auth/user.py
@@ -37,8 +37,6 @@ _auth_cfg = get_auth_settings()
 EXPECTED_AUDIENCE = _auth_cfg.clerk_jwt_audience
 JWT_LEEWAY_SECONDS = _auth_cfg.sp_jwt_leeway
 
-if is_cloud_mode() and not EXPECTED_AUDIENCE:
-    logger.warning("CLERK_JWT_AUDIENCE not set — audience verification disabled. Set this for production security.")
 
 LOCAL_USER_ID = "local"
 LOCAL_ORG_ID = "local"

--- a/signalpilot/gateway/gateway/common/ip.py
+++ b/signalpilot/gateway/gateway/common/ip.py
@@ -1,0 +1,49 @@
+"""Client IP derivation for audit metadata.
+
+This module provides a single canonical way to extract the trusted client IP
+from an incoming HTTP request.  It intentionally mirrors
+``RateLimitMiddleware._client_ip`` so that the IP logged in audit entries and
+the IP used as the rate-limit bucket key are always the same value.
+
+# TODO(security): Add SP_TRUSTED_PROXY_HOPS support for multi-proxy chains.
+# Today's deployments terminate at a single trusted proxy so the rightmost XFF
+# hop is always correct.  When configurable hop counts land, this module is the
+# only place that needs to change.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+_XFF = "x-forwarded-for"
+
+
+def client_ip(request: Request) -> str | None:
+    """Return the rightmost-trusted-hop client IP for audit metadata.
+
+    Order (matches RateLimitMiddleware._client_ip exactly):
+      1. Last non-empty, stripped entry of X-Forwarded-For, if present.
+      2. request.client.host, if available.
+      3. None.
+
+    Never consults X-Real-IP (would diverge from rate-limit bucket key).
+    Never returns the leftmost XFF value (spoofable by the client).
+    Never raises.
+    """
+    forwarded = request.headers.get(_XFF)
+    if forwarded is not None:
+        parts = [p.strip() for p in forwarded.split(",")]
+        non_empty = [p for p in parts if p]
+        if non_empty:
+            return non_empty[-1]
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def request_meta(request: Request) -> tuple[str | None, str | None]:
+    """Return ``(client_ip, user_agent)`` for ``AuditEntry`` construction.
+
+    ``user_agent`` is ``request.headers.get("user-agent")``; no normalization.
+    """
+    return client_ip(request), request.headers.get("user-agent")

--- a/signalpilot/gateway/gateway/config/auth.py
+++ b/signalpilot/gateway/gateway/config/auth.py
@@ -4,7 +4,7 @@ Cached because no test monkeypatches these vars after import.
 If you add an env var here, audit tests/ for monkeypatch.setenv("YOUR_VAR")
 before adding — if any test touches it, keep it as os.getenv (Class B).
 
-Class A vars managed here: CLERK_JWT_AUDIENCE, SP_JWT_LEEWAY
+Class A vars managed here: CLERK_JWT_AUDIENCE, SP_JWT_LEEWAY, SP_EXPECTED_AZP
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ class AuthSettings(_GatewaySettingsBase):
     """Typed auth configuration read from process environment at instantiation."""
 
     clerk_jwt_audience: str = Field("", alias="CLERK_JWT_AUDIENCE")
+    sp_expected_azp: str = Field("", alias="SP_EXPECTED_AZP")
     sp_jwt_leeway: int = Field(30, alias="SP_JWT_LEEWAY")
 
 

--- a/signalpilot/gateway/gateway/connectors/ssh_tunnel.py
+++ b/signalpilot/gateway/gateway/connectors/ssh_tunnel.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -23,16 +24,79 @@ try:
 except ImportError:
     HAS_SSHTUNNEL = False
 
+# Hostname character allowlist for socat address-spec injection prevention.
+# socat uses ',', ':', '=', '!!', '|', and whitespace as special characters in
+# address specs. This regex admits only DNS-name and bare IPv4 characters, which
+# excludes every socat metacharacter. Do NOT relax without re-evaluating socat's
+# address-spec parser.
+_HOSTNAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,253}$")
 
-def _build_proxy_command(proxy_host: str, proxy_port: int, ssh_host: str, ssh_port: int) -> str:
+# Valid port range.
+_PORT_MIN = 1
+_PORT_MAX = 65535
+
+
+def _validate_socat_host(label: str, value: str) -> str:
+    """Validate a hostname for safe use in a socat ProxyCommand string.
+
+    Strips whitespace, asserts non-empty, and asserts the value matches
+    _HOSTNAME_RE (A-Z, a-z, 0-9, '.', '_', '-', 1-253 chars).
+
+    Raises:
+        ValueError: with a generic message that does NOT echo the raw value.
+
+    Returns:
+        The stripped hostname string.
+    """
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"Invalid {label}: must not be empty")
+    if not _HOSTNAME_RE.fullmatch(stripped):
+        raise ValueError(
+            f"Invalid {label}: contains disallowed characters "
+            f"(only A-Z, a-z, 0-9, '.', '_', '-' allowed)"
+        )
+    return stripped
+
+
+def _validate_socat_port(label: str, value: Any) -> int:
+    """Validate a port value for safe use in a socat ProxyCommand string.
+
+    Coerces via int(), then asserts the result is in range 1..65535.
+
+    Raises:
+        ValueError: with a generic message that does NOT echo the raw value.
+
+    Returns:
+        The port as an int.
+    """
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid {label}: must be an integer")
+    if not (_PORT_MIN <= port <= _PORT_MAX):
+        raise ValueError(f"Invalid {label}: must be in range {_PORT_MIN}..{_PORT_MAX}")
+    return port
+
+
+def _build_proxy_command(proxy_host: str, proxy_port: Any, ssh_host: str, ssh_port: Any) -> str:
     """Build a ProxyCommand string for HTTP CONNECT proxy tunneling.
 
     This enables SSH through corporate HTTP proxies (e.g. Squid) that support
     the CONNECT method — common in VPC environments where direct SSH is blocked.
+
+    Inputs are regex-validated and integer-clamped to prevent socat address-spec
+    injection (',', ':', '=', 'OPEN:', 'EXEC:', etc.). Do NOT relax the regex
+    without re-evaluating socat's address-spec parser.
+
+    Note: the design intentionally keeps this string-based ProxyCommand rather
+    than restructuring away from it — the regex-reject is sufficient and minimal.
     """
-    # Use socat or nc (netcat) to tunnel through the HTTP proxy
-    # socat is preferred because it handles the CONNECT handshake properly
-    return f"socat - PROXY:{proxy_host}:{ssh_host}:{ssh_port},proxyport={proxy_port}"
+    safe_proxy_host = _validate_socat_host("proxy_host", proxy_host)
+    safe_proxy_port = _validate_socat_port("proxy_port", proxy_port)
+    safe_ssh_host = _validate_socat_host("ssh_host", ssh_host)
+    safe_ssh_port = _validate_socat_port("ssh_port", ssh_port)
+    return f"socat - PROXY:{safe_proxy_host}:{safe_ssh_host}:{safe_ssh_port},proxyport={safe_proxy_port}"
 
 
 class SSHTunnel:
@@ -58,6 +122,11 @@ class SSHTunnel:
         if not ssh_host or not ssh_username:
             raise ValueError("SSH tunnel requires host and username")
 
+        # Defense-in-depth: validate host/port shape before touching paramiko or
+        # socat — cheap regex check that also covers the no-proxy path.
+        ssh_host = _validate_socat_host("ssh_host", ssh_host)
+        ssh_port = _validate_socat_port("ssh_port", ssh_port)
+
         tunnel_kwargs: dict[str, Any] = {
             "ssh_address_or_host": (ssh_host, ssh_port),
             "ssh_username": ssh_username,
@@ -72,6 +141,10 @@ class SSHTunnel:
         if proxy_host:
             import paramiko
 
+            # Validate proxy host/port — _build_proxy_command validates again
+            # internally, but validate here too so errors surface before import.
+            proxy_host = _validate_socat_host("proxy_host", proxy_host)
+            proxy_port = _validate_socat_port("proxy_port", proxy_port)
             proxy_cmd = _build_proxy_command(proxy_host, proxy_port, ssh_host, ssh_port)
             sock = paramiko.ProxyCommand(proxy_cmd)
             tunnel_kwargs["ssh_proxy"] = sock

--- a/signalpilot/gateway/gateway/dbt_proxy/api.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/api.py
@@ -18,16 +18,29 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import UTC, datetime
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from ..auth import OrgID, UserID
+from ..auth import DBSession, OrgID, UserID
+from ..models import DBType
 from ..runtime.mode import is_cloud_mode
 from ..security.scope_guard import RequireScope
+from ..store import Store
 from .config import DbtProxyConfig
 from .errors import ProxyDisabled, RunTokenAlreadyExists
 from .tokens import RunTokenClaims, RunTokenStore
+
+# ─── Store dependency (local to avoid circular import with gateway.api) ───────
+
+
+async def get_store(org_id: OrgID, user_id: UserID, db: DBSession) -> Store:
+    """FastAPI dependency: yields a Store scoped to the current org."""
+    return Store(db, org_id=org_id, user_id=user_id)
+
+
+_StoreD = Annotated[Store, Depends(get_store)]
 
 logger = logging.getLogger(__name__)
 
@@ -98,15 +111,26 @@ async def mint_run_token(
     request: Request,
     org_id: OrgID,
     user_id: UserID,
+    store: _StoreD,
 ) -> MintResponse:
     """Mint a short-lived run-token for a dbt-proxy session.
 
     org_id and user_id come from the auth context (not the request body).
     Duplicate run_id → 409. Missing secret or disabled proxy → 503.
+    Connector must belong to the caller's org and be postgres → 404 otherwise.
     """
     config = _get_config(request)
     _check_proxy_enabled(config)
     _check_secret_configured(config)
+
+    info = await store.get_connection(body.connector_name)
+    if info is None or info.db_type != DBType.postgres:
+        # 404 (not 403): do not leak whether the connector exists in another org
+        # or exists at all with the wrong db_type.
+        raise HTTPException(
+            status_code=404,
+            detail={"error_code": "connector_not_found", "message": f"Connector {body.connector_name!r} not found"},
+        )
 
     # Cloud-only: cap TTL to 1h regardless of request value.
     # Localhost keeps the documented 24h max.
@@ -139,20 +163,34 @@ async def mint_run_token(
 
 
 @router.delete("/{run_id}", status_code=204, response_model=None, dependencies=[RequireScope("dbt_proxy")])
-async def revoke_run_token(run_id: uuid.UUID, request: Request) -> None:
-    """Revoke a run-token. No-op if the token does not exist."""
+async def revoke_run_token(run_id: uuid.UUID, request: Request, org_id: OrgID) -> None:
+    """Revoke a run-token. No-op if the token does not exist or belongs to another org."""
     token_store = _get_token_store(request)
+    claims = await token_store.get(run_id)
+    if claims is None or claims.org_id != org_id:
+        # Foreign-org token treated as 404 to avoid an existence oracle.
+        # Spec: DELETE is otherwise idempotent (no-op on missing),
+        # so emitting 204 for "no such token" preserves that contract.
+        # But we MUST NOT actually revoke a foreign-org token, so the
+        # branch returns early without touching the store.
+        return  # 204 — same response as the legitimate no-op revoke
     await token_store.revoke(run_id)
     logger.info("dbt_proxy revoke run_id=%s", run_id)
 
 
 @router.get("/{run_id}", response_model=TokenInfoResponse, dependencies=[RequireScope("dbt_proxy")])
-async def get_run_token(run_id: uuid.UUID, request: Request) -> TokenInfoResponse:
-    """Inspect a run-token by run_id. Returns 404 if not found."""
+async def get_run_token(run_id: uuid.UUID, request: Request, org_id: OrgID) -> TokenInfoResponse:
+    """Inspect a run-token by run_id. Returns 404 if not found or belongs to another org."""
     config = _get_config(request)
     token_store = _get_token_store(request)
     claims: RunTokenClaims | None = await token_store.get(run_id)
     if claims is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"error_code": "run_token_not_found", "message": f"No token for run_id={run_id}"},
+        )
+    if claims.org_id != org_id:
+        # Treat foreign-org as not found (no existence oracle).
         raise HTTPException(
             status_code=404,
             detail={"error_code": "run_token_not_found", "message": f"No token for run_id={run_id}"},

--- a/signalpilot/gateway/gateway/dbt_proxy/config.py
+++ b/signalpilot/gateway/gateway/dbt_proxy/config.py
@@ -47,5 +47,24 @@ class DbtProxyConfig(BaseSettings):
                 self.sp_dbt_proxy_host,
             )
 
+    def enforce_bind_safety(self, cloud: bool) -> None:
+        """Hard-fail in cloud mode when bound to a non-loopback host.
+
+        In cloud mode, a non-loopback bind with the current cleartext pg-wire
+        handshake would expose run-tokens on the container-internal network.
+        In local (dev) mode, delegate to warn_if_non_loopback() so existing
+        behaviour is unchanged.
+        """
+        if self.sp_dbt_proxy_host in _LOOPBACK_HOSTS:
+            return
+        if cloud:
+            raise RuntimeError(
+                f"SECURITY: dbt-proxy bound to non-loopback host {self.sp_dbt_proxy_host!r}"
+                f" (SP_DBT_PROXY_HOST) in cloud mode; pg-wire handshake is cleartext"
+                f" (TLS deferred to R8) and run-tokens would be exposed on the"
+                f" container-internal network. Refusing to boot."
+            )
+        self.warn_if_non_loopback()
+
 
 __all__ = ["DbtProxyConfig"]

--- a/signalpilot/gateway/gateway/http/__init__.py
+++ b/signalpilot/gateway/gateway/http/__init__.py
@@ -2,6 +2,7 @@ from .correlation import RequestCorrelationMiddleware, get_request_id
 from .middleware import (
     PUBLIC_PATHS,
     APIKeyAuthMiddleware,
+    CookieAuthCsrfMiddleware,
     RateLimitMiddleware,
     RequestBodySizeLimitMiddleware,
     SecurityHeadersMiddleware,
@@ -11,6 +12,7 @@ from .middleware import (
 
 __all__ = [
     "APIKeyAuthMiddleware",
+    "CookieAuthCsrfMiddleware",
     "PUBLIC_PATHS",
     "RateLimitMiddleware",
     "RequestCorrelationMiddleware",

--- a/signalpilot/gateway/gateway/http/middleware/__init__.py
+++ b/signalpilot/gateway/gateway/http/middleware/__init__.py
@@ -1,5 +1,6 @@
 from .auth import PUBLIC_PATHS, APIKeyAuthMiddleware
 from .body_size import RequestBodySizeLimitMiddleware
+from .csrf import CookieAuthCsrfMiddleware
 from .rate_limit import (
     RateLimitMiddleware,
     check_principal_rate_limit,
@@ -9,6 +10,7 @@ from .security_headers import SecurityHeadersMiddleware
 
 __all__ = [
     "APIKeyAuthMiddleware",
+    "CookieAuthCsrfMiddleware",
     "PUBLIC_PATHS",
     "RateLimitMiddleware",
     "RequestBodySizeLimitMiddleware",

--- a/signalpilot/gateway/gateway/http/middleware/csrf.py
+++ b/signalpilot/gateway/gateway/http/middleware/csrf.py
@@ -1,0 +1,133 @@
+"""
+Cookie-auth CSRF protection middleware.
+
+Blocks cross-site mutation requests (non-safe methods) that are authenticated
+solely via the __session cookie in cloud mode.  Bearer / API-key clients and
+webhook prefixes are explicitly exempted.
+"""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+logger = logging.getLogger(__name__)
+
+# Exempt path prefixes — these paths have their own auth / CSRF model and
+# must not be blocked by this middleware.
+_EXEMPT_PREFIXES: tuple[str, ...] = (
+    "/health",
+    "/docs",
+    "/openapi.json",
+    "/mcp",             # Bearer-only MCP auth
+    "/auth/github",     # Browser redirect; M-4 HMAC+nonce covers CSRF for install/link
+    "/git/",            # Basic Auth, no cookie
+    "/notebook/",       # sp_nb_<sid> cookie, not __session
+    "/api/webhooks/",   # Reserved for future signed-body webhooks (Stripe/Clerk etc.)
+)
+
+_FORBIDDEN_BODY = '{"detail":"Forbidden."}'
+
+
+def _is_exempt_path(path: str) -> bool:
+    for prefix in _EXEMPT_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    return False
+
+
+def _recompose_origin(referer: str) -> str:
+    """Parse Referer and recompose as scheme://netloc for allow-list comparison."""
+    parsed = urllib.parse.urlsplit(referer)
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+class CookieAuthCsrfMiddleware(BaseHTTPMiddleware):
+    """Enforce Origin/Sec-Fetch-Site on cookie-only mutation requests in cloud mode.
+
+    - Safe methods (GET, HEAD, OPTIONS) always pass through.
+    - Exempt path prefixes always pass through.
+    - Requests without a __session cookie pass through (auth middleware decides).
+    - Requests with both __session and a Bearer/API-key header pass through
+      (treat the non-cookie credential as primary, matching auth.py semantics).
+    - For cookie-only mutations: accept if Sec-Fetch-Site indicates same-origin/site/none,
+      or if Origin is in the allow-list, or if Referer's origin is in the allow-list.
+    - Anything else is rejected with 403.
+    """
+
+    SAFE_METHODS: frozenset[str] = frozenset({"GET", "HEAD", "OPTIONS"})
+    SAME_SITE_TOKENS: frozenset[str] = frozenset({"same-origin", "same-site", "none"})
+
+    def __init__(self, app: object, allowed_origins: list[str], enabled: bool) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._enabled = enabled
+        self._allowed_origins: frozenset[str] = frozenset(
+            o.rstrip("/") for o in allowed_origins
+        )
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if not self._enabled:
+            return await call_next(request)
+
+        # Step 1 — safe methods always pass
+        if request.method in self.SAFE_METHODS:
+            return await call_next(request)
+
+        # Step 2 — exempt path prefixes
+        if _is_exempt_path(request.url.path):
+            return await call_next(request)
+
+        # Step 3 — cookie-only auth detection
+        has_session_cookie = bool(request.cookies.get("__session"))
+        auth_header = request.headers.get("authorization", "")
+        has_bearer = auth_header.lower().startswith("bearer ")
+        has_api_key_header = bool(request.headers.get("x-api-key", "").strip())
+
+        if not has_session_cookie:
+            # Bearer / API-key / unauthenticated — not our concern
+            return await call_next(request)
+
+        if has_bearer or has_api_key_header:
+            # Dual-presented; treat non-cookie credential as primary
+            return await call_next(request)
+
+        # Step 4 — Sec-Fetch-Site fast accept
+        sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
+        if sec_fetch_site in self.SAME_SITE_TOKENS:
+            return await call_next(request)
+
+        # Step 5 — Origin allow-list check
+        origin = request.headers.get("origin", "").rstrip("/")
+        if origin and origin in self._allowed_origins:
+            return await call_next(request)
+
+        # Step 6 — Referer fallback (legacy browsers that strip Origin on same-origin POSTs)
+        referer_host = ""
+        if not origin:
+            referer = request.headers.get("referer", "")
+            if referer:
+                referer_host = _recompose_origin(referer)
+                if referer_host and referer_host in self._allowed_origins:
+                    return await call_next(request)
+
+        # Step 7 — reject
+        request_id = getattr(request.state, "request_id", "unknown")
+        logger.warning(
+            "csrf_block path=%s method=%s origin=%r sec_fetch_site=%r referer_host=%r request_id=%s",
+            request.url.path,
+            request.method,
+            origin,
+            sec_fetch_site,
+            referer_host,
+            request_id,
+        )
+        return Response(
+            content=_FORBIDDEN_BODY,
+            status_code=403,
+            media_type="application/json",
+        )

--- a/signalpilot/gateway/gateway/http/middleware/rate_limit.py
+++ b/signalpilot/gateway/gateway/http/middleware/rate_limit.py
@@ -12,6 +12,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp
 
+from ...common.ip import client_ip as _common_client_ip
 from ...config import get_network_settings
 
 
@@ -75,12 +76,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 del store_dict[ip]
 
     def _client_ip(self, request: Request) -> str:
-        forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            # Use rightmost IP (added by the closest trusted proxy) to prevent
-            # spoofing via attacker-controlled leftmost values.
-            return forwarded.split(",")[-1].strip()
-        return request.client.host if request.client else "unknown"
+        # Delegate to the shared helper so audit metadata and rate-limit bucket
+        # keys always use the same IP derivation (rightmost trusted XFF hop,
+        # then request.client.host).  Empty XFF entries are now skipped — this
+        # aligns the middleware with the helper's filtering and preserves parity.
+        # The "unknown" sentinel is rate-limit-internal and stays here only.
+        return _common_client_ip(request) or "unknown"
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         if request.method == "OPTIONS":

--- a/signalpilot/gateway/gateway/http/middleware/rate_limit.py
+++ b/signalpilot/gateway/gateway/http/middleware/rate_limit.py
@@ -34,6 +34,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         {
             "/api/query",
             "/api/sandboxes",
+            "/api/dbt-cloud/projects",
         }
     )
 

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -109,6 +109,10 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("STARTUP: Encryption health check passed.")
 
+    # Verify OAuth state-signing key is resolvable (cloud mode raises if SP_ENCRYPTION_KEY absent)
+    from .api._oauth_state import get_state_hmac_key
+    get_state_hmac_key()  # raises RuntimeError in cloud mode when key missing — fail fast
+
     # Configure BYOK provider — type and config are read from env vars at startup.
     # SP_BYOK_PROVIDER: provider type string (default: "local")
     # SP_BYOK_PROVIDER_CONFIG: JSON-encoded provider config dict (optional)

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -355,7 +355,7 @@ async def lifespan(app: FastAPI):
 
     # Start dbt-proxy TCP listener
     dbt_proxy_config = DbtProxyConfig()
-    dbt_proxy_config.warn_if_non_loopback()
+    dbt_proxy_config.enforce_bind_safety(cloud=is_cloud_mode())
 
     # Fail closed: if secret is absent, token store is not created and the
     # server.start() context manager will log an error and skip binding.

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -160,7 +160,7 @@ async def lifespan(app: FastAPI):
                 except Exception:
                     alive = False
                 if not alive:
-                    await mark_stopped(db_session, session_id=s.id)
+                    await mark_stopped(db_session, session_id=s.id, org_id=s.org_id or "")
                     logger.info("STARTUP: cleaned stale session %s (pod %s dead)", s.id, s.pod_name)
             await db_session.commit()
     except Exception as e:
@@ -326,7 +326,7 @@ async def lifespan(app: FastAPI):
                         logger.info("Cleaning up stale notebook session %s (pod=%s)", s.id, s.pod_name)
                         if s.pod_name:
                             await orch.delete_pod(s.pod_name, org_id=s.org_id or "")
-                        await ns.mark_stopped(session, session_id=s.id)
+                        await ns.mark_stopped(session, session_id=s.id, org_id=s.org_id or "")
             except Exception as e:
                 logger.warning("Notebook cleanup loop error: %s", e)
             # F-13: reap sp-jwt-* Secrets orphaned by a gateway crash between

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -31,6 +31,7 @@ from .dbt_proxy.config import DbtProxyConfig
 from .governance.context import current_org_id_var
 from .http import (
     APIKeyAuthMiddleware,
+    CookieAuthCsrfMiddleware,
     RateLimitMiddleware,
     RequestBodySizeLimitMiddleware,
     RequestCorrelationMiddleware,
@@ -439,14 +440,20 @@ def _build_allowed_origins() -> list[str]:
 
 
 _ALLOWED_ORIGINS = _build_allowed_origins()
+_CSRF_ENABLED = is_cloud_mode()
 
 # Middleware stack (last added = outermost = runs first)
 # Execution order (outermost → innermost):
-#   CORS → BodySizeLimit → SecurityHeaders → RateLimit → Correlation → Auth
+#   CORS → BodySizeLimit → SecurityHeaders → RateLimit → Correlation → CSRF → Auth
 # CORS is outermost so all error responses (including auth errors) get CORS headers.
-# RequestCorrelationMiddleware runs before Auth so auth logs already have a request ID.
+# RequestCorrelationMiddleware runs before CSRF so CSRF logs already have a request ID.
+# CookieAuthCsrfMiddleware runs after Correlation and before Auth — it inspects
+#   headers/cookies directly (same primitives as auth.py) without coupling to
+#   request.state.auth set by Auth.  RateLimit is outer of CSRF so a CSRF-blocked
+#   flood still costs the attacker general-tier quota.
 # APIKeyAuthMiddleware is innermost — closest to the application handlers.
 app.add_middleware(APIKeyAuthMiddleware)
+app.add_middleware(CookieAuthCsrfMiddleware, allowed_origins=_ALLOWED_ORIGINS, enabled=_CSRF_ENABLED)
 app.add_middleware(RequestCorrelationMiddleware)
 app.add_middleware(RateLimitMiddleware, general_rpm=10000, expensive_rpm=1000, auth_rpm=100)
 app.add_middleware(SecurityHeadersMiddleware)

--- a/signalpilot/gateway/gateway/mcp/tools/notebook.py
+++ b/signalpilot/gateway/gateway/mcp/tools/notebook.py
@@ -4,9 +4,12 @@ import logging
 import re
 import uuid
 
+from gateway.auth.notebook_jwt import mint_session_jwt
+from gateway.config.k8s import get_k8s_settings as _get_k8s_settings
 from gateway.mcp.audit import audited_tool
 from gateway.mcp.context import _store_session, mcp_org_id_var, mcp_user_id_var
 from gateway.mcp.server import mcp
+from gateway.runtime.mode import is_cloud_mode
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +33,58 @@ def _validate_branch(branch: str) -> str | None:
     if not branch or branch.startswith("-") or not _BRANCH_RE.match(branch):
         return f"Error: agent_branch {branch!r} is invalid (must match [A-Za-z0-9._/\\-]+ and not start with -)"
     return None
+
+
+def _build_export_invocation(
+    *,
+    cloud: bool,
+    user_id: str,
+    org_id: str,
+    session_id: str,
+    project_id: str,
+    branch: str,
+    export_target: str,
+) -> tuple[list[str], bytes | None]:
+    """Return (argv, stdin_bytes) for the pod export exec.
+
+    L-3: In cloud mode we mint a notebook session JWT scoped to
+    read/write/query/execute and pipe it as SP_API_KEY over stdin (never argv —
+    argv lands in the k8s control-plane audit log). The caller's raw API key is
+    NEVER forwarded into the pod — it may be admin-scoped, and the in-pod kernel
+    only needs data-plane access.
+
+    In local mode no credential is needed; the local gateway has no auth.
+    """
+    if cloud:
+        export_jwt = mint_session_jwt(
+            user_id=user_id,
+            org_id=org_id,
+            session_id=session_id,
+            project_id=project_id,
+            branch=branch,
+            ttl=_get_k8s_settings().sp_session_jwt_ttl_seconds,
+        )
+        # standalone_mode default (True): Click calls sys.exit(code) so a failed
+        # export propagates a non-zero exit code to exec_in_pod, same as the
+        # `python -m signalpilot export` path below.
+        wrapper = (
+            "import os,sys;"
+            "os.environ['SP_API_KEY']=sys.stdin.readline().strip();"
+            "from signalpilot._cli.cli import main;"
+            "main(args=['export','session',"
+            f"{export_target!r},'--force-overwrite','--verbose'],prog_name='sp')"
+        )
+        return (
+            ["python", "-c", wrapper],
+            (export_jwt + "\n").encode("utf-8"),
+        )
+    return (
+        [
+            "python", "-m", "signalpilot", "export", "session",
+            export_target, "--force-overwrite", "--verbose",
+        ],
+        None,
+    )
 
 
 @audited_tool(mcp)
@@ -118,12 +173,9 @@ async def run_notebook(
             import hashlib
             import os
 
-            from gateway.auth.notebook_jwt import mint_session_jwt
-            from gateway.config.k8s import get_k8s_settings
-
             h = hashlib.sha256(f"{org_id}:{user_id}".encode()).hexdigest()[:12]
             pod_name = f"nb-{h}"
-            k8s_settings = get_k8s_settings()
+            k8s_settings = _get_k8s_settings()
 
             # Clean up any stale session
             if existing:
@@ -230,40 +282,27 @@ async def run_notebook(
     # 6. Run sp export session. The export runs as a fresh exec'd process (not the
     # pod's `sp edit` server), so it doesn't inherit the kernel SP_API_KEY the
     # server injects — the Data SDK (sp.init()) would have no gateway credential.
-    # Pass the MCP caller's own API key so the SDK authenticates as that caller.
-    # The key is read from STDIN by a constant wrapper (never argv — argv lands in
-    # the k8s control-plane audit log), which sets SP_API_KEY then exec's the real
-    # export; the export's kernel inherits SP_API_KEY via construct_kernel_env.
-    # The wrapper string is constant (no user-data interpolation) — F-4-safe.
-    from gateway.mcp.context import mcp_raw_key_var
-
-    mcp_key = mcp_raw_key_var.get(None)
+    # L-3: We mint a notebook session JWT scoped to read/write/query/execute and
+    # pipe it as SP_API_KEY over stdin (never argv — argv lands in the k8s
+    # control-plane audit log). The caller's raw API key is NEVER forwarded into
+    # the pod — it may be admin-scoped, and the in-pod kernel only needs
+    # data-plane access.
     export_target = f"{project_dir}/{filename}"
-    if mcp_key:
-        # standalone_mode default (True): Click calls sys.exit(code) so a failed
-        # export propagates a non-zero exit code to exec_in_pod, same as the
-        # `python -m signalpilot export` path below.
-        wrapper = (
-            "import os,sys;"
-            "os.environ['SP_API_KEY']=sys.stdin.readline().strip();"
-            "from signalpilot._cli.cli import main;"
-            "main(args=['export','session',"
-            f"{export_target!r},'--force-overwrite','--verbose'],prog_name='sp')"
-        )
-        stdout, stderr, exit_code = await orch.exec_in_pod(
-            pod_name, org_id=org_id,
-            argv=["python", "-c", wrapper],
-            stdin_bytes=(mcp_key + "\n").encode("utf-8"),
-            timeout=300,
-        )
-    else:
-        # Local mode (no MCP key) — gateway needs no credential.
-        stdout, stderr, exit_code = await orch.exec_in_pod(
-            pod_name, org_id=org_id,
-            argv=["python", "-m", "signalpilot", "export", "session",
-                  export_target, "--force-overwrite", "--verbose"],
-            timeout=300,
-        )
+    export_argv, export_stdin = _build_export_invocation(
+        cloud=is_cloud_mode(),
+        user_id=user_id,
+        org_id=org_id,
+        session_id=session_id,
+        project_id=project_id,
+        branch=agent_branch,
+        export_target=export_target,
+    )
+    stdout, stderr, exit_code = await orch.exec_in_pod(
+        pod_name, org_id=org_id,
+        argv=export_argv,
+        stdin_bytes=export_stdin,
+        timeout=300,
+    )
 
     # 7. Read session JSON from pod to extract cell outputs
     cell_outputs = ""
@@ -291,9 +330,6 @@ async def run_notebook(
         # we mint a short-lived session JWT and pipe it over stdin (never on argv,
         # so it never lands in /proc/<pid>/cmdline). The git_auth CLI takes the
         # repo path as its first arg, so we pass project_dir (no cd).
-        from gateway.auth.notebook_jwt import mint_session_jwt
-        from gateway.config.k8s import get_k8s_settings as _get_k8s_settings
-
         push_jwt = mint_session_jwt(
             user_id=user_id, org_id=org_id, session_id=session_id,
             project_id=project_id, branch=agent_branch,

--- a/signalpilot/gateway/gateway/mcp/tools/notebook.py
+++ b/signalpilot/gateway/gateway/mcp/tools/notebook.py
@@ -127,7 +127,7 @@ async def run_notebook(
 
             # Clean up any stale session
             if existing:
-                await ns.mark_stopped(session, session_id=existing.id)
+                await ns.mark_stopped(session, session_id=existing.id, org_id=existing.org_id)
             await ns.delete_stopped(session, org_id=org_id, user_id=user_id)
 
             session_info = await ns.create_session(
@@ -152,7 +152,7 @@ async def run_notebook(
 
             await orch._ensure_client()
             if not orch._core_api:
-                await ns.update_session_status(session, session_id=session_id, status="error")
+                await ns.update_session_status(session, session_id=session_id, org_id=org_id, status="error")
                 return "Error starting notebook pod: K8s orchestrator not available"
             core_v1 = orch._core_api
             # Ensure the namespace exists BEFORE the Secret (else create fails on a new org).
@@ -177,7 +177,7 @@ async def run_notebook(
                     session_jwt=session_jwt, create_pod_fn=_create_pod_fn,
                 )
             except Exception as exc:
-                await ns.update_session_status(session, session_id=session_id, status="error")
+                await ns.update_session_status(session, session_id=session_id, org_id=org_id, status="error")
                 return f"Error starting notebook pod: {exc}"
 
             # Outer try: pod EXISTS here; readiness waits are ours to clean up.
@@ -188,12 +188,12 @@ async def run_notebook(
                 await orch.wait_for_ready(pod_name, org_id=org_id, timeout=90)
                 pod_info = await orch.get_pod(pod_name, org_id=org_id)
                 await ns.update_session_status(
-                    session, session_id=session_id, status="running",
+                    session, session_id=session_id, org_id=org_id, status="running",
                     pod_ip=pod_info.ip if pod_info else None,
                     pod_ip_internal=pod_info.ip if pod_info else None,
                 )
             except Exception as exc:
-                await ns.update_session_status(session, session_id=session_id, status="error")
+                await ns.update_session_status(session, session_id=session_id, org_id=org_id, status="error")
                 try:
                     await orch.delete_pod(pod_name, org_id=org_id)
                 except Exception:

--- a/signalpilot/gateway/gateway/notion/client.py
+++ b/signalpilot/gateway/gateway/notion/client.py
@@ -86,6 +86,7 @@ async def search_pages(
 
 MAX_DEPTH = 4
 MAX_CONTENT_CHARS = 8000
+MAX_TOTAL_BLOCKS = 2000
 
 
 async def _fetch_blocks_recursive(
@@ -93,8 +94,12 @@ async def _fetch_blocks_recursive(
     headers: dict[str, str],
     block_id: str,
     depth: int,
+    counter: list[int] | None = None,
 ) -> tuple[list[str], list[dict[str, str]]]:
     """Recursively fetch all text and child pages from a block tree."""
+    if counter is None:
+        counter = [0]
+
     if depth > MAX_DEPTH:
         return [], []
 
@@ -110,6 +115,11 @@ async def _fetch_blocks_recursive(
     child_pages: list[dict[str, str]] = []
 
     for block in blocks:
+        if counter[0] >= MAX_TOTAL_BLOCKS:
+            break
+
+        counter[0] += 1
+
         block_type = block.get("type", "")
 
         if block_type == "child_page":
@@ -125,7 +135,7 @@ async def _fetch_blocks_recursive(
 
         if block.get("has_children", False):
             sub_lines, sub_children = await _fetch_blocks_recursive(
-                client, headers, block["id"], depth + 1,
+                client, headers, block["id"], depth + 1, counter=counter,
             )
             lines.extend(sub_lines)
             child_pages.extend(sub_children)

--- a/signalpilot/gateway/gateway/runtime/mode.py
+++ b/signalpilot/gateway/gateway/runtime/mode.py
@@ -32,6 +32,39 @@ def byok_custom_endpoint_allowed() -> bool:
     return False
 
 
+def _validate_cloud_allowed_origins(raw: str) -> list[str]:
+    """Return a list of violation descriptor strings for SP_ALLOWED_ORIGINS.
+
+    Pure helper — no env reads, no logging. Callers pass the raw env value.
+    Descriptors use var names only; origin values are never included (they may
+    carry sensitive path info — matches the existing "names never values" rule).
+    """
+    if raw.strip() == "":
+        return ["SP_ALLOWED_ORIGINS(unset_or_empty)"]
+
+    descriptors: set[str] = set()
+    for entry in raw.split(","):
+        stripped = entry.strip()
+        if stripped == "":
+            descriptors.add("SP_ALLOWED_ORIGINS(empty_entry)")
+            continue
+        if "*" in stripped:
+            descriptors.add("SP_ALLOWED_ORIGINS(wildcard)")
+            continue
+        if stripped.startswith(("http://localhost", "http://127.0.0.1")):
+            continue
+        if stripped.startswith("https://"):
+            continue
+        # Non-https, non-loopback entry — extract scheme without including the value
+        if "://" in stripped:
+            scheme = stripped.split("://", 1)[0]
+        else:
+            scheme = "unparseable"
+        descriptors.add(f"SP_ALLOWED_ORIGINS(non_https:{scheme})")
+
+    return sorted(descriptors)
+
+
 def assert_cloud_hardening_intact() -> None:
     """Validate that security kill-switches are not disabled in cloud mode.
 
@@ -48,6 +81,8 @@ def assert_cloud_hardening_intact() -> None:
       SP_NOTEBOOK_RUNTIME_CLASS   — empty string is forbidden
       SP_NOTEBOOK_DIRECT_URL      — any non-empty value is forbidden
       SP_DISABLE_SANDBOX          — case-insensitive "true", "1", "yes" is forbidden
+      SP_ALLOWED_ORIGINS          — must be set; no wildcards; all entries must be
+                                    https:// or http://localhost / http://127.0.0.1 (L-5)
 
     Raises RuntimeError listing violated env var NAMES (never values — values may
     contain secrets such as embedded tokens in a direct URL).
@@ -101,6 +136,9 @@ def assert_cloud_hardening_intact() -> None:
     disable_sandbox = os.environ.get("SP_DISABLE_SANDBOX", "").strip().lower()
     if disable_sandbox in ("true", "1", "yes"):
         violations.append("SP_DISABLE_SANDBOX")
+
+    allowed_origins_raw = os.environ.get("SP_ALLOWED_ORIGINS", "")
+    violations.extend(_validate_cloud_allowed_origins(allowed_origins_raw))
 
     if violations:
         raise RuntimeError(

--- a/signalpilot/gateway/gateway/runtime/mode.py
+++ b/signalpilot/gateway/gateway/runtime/mode.py
@@ -41,8 +41,10 @@ def assert_cloud_hardening_intact() -> None:
     That path fires before lifespan; this validator catches any path that bypasses
     pydantic settings instantiation (subprocess, test harness, misconfigured import).
 
-    Enforced kill-switches (final list — extend only via spec revision):
-      SP_NOTEBOOK_NETWORK_POLICY  — case-insensitive "false" is forbidden
+    Enforced kill-switches and required settings (final list — extend only via spec revision):
+      CLERK_JWT_AUDIENCE          — must be non-empty in cloud mode (L-1)
+      SP_NOTEBOOK_NETWORK_POLICY  — case-insensitive "false" is forbidden unless
+                                    SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK=1|true|yes (I-5)
       SP_NOTEBOOK_RUNTIME_CLASS   — empty string is forbidden
       SP_NOTEBOOK_DIRECT_URL      — any non-empty value is forbidden
       SP_DISABLE_SANDBOX          — case-insensitive "true", "1", "yes" is forbidden
@@ -55,23 +57,38 @@ def assert_cloud_hardening_intact() -> None:
 
     violations: list[str] = []
 
-    # SP_NOTEBOOK_NETWORK_POLICY=false is a WARNING, not a boot-blocking violation,
-    # on this deployment. Full default-deny requires the AWS VPC CNI NetworkPolicy
-    # agent, whose eBPF enforcement does NOT compose with gVisor pods (the runsc
-    # userspace netstack egress isn't matched by the agent's ipBlock allow rules),
-    # so enabling it severs pod->gateway egress and breaks every notebook. The
-    # crown-jewel threat this kill-switch defends — node IAM credential theft via
-    # IMDS — is independently closed by the IMDS hop-limit=1 (verified: a pod's
-    # IMDSv2 token PUT times out) PLUS the always-on block-imds-egress NetworkPolicy.
+    # L-1: CLERK_JWT_AUDIENCE must be set in cloud mode. Without it, audience
+    # verification is skipped in _resolve_via_clerk, which means any Clerk-signed
+    # JWT for a different application would be accepted. Enforcement lives here
+    # (lifespan fail-fast) rather than at import time, per R7 lesson.
+    clerk_audience = os.environ.get("CLERK_JWT_AUDIENCE", "").strip()
+    if not clerk_audience:
+        violations.append("CLERK_JWT_AUDIENCE")
+
+    # SP_NOTEBOOK_NETWORK_POLICY=false is a hard-fail by default in cloud mode.
+    # Full default-deny requires the AWS VPC CNI NetworkPolicy agent, whose eBPF
+    # enforcement does NOT compose with gVisor pods (the runsc userspace netstack
+    # egress isn't matched by the agent's ipBlock allow rules), so enabling it
+    # severs pod->gateway egress and breaks every notebook. The crown-jewel threat
+    # this kill-switch defends — node IAM credential theft via IMDS — is
+    # independently closed by the IMDS hop-limit=1 (verified: a pod's IMDSv2 token
+    # PUT times out) PLUS the always-on block-imds-egress NetworkPolicy.
     # Revisit if/when gVisor + VPC CNI NetworkPolicy interop is fixed upstream.
+    # I-5: To opt back into the relaxed mode, set SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK=1|true|yes.
+    # This requires an explicit, auditable operator acknowledgement (mirrors SP_BYOK_ALLOW_CUSTOM_ENDPOINT).
     netpol = os.environ.get("SP_NOTEBOOK_NETWORK_POLICY", "true").strip().lower()
     if netpol == "false":
-        logger.warning(
-            "SP_NOTEBOOK_NETWORK_POLICY=false in cloud mode: full default-deny is "
-            "disabled (gVisor + VPC CNI NetworkPolicy incompatibility). IMDS "
-            "credential theft remains blocked via hop-limit + block-imds-egress "
-            "policy; arbitrary outbound egress from notebooks is NOT restricted."
-        )
+        netpol_ack = os.environ.get("SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK", "").strip().lower()
+        if netpol_ack in _TRUTHY_VALUES:
+            logger.warning(
+                "SP_NOTEBOOK_NETWORK_POLICY=false in cloud mode: full default-deny is "
+                "disabled (gVisor + VPC CNI NetworkPolicy incompatibility). IMDS "
+                "credential theft remains blocked via hop-limit + block-imds-egress "
+                "policy; arbitrary outbound egress from notebooks is NOT restricted. "
+                "Operator acknowledged via SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK."
+            )
+        else:
+            violations.append("SP_NOTEBOOK_NETWORK_POLICY")
 
     runtime_class = os.environ.get("SP_NOTEBOOK_RUNTIME_CLASS", "").strip()
     if runtime_class == "":
@@ -87,5 +104,5 @@ def assert_cloud_hardening_intact() -> None:
 
     if violations:
         raise RuntimeError(
-            f"Cloud mode hardening kill-switches set: {violations}. Refusing to boot."
+            f"Cloud mode hardening violations: {violations}. Refusing to boot."
         )

--- a/signalpilot/gateway/gateway/store/notebook_sessions.py
+++ b/signalpilot/gateway/gateway/store/notebook_sessions.py
@@ -123,6 +123,7 @@ async def update_session_status(
     session: AsyncSession,
     *,
     session_id: str,
+    org_id: str,
     status: str,
     pod_ip: str | None = None,
     pod_ip_internal: str | None = None,
@@ -134,7 +135,10 @@ async def update_session_status(
         values["pod_ip_internal"] = pod_ip_internal
     await session.execute(
         update(GatewayNotebookSession)
-        .where(GatewayNotebookSession.id == session_id)
+        .where(
+            GatewayNotebookSession.id == session_id,
+            GatewayNotebookSession.org_id == org_id,
+        )
         .values(**values)
     )
     await session.commit()
@@ -173,10 +177,13 @@ async def ping_session_by_id(
     return _to_info(row)
 
 
-async def mark_stopped(session: AsyncSession, *, session_id: str) -> None:
+async def mark_stopped(session: AsyncSession, *, session_id: str, org_id: str) -> None:
     await session.execute(
         update(GatewayNotebookSession)
-        .where(GatewayNotebookSession.id == session_id)
+        .where(
+            GatewayNotebookSession.id == session_id,
+            GatewayNotebookSession.org_id == org_id,
+        )
         .values(status="stopped")
     )
     await session.commit()

--- a/signalpilot/gateway/gateway/store/settings.py
+++ b/signalpilot/gateway/gateway/store/settings.py
@@ -41,10 +41,13 @@ async def save_settings(session: AsyncSession, *, org_id: str, user_id: str | No
     await session.commit()
 
 
-async def get_credentials_needing_rotation(session: AsyncSession) -> int:
-    result = await session.execute(
+async def get_credentials_needing_rotation(session: AsyncSession, org_id: str | None = None) -> int:
+    query = (
         select(sa_func.count())
         .select_from(GatewayCredential)
         .where(GatewayCredential.key_version < CURRENT_KEY_VERSION)
     )
+    if org_id is not None:
+        query = query.where(GatewayCredential.org_id == org_id)
+    result = await session.execute(query)
     return result.scalar_one()

--- a/signalpilot/gateway/gateway/store/store.py
+++ b/signalpilot/gateway/gateway/store/store.py
@@ -682,13 +682,16 @@ class Store:
 
     # ─── Key Rotation ────────────────────────────────────────────────────
 
-    async def get_credentials_needing_rotation(self) -> int:
+    async def get_credentials_needing_rotation(self, org_scoped: bool = True) -> int:
         """Return count of credentials encrypted with a key version below CURRENT_KEY_VERSION.
 
-        This is a global (non-user-scoped) query, intentionally, because it is
-        called from the admin-only security_status endpoint which needs a system-wide count.
+        ORG-SCOPED by default (org_scoped=True): filters to the current org via
+        _require_org_id(). Cross-org count is opt-in (org_scoped=False) and
+        intended only for future operator-only callers — no production caller
+        currently passes org_scoped=False.
         """
-        return await settings_mod.get_credentials_needing_rotation(self.session)
+        org_id = self._require_org_id() if org_scoped else None
+        return await settings_mod.get_credentials_needing_rotation(self.session, org_id=org_id)
 
     # ─── Knowledge Base ──────────────────────────────────────────────────
 

--- a/signalpilot/gateway/tests/test_admin_audit_logging.py
+++ b/signalpilot/gateway/tests/test_admin_audit_logging.py
@@ -112,6 +112,55 @@ class TestBYOKAudit:
         _assert_no_credential_material(entry.metadata)
 
     @pytest.mark.asyncio
+    async def test_byok_key_create_uses_trusted_hop_ip(self):
+        """Regression: audit entry must use the rightmost XFF hop (trusted proxy),
+        not the leftmost (client-spoofable) value."""
+        from gateway.api.byok import create_byok_key
+        from gateway.models import BYOKKeyCreate
+
+        store = _make_store()
+        # Simulate a spoofed leftmost entry; trusted proxy appended "2.2.2.2".
+        request = _make_request(forwarded_for="evil-spoof, 2.2.2.2")
+
+        db = AsyncMock()
+        existing_result = MagicMock()
+        existing_result.scalar_one_or_none.return_value = None
+        key_mock = MagicMock()
+        key_mock.id = str(uuid.uuid4())
+        key_mock.org_id = "test-org"
+        key_mock.key_alias = "my-key"
+        key_mock.provider_type = "local"
+        key_mock.provider_config = None
+        key_mock.status = "active"
+        key_mock.created_at = time.time()
+        key_mock.revoked_at = None
+        db.execute = AsyncMock(return_value=existing_result)
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        body = BYOKKeyCreate(key_alias="my-key", provider_type="local", provider_config={})
+
+        with patch("gateway.api.byok._upsert_org", new_callable=AsyncMock):
+            await create_byok_key(
+                body=body,
+                db=db,
+                _user_id="test-user",
+                org_id="test-org",
+                _role=None,
+                store=store,
+                request=request,
+            )
+
+        store.append_audit.assert_called_once()
+        entry: AuditEntry = store.append_audit.call_args[0][0]
+        assert entry.client_ip == "2.2.2.2", (
+            f"Expected trusted rightmost XFF '2.2.2.2' but got {entry.client_ip!r}. "
+            "Audit IP must not be spoofable via leftmost XFF."
+        )
+        assert entry.client_ip != "evil-spoof"
+
+    @pytest.mark.asyncio
     async def test_byok_migrate_appends_audit(self):
         import gateway.store.byok_state as byok_state
         from gateway.api.byok import migrate_credentials_to_byok

--- a/signalpilot/gateway/tests/test_audit_csv_injection.py
+++ b/signalpilot/gateway/tests/test_audit_csv_injection.py
@@ -1,0 +1,152 @@
+"""Tests for M-5: CSV formula-injection neutralization in /api/audit/export?format=csv.
+
+Verifies that user/agent-controlled fields starting with formula-trigger
+characters are prefixed with a single apostrophe per OWASP guidance, and that
+benign values pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.api.audit import export_audit
+
+# ─── Shared helper ────────────────────────────────────────────────────────────
+
+
+def _make_entry(**kwargs: object) -> dict:
+    """Return a minimal audit entry dict, overriding any fields via kwargs."""
+    base: dict = {
+        "id": "abc-123",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "event_type": "read_query",
+        "connection_name": "prod_db",
+        "sql": "SELECT 1",
+        "tables": [],
+        "rows_returned": 1,
+        "duration_ms": 5,
+        "blocked": False,
+        "block_reason": "",
+        "agent_id": "agent-1",
+        "metadata": {},
+    }
+    base.update(kwargs)
+    return base
+
+
+async def _run_export(entries: list[dict]) -> list[list[str]]:
+    """Invoke export_audit with a mocked store and return parsed CSV rows."""
+    store = AsyncMock()
+    store.read_audit = AsyncMock(return_value=entries)
+    resp = await export_audit(
+        store=store,
+        limit=None,
+        connection_name=None,
+        event_type=None,
+        format="csv",
+    )
+    chunks = [chunk async for chunk in resp.body_iterator]
+    if chunks and isinstance(chunks[0], bytes):
+        body = b"".join(chunks).decode()  # type: ignore[arg-type]
+    else:
+        body = "".join(chunks)  # type: ignore[arg-type]
+    return list(csv.reader(io.StringIO(body)))
+
+
+# ─── Test class ───────────────────────────────────────────────────────────────
+
+
+class TestAuditCsvInjection:
+    """Verify CSV formula-injection mitigation in the audit export endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_formula_trigger_equals(self):
+        """sql starting with '=' must be prefixed with apostrophe."""
+        payload = '=WEBSERVICE("http://x")'
+        rows = await _run_export([_make_entry(sql=payload)])
+        # Row 0 is the header; row 1 is data. sql is column index 4.
+        sql_cell = rows[1][4]
+        assert sql_cell == "'" + payload
+
+    @pytest.mark.asyncio
+    async def test_formula_trigger_plus(self):
+        """connection_name starting with '+' must be prefixed with apostrophe."""
+        rows = await _run_export([_make_entry(connection_name="+attack")])
+        conn_cell = rows[1][3]
+        assert conn_cell.startswith("'+")
+
+    @pytest.mark.asyncio
+    async def test_formula_trigger_minus(self):
+        """block_reason starting with '-' must be prefixed with apostrophe."""
+        rows = await _run_export([_make_entry(block_reason="-1+1")])
+        block_reason_cell = rows[1][9]
+        assert block_reason_cell.startswith("'-")
+
+    @pytest.mark.asyncio
+    async def test_formula_trigger_at(self):
+        """agent_id starting with '@' must be prefixed with apostrophe."""
+        rows = await _run_export([_make_entry(agent_id="@SUM(A1)")])
+        agent_cell = rows[1][10]
+        assert agent_cell.startswith("'@")
+
+    @pytest.mark.asyncio
+    async def test_formula_trigger_tab(self):
+        """sql starting with tab must be prefixed with apostrophe."""
+        rows = await _run_export([_make_entry(sql="\t=cmd")])
+        sql_cell = rows[1][4]
+        assert sql_cell.startswith("'\t")
+
+    @pytest.mark.asyncio
+    async def test_formula_trigger_cr(self):
+        """sql starting with carriage return must be prefixed with apostrophe."""
+        rows = await _run_export([_make_entry(sql="\rinject")])
+        sql_cell = rows[1][4]
+        assert sql_cell.startswith("'\r")
+
+    @pytest.mark.asyncio
+    async def test_benign_values_unchanged(self):
+        """Benign values must pass through without any leading apostrophe."""
+        rows = await _run_export(
+            [_make_entry(sql="SELECT 1", event_type="read_query", connection_name="prod_db")]
+        )
+        data_row = rows[1]
+        # event_type col 2, connection_name col 3, sql col 4
+        assert data_row[2] == "read_query"
+        assert data_row[3] == "prod_db"
+        assert data_row[4] == "SELECT 1"
+        # None of the cells should start with apostrophe
+        for cell in data_row:
+            assert not cell.startswith("'"), f"Unexpected apostrophe in cell: {cell!r}"
+
+    @pytest.mark.asyncio
+    async def test_none_and_empty_stay_empty(self):
+        """None and empty-string fields must produce empty CSV cells."""
+        rows = await _run_export(
+            [_make_entry(sql=None, block_reason=None, agent_id="")]
+        )
+        data_row = rows[1]
+        sql_cell = data_row[4]
+        block_reason_cell = data_row[9]
+        agent_cell = data_row[10]
+        assert sql_cell == ""
+        assert block_reason_cell == ""
+        assert agent_cell == ""
+
+    @pytest.mark.asyncio
+    async def test_metadata_json_with_trigger_neutralized(self):
+        """metadata column contains json.dumps output; confirm it passes through _csv_safe.
+
+        json.dumps of a dict always starts with '{', which is not a trigger char,
+        so the cell must equal the literal json.dumps output with no apostrophe.
+        """
+        metadata = {"key": "value", "count": 42}
+        rows = await _run_export([_make_entry(metadata=metadata)])
+        metadata_cell = rows[1][11]
+        expected = json.dumps(metadata)
+        assert metadata_cell == expected
+        assert not metadata_cell.startswith("'")

--- a/signalpilot/gateway/tests/test_byok_aws.py
+++ b/signalpilot/gateway/tests/test_byok_aws.py
@@ -394,7 +394,7 @@ class TestSecurityStatusBYOKFields:
             patch("gateway.store.crypto._validate_encryption_health", return_value=True),
             patch.dict(os.environ, {"SP_ENCRYPTION_KEY": "test-key"}),
         ):
-            result = await security_status(mock_store, "test-org")
+            result = await security_status(mock_store, "test-org", None)
 
         required_fields = {
             "byok_provider",
@@ -413,6 +413,67 @@ class TestSecurityStatusBYOKFields:
         assert result["byok_keys_total"] == 3
         assert result["credentials_managed"] == 3
         assert result["credentials_byok"] == 1
+
+    @pytest.mark.asyncio
+    async def test_security_status_pending_rotation_is_org_scoped(self):
+        """total_credentials_pending_rotation must reflect the org-scoped count.
+
+        The handler calls store.get_credentials_needing_rotation() with no
+        explicit org_id argument; scoping happens inside Store via
+        _require_org_id(). The mock returns an org-specific value and we assert
+        it flows through to the response unchanged.
+        """
+        from gateway.api.security import security_status
+        from gateway.byok import DEKCache, LocalBYOKProvider
+        from gateway.store import configure_byok
+
+        provider = LocalBYOKProvider()
+        cache = DEKCache(ttl_seconds=300)
+        configure_byok(provider, cache)
+
+        mock_store = MagicMock()
+        mock_store.user_id = "local"
+        mock_store.org_id = "org-A"
+
+        # Simulate an org-scoped count of 5 credentials pending rotation
+        mock_store.get_credentials_needing_rotation = AsyncMock(return_value=5)
+
+        def _make_result(value: int = 0) -> MagicMock:
+            r = MagicMock()
+            r.scalar_one = MagicMock(return_value=value)
+            return r
+
+        execute_results = [
+            _make_result(10),  # credentials_encrypted
+            _make_result(3),   # byok_keys_active
+            _make_result(1),   # byok_keys_revoked
+            _make_result(8),   # credentials_managed
+            _make_result(2),   # credentials_byok
+        ]
+        execute_index = [0]
+
+        async def _mock_execute(query):
+            idx = execute_index[0]
+            execute_index[0] += 1
+            if idx < len(execute_results):
+                return execute_results[idx]
+            return _make_result(0)
+
+        mock_store.session = MagicMock()
+        mock_store.session.execute = _mock_execute
+
+        with (
+            patch("gateway.store.crypto._validate_encryption_health", return_value=True),
+            patch.dict(os.environ, {"SP_ENCRYPTION_KEY": "test-key"}),
+        ):
+            result = await security_status(mock_store, "org-A", None)
+
+        # Assert the handler invoked get_credentials_needing_rotation with no
+        # org_id argument (self-scoping via _require_org_id() inside Store)
+        mock_store.get_credentials_needing_rotation.assert_called_once_with()
+
+        # Assert the org-scoped count flows through to the response key
+        assert result["total_credentials_pending_rotation"] == 5
 
 
 # ─── main.py lifespan env var integration test ───────────────────────────────

--- a/signalpilot/gateway/tests/test_byok_hardening.py
+++ b/signalpilot/gateway/tests/test_byok_hardening.py
@@ -187,7 +187,7 @@ class TestSecurityStatusOrgScoping:
             patch("gateway.store.crypto._validate_encryption_health", return_value=True),
             patch.dict(os.environ, {"SP_ENCRYPTION_KEY": "test-key"}),
         ):
-            result = await security_status(mock_store, "org1")
+            result = await security_status(mock_store, "org1", None)
 
         assert result["byok_keys_active"] == 2
         assert result["byok_keys_revoked"] == 0
@@ -227,7 +227,7 @@ class TestSecurityStatusOrgScoping:
                 patch("gateway.store.crypto._validate_encryption_health", return_value=True),
                 patch.dict(os.environ, {"SP_ENCRYPTION_KEY": "test-key"}),
             ):
-                return await security_status(mock_store, org_id)
+                return await security_status(mock_store, org_id, None)
 
         result_org1 = await _call_with_org("org1", active=3, revoked=1)
         result_org2 = await _call_with_org("org2", active=0, revoked=0)
@@ -277,7 +277,7 @@ class TestSecurityStatusOrgScoping:
             patch("gateway.store.crypto._validate_encryption_health", return_value=True),
             patch.dict(os.environ, {"SP_ENCRYPTION_KEY": "test-key"}),
         ):
-            result = await security_status(mock_store, "org-xyz")
+            result = await security_status(mock_store, "org-xyz", None)
 
         assert result["credentials_managed"] == 3
         assert result["credentials_byok"] == 1

--- a/signalpilot/gateway/tests/test_client_ip_unification.py
+++ b/signalpilot/gateway/tests/test_client_ip_unification.py
@@ -1,0 +1,220 @@
+"""Tests for F-L6: unified client-IP derivation via gateway.common.ip.
+
+Verifies that:
+- ``client_ip`` returns the rightmost XFF entry (spoof-rejection).
+- Whitespace is stripped; empty/blank entries are skipped.
+- ``x-real-ip`` is never consulted (parity with RateLimitMiddleware).
+- ``request_meta`` returns ``(client_ip, user_agent)`` verbatim.
+- ``RateLimitMiddleware._client_ip`` is exactly ``client_ip(req) or "unknown"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.common.ip import client_ip, request_meta
+from gateway.http.middleware.rate_limit import RateLimitMiddleware
+
+# ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_request(
+    headers: dict[str, str] | None = None,
+    client_host: str | None = "10.0.0.1",
+) -> MagicMock:
+    """Build a minimal mock Request matching FastAPI's interface."""
+    req = MagicMock()
+    req.headers = headers or {}
+    if client_host is None:
+        req.client = None
+    else:
+        req.client = MagicMock()
+        req.client.host = client_host
+    return req
+
+
+# ─── Unit tests for client_ip / request_meta ──────────────────────────────────
+
+
+class TestClientIp:
+    def test_leftmost_xff_is_not_returned(self) -> None:
+        req = _make_request(
+            headers={"x-forwarded-for": "1.1.1.1, 2.2.2.2"},
+            client_host="10.0.0.1",
+        )
+        result = client_ip(req)
+        assert result == "2.2.2.2", "Rightmost XFF must be returned, not leftmost"
+        assert result != "1.1.1.1"
+
+    def test_single_xff_value(self) -> None:
+        req = _make_request(headers={"x-forwarded-for": "1.1.1.1"})
+        assert client_ip(req) == "1.1.1.1"
+
+    def test_xff_whitespace_trimmed(self) -> None:
+        req = _make_request(headers={"x-forwarded-for": "1.1.1.1 , 2.2.2.2 "})
+        assert client_ip(req) == "2.2.2.2"
+
+    def test_xff_empty_header_falls_through(self) -> None:
+        req = _make_request(
+            headers={"x-forwarded-for": ""},
+            client_host="10.0.0.1",
+        )
+        assert client_ip(req) == "10.0.0.1"
+
+    def test_xff_only_empty_entries_falls_through(self) -> None:
+        req = _make_request(
+            headers={"x-forwarded-for": ", , "},
+            client_host="10.0.0.1",
+        )
+        assert client_ip(req) == "10.0.0.1"
+
+    def test_xff_with_leading_empty_entries(self) -> None:
+        req = _make_request(headers={"x-forwarded-for": ", , 2.2.2.2"})
+        assert client_ip(req) == "2.2.2.2"
+
+    def test_xff_ipv6(self) -> None:
+        req = _make_request(
+            headers={"x-forwarded-for": "2001:db8::1, 2001:db8::2"}
+        )
+        assert client_ip(req) == "2001:db8::2"
+
+    def test_x_real_ip_ignored_when_no_xff(self) -> None:
+        """Helper must NOT fall back to x-real-ip — parity guard."""
+        req = _make_request(
+            headers={"x-real-ip": "3.3.3.3"},
+            client_host="10.0.0.1",
+        )
+        # Must return client.host, not x-real-ip
+        assert client_ip(req) == "10.0.0.1"
+
+    def test_x_real_ip_ignored_when_xff_present(self) -> None:
+        req = _make_request(
+            headers={
+                "x-forwarded-for": "1.1.1.1, 2.2.2.2",
+                "x-real-ip": "9.9.9.9",
+            },
+            client_host="10.0.0.1",
+        )
+        # XFF rightmost wins; x-real-ip is ignored entirely
+        assert client_ip(req) == "2.2.2.2"
+
+    def test_remote_addr_fallback(self) -> None:
+        req = _make_request(headers={}, client_host="10.0.0.1")
+        assert client_ip(req) == "10.0.0.1"
+
+    def test_returns_none_when_nothing_available(self) -> None:
+        req = _make_request(headers={}, client_host=None)
+        assert client_ip(req) is None
+
+    def test_request_meta_returns_user_agent(self) -> None:
+        req = _make_request(
+            headers={
+                "x-forwarded-for": "1.1.1.1, 2.2.2.2",
+                "user-agent": "test-agent/1.0",
+            },
+            client_host="10.0.0.1",
+        )
+        ip, ua = request_meta(req)
+        assert ip == "2.2.2.2"
+        assert ua == "test-agent/1.0"
+
+    def test_request_meta_user_agent_none_when_absent(self) -> None:
+        req = _make_request(headers={}, client_host="10.0.0.1")
+        _ip, ua = request_meta(req)
+        assert ua is None
+
+
+# ─── Parity test: middleware._client_ip == (client_ip(req) or "unknown") ──────
+
+_PARITY_MATRIX: list[tuple[str, dict[str, Any], str | None, str]] = [
+    # (case_id, headers, client_host, expected_both)
+    (
+        "spoof",
+        {"x-forwarded-for": "evil, 2.2.2.2"},
+        "10.0.0.1",
+        "2.2.2.2",
+    ),
+    (
+        "single-xff",
+        {"x-forwarded-for": "1.1.1.1"},
+        "10.0.0.1",
+        "1.1.1.1",
+    ),
+    (
+        "whitespace-xff",
+        {"x-forwarded-for": "1.1.1.1 , 2.2.2.2 "},
+        "10.0.0.1",
+        "2.2.2.2",
+    ),
+    (
+        "empty-xff",
+        {"x-forwarded-for": ""},
+        "10.0.0.1",
+        "10.0.0.1",
+    ),
+    (
+        "only-empty-entries",
+        {"x-forwarded-for": ", , "},
+        "10.0.0.1",
+        "10.0.0.1",
+    ),
+    (
+        "ipv6-xff",
+        {"x-forwarded-for": "2001:db8::1, 2001:db8::2"},
+        "10.0.0.1",
+        "2001:db8::2",
+    ),
+    (
+        "x-real-ip-only",
+        {"x-real-ip": "3.3.3.3"},
+        "10.0.0.1",
+        "10.0.0.1",  # x-real-ip must be ignored; client.host wins
+    ),
+    (
+        "no-headers-with-host",
+        {},
+        "10.0.0.1",
+        "10.0.0.1",
+    ),
+    (
+        "no-headers-no-host",
+        {},
+        None,
+        "unknown",  # helper returns None; middleware returns "unknown"
+    ),
+]
+
+_NOOP_APP: Any = None  # sentinel; BaseHTTPMiddleware accepts an ASGI callable
+
+
+@pytest.mark.parametrize(
+    "case_id,headers,client_host,expected",
+    _PARITY_MATRIX,
+    ids=[row[0] for row in _PARITY_MATRIX],
+)
+def test_parity_with_rate_limit_middleware(
+    case_id: str,
+    headers: dict[str, Any],
+    client_host: str | None,
+    expected: str,
+) -> None:
+    """``middleware._client_ip(req)`` must equal ``client_ip(req) or "unknown"``."""
+    # Instantiate with a no-op ASGI app — dispatch is never called in this test.
+    middleware = RateLimitMiddleware(app=MagicMock())  # type: ignore[arg-type]
+    req = _make_request(headers=headers, client_host=client_host)
+
+    helper_result = client_ip(req) or "unknown"
+    middleware_result = middleware._client_ip(req)
+
+    assert middleware_result == expected, (
+        f"[{case_id}] middleware returned {middleware_result!r}, expected {expected!r}"
+    )
+    assert helper_result == expected, (
+        f"[{case_id}] helper returned {helper_result!r}, expected {expected!r}"
+    )
+    assert middleware_result == helper_result, (
+        f"[{case_id}] middleware={middleware_result!r} != helper={helper_result!r}"
+    )

--- a/signalpilot/gateway/tests/test_connection_validation_ssh.py
+++ b/signalpilot/gateway/tests/test_connection_validation_ssh.py
@@ -1,0 +1,153 @@
+"""Tests for cloud-mode SSRF validation of SSH tunnel bastion/proxy hosts.
+
+Covers the _validate_connection_params path in
+gateway.api.connections._validation for ssh_tunnel.host and
+ssh_tunnel.proxy_host.
+
+_validate_connection_params is imported lazily via importlib to bypass the
+gateway.api.__init__ FastAPI import (which is not installed in this test
+environment).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_validation_module() -> Any:
+    """Load gateway.api.connections._validation directly without triggering
+    gateway.api or gateway.api.connections package __init__ files (which
+    require FastAPI, not available in this test environment)."""
+    import sys
+
+    # Stub out the parent packages if not already loaded so that
+    # gateway.models and gateway.network (the only real deps of _validation.py)
+    # import cleanly without triggering the FastAPI-dependent __init__ files.
+    for pkg in ("gateway.api", "gateway.api.connections"):
+        if pkg not in sys.modules:
+            sys.modules[pkg] = types.ModuleType(pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "gateway.api.connections._validation",
+        Path(__file__).parent.parent / "gateway" / "api" / "connections" / "_validation.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_VALIDATION_MOD = _load_validation_module()
+_validate_connection_params = _VALIDATION_MOD._validate_connection_params
+
+
+def _patch_dns(resolved_ip: str):
+    """Patch socket.getaddrinfo to return a single resolved IP."""
+    return patch(
+        "gateway.network.validation.socket.getaddrinfo",
+        return_value=[(None, None, None, None, (resolved_ip, 0))],
+    )
+
+
+def _make_postgres_conn_with_ssh(ssh_host: str, proxy_host: str | None = None):
+    """Build a minimal postgres ConnectionCreate with SSH tunnel enabled."""
+    from gateway.models import ConnectionCreate, SSHTunnelConfig
+
+    tunnel = SSHTunnelConfig(
+        enabled=True,
+        host=ssh_host,
+        username="tunnel-user",
+        auth_method="password",
+        password="s3cret",
+        proxy_host=proxy_host,
+    )
+    return ConnectionCreate(
+        name="test-conn",
+        db_type="postgres",
+        host="db.example.com",
+        port=5432,
+        username="dbuser",
+        password="dbpass",
+        database="mydb",
+        ssh_tunnel=tunnel,
+    )
+
+
+class TestSshTunnelCloudModeBastion:
+    def test_imds_bastion_host_rejected_in_cloud_mode(self, monkeypatch):
+        """169.254.169.254 as SSH bastion host must produce an error in cloud mode."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        conn = _make_postgres_conn_with_ssh("169.254.169.254")
+        with _patch_dns("169.254.169.254"):
+            errors = _validate_connection_params(conn)
+        assert errors, "Expected errors for IMDS bastion host"
+        assert any("bastion" in e.lower() for e in errors)
+
+    def test_loopback_bastion_host_rejected_in_cloud_mode(self, monkeypatch):
+        """127.0.0.1 as SSH bastion host must produce an error in cloud mode."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        conn = _make_postgres_conn_with_ssh("127.0.0.1")
+        with _patch_dns("127.0.0.1"):
+            errors = _validate_connection_params(conn)
+        assert errors, "Expected errors for loopback bastion host"
+        assert any("bastion" in e.lower() for e in errors)
+
+    def test_public_bastion_host_allowed_in_cloud_mode(self, monkeypatch):
+        """A public-resolving bastion host must not produce SSH-tunnel errors."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        conn = _make_postgres_conn_with_ssh("bastion.example.com")
+        # Patch validate_connection_host on the loaded module to avoid live DNS
+        with patch.object(_VALIDATION_MOD, "validate_connection_host"):
+            with _patch_dns("52.0.0.1"):
+                errors = _validate_connection_params(conn)
+        ssh_errors = [e for e in errors if "bastion" in e.lower() or "proxy" in e.lower()]
+        assert not ssh_errors, f"Unexpected SSH-tunnel errors: {ssh_errors}"
+
+    def test_bastion_host_validation_skipped_in_local_mode(self, monkeypatch):
+        """In local mode, bastion host SSRF validation must be skipped entirely."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        conn = _make_postgres_conn_with_ssh("10.0.0.1")
+        # In local mode validate_connection_params also skips SSRF for all hosts
+        with _patch_dns("10.0.0.1"):
+            errors = _validate_connection_params(conn)
+        ssh_errors = [e for e in errors if "bastion" in e.lower() or "proxy" in e.lower()]
+        assert not ssh_errors, f"Unexpected SSH-tunnel SSRF errors in local mode: {ssh_errors}"
+
+
+class TestSshTunnelCloudModeProxy:
+    def test_imds_proxy_host_rejected_in_cloud_mode(self, monkeypatch):
+        """169.254.169.254 as SSH HTTP proxy host must produce an error in cloud mode."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        conn = _make_postgres_conn_with_ssh("bastion.example.com", proxy_host="169.254.169.254")
+
+        def _fake_validate_host(host: str) -> None:
+            if host == "169.254.169.254":
+                raise ValueError("169.254.169.254 is a blocked link-local address")
+            # bastion.example.com passes
+
+        with patch.object(_VALIDATION_MOD, "validate_connection_host", side_effect=_fake_validate_host):
+            with _patch_dns("52.0.0.1"):
+                errors = _validate_connection_params(conn)
+        assert errors, "Expected errors for IMDS proxy host"
+        assert any("proxy" in e.lower() for e in errors)
+
+    def test_loopback_proxy_host_rejected_in_cloud_mode(self, monkeypatch):
+        """127.0.0.1 as SSH HTTP proxy host must produce an error in cloud mode."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        conn = _make_postgres_conn_with_ssh("bastion.example.com", proxy_host="127.0.0.1")
+
+        def _fake_validate_host(host: str) -> None:
+            if host == "127.0.0.1":
+                raise ValueError("127.0.0.1 is a blocked loopback address")
+
+        with patch.object(_VALIDATION_MOD, "validate_connection_host", side_effect=_fake_validate_host):
+            with _patch_dns("52.0.0.1"):
+                errors = _validate_connection_params(conn)
+        assert errors, "Expected errors for loopback proxy host"
+        assert any("proxy" in e.lower() for e in errors)

--- a/signalpilot/gateway/tests/test_dbt_proxy_api.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_api.py
@@ -12,10 +12,25 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from gateway.dbt_proxy.api import get_store
 from gateway.dbt_proxy.api import router as dbt_proxy_router
 from gateway.dbt_proxy.config import DbtProxyConfig
 from gateway.dbt_proxy.tokens import RunTokenStore
+from gateway.models import DBType
 from gateway.security.scope_guard import require_scopes
+
+
+class _FakeStubConn:
+    """Minimal connection stub with a postgres db_type for test apps."""
+
+    db_type: DBType = DBType.postgres
+
+
+class _FakeStoreWithPostgres:
+    """Fake store stub that always returns a postgres connection."""
+
+    async def get_connection(self, name: str) -> _FakeStubConn:
+        return _FakeStubConn()
 
 
 def _make_test_app(secret: str = "test-secret", enabled: bool = True) -> FastAPI:
@@ -44,6 +59,11 @@ def _make_test_app(secret: str = "test-secret", enabled: bool = True) -> FastAPI
             return await call_next(request)
 
     app.add_middleware(_LocalAuthMiddleware)
+
+    # Override get_store to avoid needing a real DB connection
+    fake_store = _FakeStoreWithPostgres()
+    app.dependency_overrides[get_store] = lambda: fake_store
+
     return app
 
 

--- a/signalpilot/gateway/tests/test_dbt_proxy_org_scoping.py
+++ b/signalpilot/gateway/tests/test_dbt_proxy_org_scoping.py
@@ -1,0 +1,235 @@
+"""Org-scoping tests for dbt-proxy run-token routes.
+
+Covers M-2 (IDOR on revoke/get) and M-3 (connector ownership at mint time).
+Uses dependency overrides to avoid needing a real DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from gateway.dbt_proxy.api import get_store
+from gateway.dbt_proxy.api import router as dbt_proxy_router
+from gateway.dbt_proxy.config import DbtProxyConfig
+from gateway.dbt_proxy.tokens import RunTokenStore
+from gateway.models import DBType
+
+# ─── FakeStore ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _StubConnection:
+    db_type: DBType
+
+
+class FakeStore:
+    """Minimal store stub that returns a configurable connection for get_connection."""
+
+    def __init__(self, connection: _StubConnection | None) -> None:
+        self._connection = connection
+
+    async def get_connection(self, name: str) -> _StubConnection | None:
+        return self._connection
+
+
+# ─── Test app factory ─────────────────────────────────────────────────────────
+
+_DEFAULT_SECRET = "test-secret-org-scope"
+
+
+def _make_test_app_with_org(
+    org_id: str,
+    fake_store: FakeStore | None = None,
+    secret: str = _DEFAULT_SECRET,
+) -> FastAPI:
+    """Build a minimal FastAPI app with configurable org_id and store override."""
+    app = FastAPI()
+    app.include_router(dbt_proxy_router)
+
+    config = DbtProxyConfig(
+        sp_dbt_proxy_enabled=True,
+        sp_gateway_run_token_secret=secret,
+        sp_dbt_proxy_port=15432,
+    )
+    token_store = RunTokenStore(secret)
+    app.state.dbt_proxy_config = config
+    app.state.dbt_proxy_token_store = token_store
+
+    class _LocalAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next: Any) -> Any:
+            request.state.auth = {"auth_method": "local_key"}
+            request.state._jwt_claims = {"sub": "test-user", "org_id": org_id}
+            return await call_next(request)
+
+    app.add_middleware(_LocalAuthMiddleware)
+
+    if fake_store is not None:
+        app.dependency_overrides[get_store] = lambda: fake_store
+
+    return app
+
+
+def _postgres_store() -> FakeStore:
+    return FakeStore(_StubConnection(db_type=DBType.postgres))
+
+
+def _mysql_store() -> FakeStore:
+    return FakeStore(_StubConnection(db_type=DBType.mysql))
+
+
+def _none_store() -> FakeStore:
+    return FakeStore(None)
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestDbtProxyOrgScoping:
+    def test_mint_with_foreign_org_connector_returns_404(self) -> None:
+        """FakeStore returns None (connector exists in org B, not visible to org A)."""
+        app = _make_test_app_with_org("org-a", fake_store=_none_store())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={"run_id": str(uuid.uuid4()), "connector_name": "conn_b", "ttl_seconds": 300},
+            )
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["error_code"] == "connector_not_found"
+
+    def test_mint_with_nonexistent_connector_returns_404(self) -> None:
+        """FakeStore returns None for any connector name."""
+        app = _make_test_app_with_org("org-a", fake_store=_none_store())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={"run_id": str(uuid.uuid4()), "connector_name": "does_not_exist", "ttl_seconds": 300},
+            )
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["error_code"] == "connector_not_found"
+
+    def test_mint_with_non_postgres_connector_returns_404(self) -> None:
+        """Non-postgres connector returns same 404 as missing — no type leak."""
+        app = _make_test_app_with_org("org-a", fake_store=_mysql_store())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={"run_id": str(uuid.uuid4()), "connector_name": "mysql_conn", "ttl_seconds": 300},
+            )
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["error_code"] == "connector_not_found"
+
+    def test_mint_with_postgres_connector_succeeds(self) -> None:
+        """Postgres connector in caller's org → 201 with token."""
+        app = _make_test_app_with_org("org-a", fake_store=_postgres_store())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={"run_id": str(uuid.uuid4()), "connector_name": "pg_conn", "ttl_seconds": 300},
+            )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "token" in data
+        assert len(data["token"]) == 64
+
+    def test_revoke_foreign_org_run_id_returns_204_and_does_not_revoke(self) -> None:
+        """Critical: revoke by a different org returns 204 but does NOT remove the token."""
+        secret = _DEFAULT_SECRET
+        # Mint a token as "other-org" directly into the store
+        app = _make_test_app_with_org("test-org", fake_store=_postgres_store(), secret=secret)
+        token_store: RunTokenStore = app.state.dbt_proxy_token_store
+
+        run_id = uuid.uuid4()
+
+        asyncio.run(
+            token_store.mint(
+                run_id=run_id,
+                org_id="other-org",
+                user_id="other-user",
+                connector_name="conn",
+                ttl_seconds=300,
+            )
+        )
+
+        with TestClient(app) as client:
+            del_resp = client.delete(f"/api/dbt-proxy/run-tokens/{run_id}")
+
+        assert del_resp.status_code == 204
+
+        # Token must still be present — the revoke must NOT have executed
+        claims = asyncio.run(token_store.get(run_id))
+        assert claims is not None
+        assert claims.org_id == "other-org"
+
+    def test_get_foreign_org_run_id_returns_404(self) -> None:
+        """GET for a run_id that belongs to another org → 404 with same error_code as genuine miss."""
+        secret = _DEFAULT_SECRET
+        app = _make_test_app_with_org("test-org", fake_store=_postgres_store(), secret=secret)
+        token_store: RunTokenStore = app.state.dbt_proxy_token_store
+
+        run_id = uuid.uuid4()
+
+        asyncio.run(
+            token_store.mint(
+                run_id=run_id,
+                org_id="other-org",
+                user_id="other-user",
+                connector_name="conn",
+                ttl_seconds=300,
+            )
+        )
+
+        with TestClient(app) as client:
+            get_resp = client.get(f"/api/dbt-proxy/run-tokens/{run_id}")
+
+        assert get_resp.status_code == 404
+        detail = get_resp.json()["detail"]
+        assert detail["error_code"] == "run_token_not_found"
+        assert f"run_id={run_id}" in detail["message"]
+
+    def test_revoke_own_org_token_succeeds(self) -> None:
+        """Mint via API as test-org, DELETE → 204, then token is gone."""
+        app = _make_test_app_with_org("test-org", fake_store=_postgres_store())
+        token_store: RunTokenStore = app.state.dbt_proxy_token_store
+        run_id = uuid.uuid4()
+
+        with TestClient(app) as client:
+            mint_resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={"run_id": str(run_id), "connector_name": "pg_conn", "ttl_seconds": 300},
+            )
+            assert mint_resp.status_code == 201
+
+            del_resp = client.delete(f"/api/dbt-proxy/run-tokens/{run_id}")
+
+        assert del_resp.status_code == 204
+
+        claims = asyncio.run(token_store.get(run_id))
+        assert claims is None
+
+    def test_get_own_org_token_returns_info(self) -> None:
+        """Mint via API as test-org, GET → 200 with expected fields."""
+        app = _make_test_app_with_org("test-org", fake_store=_postgres_store())
+        run_id = uuid.uuid4()
+
+        with TestClient(app) as client:
+            mint_resp = client.post(
+                "/api/dbt-proxy/run-tokens",
+                json={"run_id": str(run_id), "connector_name": "pg_conn", "ttl_seconds": 300},
+            )
+            assert mint_resp.status_code == 201
+
+            get_resp = client.get(f"/api/dbt-proxy/run-tokens/{run_id}")
+
+        assert get_resp.status_code == 200
+        data = get_resp.json()
+        assert data["run_id"] == str(run_id)
+        assert "expires_at" in data
+        assert data["host_port"] == 15432
+        assert data["sessions_open"] == 0

--- a/signalpilot/gateway/tests/test_github_oauth_state.py
+++ b/signalpilot/gateway/tests/test_github_oauth_state.py
@@ -1,0 +1,183 @@
+"""Tests for GitHub OAuth state token generation and verification.
+
+Covers the public API in ``gateway.api._oauth_state``:
+- Key resolution (cloud vs local, cached vs uncached)
+- State minting and verification
+- Replay prevention via nonce store
+- Tamper resistance (signature + payload)
+- Ordering guarantee: nonce store NOT mutated for states that fail HMAC
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import gateway.api._oauth_state as _oauth_state
+from gateway.api._oauth_state import (
+    get_state_hmac_key,
+    make_state,
+    verify_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_oauth_state_module(monkeypatch: pytest.MonkeyPatch):
+    """Reset module-level singletons so each test starts clean."""
+    monkeypatch.setattr(_oauth_state, "_HMAC_KEY", None)
+    # Replace the nonce store with a fresh one so replay state doesn't bleed
+    monkeypatch.setattr(_oauth_state, "_NONCE_STORE", _oauth_state._NonceStore())
+    yield
+
+
+@pytest.fixture()
+def fixed_key_env(monkeypatch: pytest.MonkeyPatch):
+    """Set a fixed SP_ENCRYPTION_KEY and clear cloud mode for deterministic tests."""
+    monkeypatch.setenv("SP_ENCRYPTION_KEY", "test-secret-key-for-oauth-state")
+    monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+
+
+class TestGitHubOAuthState:
+    # ── Key resolution ────────────────────────────────────────────────────
+
+    def test_cloud_mode_missing_key_raises(self, monkeypatch: pytest.MonkeyPatch):
+        """Cloud mode without SP_ENCRYPTION_KEY must raise RuntimeError."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        monkeypatch.delenv("SP_ENCRYPTION_KEY", raising=False)
+        # _HMAC_KEY already reset by autouse fixture
+
+        with pytest.raises(RuntimeError, match="SP_ENCRYPTION_KEY required in cloud mode"):
+            get_state_hmac_key()
+
+    def test_local_mode_missing_key_generates_random(self, monkeypatch: pytest.MonkeyPatch):
+        """Local mode without SP_ENCRYPTION_KEY generates a random 32-byte key and caches it."""
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        monkeypatch.delenv("SP_ENCRYPTION_KEY", raising=False)
+
+        key1 = get_state_hmac_key()
+        assert isinstance(key1, bytes)
+        assert len(key1) == 32
+
+        # Second call returns the same cached key
+        key2 = get_state_hmac_key()
+        assert key1 == key2
+
+    # ── verify_state: empty / None inputs ────────────────────────────────
+
+    def test_verify_empty_string_returns_none(self, fixed_key_env: None):
+        assert verify_state("") is None
+
+    def test_verify_none_returns_none(self, fixed_key_env: None):
+        assert verify_state(None) is None
+
+    # ── verify_state: old format rejection ───────────────────────────────
+
+    def test_old_format_state_rejected(self, fixed_key_env: None):
+        """Pre-v2 state format (no v2: prefix) must be rejected."""
+        old_state = "orgid:abc123def456789.deadbeef12345678"
+        assert verify_state(old_state) is None
+
+    # ── verify_state: expiry ──────────────────────────────────────────────
+
+    def test_expired_state_rejected(self, monkeypatch: pytest.MonkeyPatch, fixed_key_env: None):
+        """State past TTL must be rejected."""
+        state = make_state("my-org")
+
+        # Advance time past TTL
+        original_time = time.time
+        monkeypatch.setattr(
+            _oauth_state.time,
+            "time",
+            lambda: original_time() + _oauth_state.STATE_TTL_SECONDS + 1,
+        )
+
+        assert verify_state(state) is None
+
+    # ── verify_state: replay ──────────────────────────────────────────────
+
+    def test_replay_rejected(self, fixed_key_env: None):
+        """Second use of the same state token must be rejected."""
+        state = make_state("my-org")
+
+        result1 = verify_state(state)
+        assert result1 == "my-org"
+
+        result2 = verify_state(state)
+        assert result2 is None
+
+    def test_replay_after_expiry_rejected(self, monkeypatch: pytest.MonkeyPatch, fixed_key_env: None):
+        """After TTL expires the state should still be rejected (expired or replay)."""
+        state = make_state("my-org")
+
+        original_time = time.time
+        monkeypatch.setattr(
+            _oauth_state.time,
+            "time",
+            lambda: original_time() + _oauth_state.STATE_TTL_SECONDS + 1,
+        )
+
+        # Both attempts return None — no exception raised
+        assert verify_state(state) is None
+        assert verify_state(state) is None
+
+    # ── verify_state: happy path ──────────────────────────────────────────
+
+    def test_happy_path(self, fixed_key_env: None):
+        """Minted state immediately verified must return the original org_id."""
+        org_id = "acme-corp"
+        state = make_state(org_id)
+        result = verify_state(state)
+        assert result == org_id
+
+    # ── verify_state: tamper resistance ──────────────────────────────────
+
+    def test_tampered_signature_rejected(self, fixed_key_env: None):
+        """Flipping a character in the signature must invalidate the state."""
+        state = make_state("my-org")
+        dot_idx = state.rfind(".")
+        payload = state[:dot_idx]
+        sig = state[dot_idx + 1:]
+
+        # Flip the first character of the signature
+        bad_char = "a" if sig[0] != "a" else "b"
+        tampered = f"{payload}.{bad_char}{sig[1:]}"
+
+        assert verify_state(tampered) is None
+
+    def test_tampered_org_rejected(self, fixed_key_env: None):
+        """Swapping org_id in the payload while reusing the original signature must fail."""
+        state = make_state("my-org")
+        dot_idx = state.rfind(".")
+        payload = state[:dot_idx]
+        sig = state[dot_idx + 1:]
+
+        # Swap org_id in payload — signature will no longer match
+        fields = payload.split(":")
+        fields[1] = "evil-org"
+        tampered_payload = ":".join(fields)
+        tampered = f"{tampered_payload}.{sig}"
+
+        assert verify_state(tampered) is None
+
+    # ── nonce-store ordering guarantee ────────────────────────────────────
+
+    def test_reserve_not_called_for_bad_hmac(self, fixed_key_env: None):
+        """Nonce must NOT be inserted into the store when HMAC verification fails."""
+        state = make_state("my-org")
+        dot_idx = state.rfind(".")
+        payload = state[:dot_idx]
+        sig = state[dot_idx + 1:]
+
+        # Tamper the signature
+        bad_char = "a" if sig[0] != "a" else "b"
+        tampered = f"{payload}.{bad_char}{sig[1:]}"
+
+        verify_state(tampered)
+
+        # Extract nonce from the original (untampered) payload
+        fields = payload.split(":")
+        nonce_hex = fields[2]
+
+        # The nonce must NOT be present in the store
+        assert nonce_hex not in _oauth_state._NONCE_STORE._entries

--- a/signalpilot/gateway/tests/test_notebook_sessions.py
+++ b/signalpilot/gateway/tests/test_notebook_sessions.py
@@ -571,7 +571,7 @@ class TestSessionReuse:
 
         mark_stopped_calls = []
 
-        async def _mock_mark_stopped(session, *, session_id):
+        async def _mock_mark_stopped(session, *, session_id, org_id):
             mark_stopped_calls.append(session_id)
 
         async def _mock_delete_stopped(session, *, org_id, user_id):

--- a/signalpilot/gateway/tests/test_notion_block_cap.py
+++ b/signalpilot/gateway/tests/test_notion_block_cap.py
@@ -1,0 +1,70 @@
+"""Tests for the MAX_TOTAL_BLOCKS cap in _fetch_blocks_recursive."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from gateway.notion.client import MAX_TOTAL_BLOCKS, _fetch_blocks_recursive
+
+
+def _make_blocks_response(count: int, has_children: bool) -> dict:
+    """Build a fake Notion blocks response with paragraph blocks."""
+    results = []
+    for i in range(count):
+        results.append({
+            "id": f"block-{i}",
+            "type": "paragraph",
+            "paragraph": {
+                "rich_text": [{"plain_text": f"line {i}"}],
+            },
+            "has_children": has_children,
+        })
+    return {"results": results}
+
+
+class TestNotionBlockCap:
+    @pytest.mark.asyncio
+    async def test_fetch_blocks_recursive_caps_at_max_total_blocks(self) -> None:
+        """Blocks fetched from a deep/wide tree must not exceed MAX_TOTAL_BLOCKS."""
+        call_count = 0
+
+        async def mock_get(url: str, **kwargs) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            response = MagicMock(spec=httpx.Response)
+            response.raise_for_status = MagicMock()
+            # 100 blocks per call, every block has children (creates unbounded tree)
+            response.json.return_value = _make_blocks_response(100, has_children=True)
+            return response
+
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(side_effect=mock_get)
+        headers: dict[str, str] = {}
+
+        lines, child_pages = await _fetch_blocks_recursive(client, headers, "root", 0)
+
+        # Lines must be bounded by the block cap
+        assert len(lines) <= MAX_TOTAL_BLOCKS
+        # API calls should be far fewer than an unbounded traversal would require
+        assert call_count < 25
+
+    @pytest.mark.asyncio
+    async def test_fetch_blocks_recursive_under_cap_returns_all(self) -> None:
+        """When total blocks are below cap, all blocks should be returned."""
+        async def mock_get(url: str, **kwargs) -> MagicMock:
+            response = MagicMock(spec=httpx.Response)
+            response.raise_for_status = MagicMock()
+            response.json.return_value = _make_blocks_response(10, has_children=False)
+            return response
+
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(side_effect=mock_get)
+        headers: dict[str, str] = {}
+
+        lines, child_pages = await _fetch_blocks_recursive(client, headers, "root", 0)
+
+        assert len(lines) == 10
+        assert child_pages == []

--- a/signalpilot/gateway/tests/test_run_notebook_scoped_jwt.py
+++ b/signalpilot/gateway/tests/test_run_notebook_scoped_jwt.py
@@ -1,0 +1,153 @@
+"""Tests for L-3: run_notebook export step uses scoped session JWT, not raw MCP key.
+
+Class: TestRunNotebookPodEnvScopedJWT
+
+Tests the _build_export_invocation helper extracted from run_notebook.
+The helper is pure (takes cloud: bool as a parameter) so no k8s or store
+mocking is required.
+"""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+
+from gateway.auth.notebook_jwt import (
+    NOTEBOOK_SESSION_AUD,
+    NOTEBOOK_SESSION_ISS,
+    NOTEBOOK_SESSION_SCOPES,
+)
+from gateway.mcp.tools.notebook import _build_export_invocation
+
+_TEST_SECRET = "test-scoped-jwt-secret-for-l3-48bytes!!"
+_RAW_MCP_KEY = "sp_admin_raw_key_xxx"
+
+_USER_ID = "user-l3"
+_ORG_ID = "org-l3"
+_SESSION_ID = "sess-l3-abc123"
+_PROJECT_ID = "proj-l3"
+_BRANCH = "signalpilot-agent/abc123"
+_EXPORT_TARGET = "/home/notebook/.sp/projects/proj-l3/analysis.py"
+
+
+def _patch_secret(monkeypatch) -> None:
+    monkeypatch.setattr("gateway.auth.notebook_jwt.load_session_jwt_secret", lambda: _TEST_SECRET)
+    monkeypatch.setattr("gateway.auth.jwt_secret._cached_secret", _TEST_SECRET)
+
+
+def _patch_k8s_settings(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    from gateway.config.k8s import K8sSettings
+
+    fake_settings = MagicMock(spec=K8sSettings)
+    fake_settings.sp_session_jwt_ttl_seconds = 3600
+    monkeypatch.setattr("gateway.mcp.tools.notebook._get_k8s_settings", lambda: fake_settings)
+
+
+def _invoke_cloud(monkeypatch) -> tuple[list[str], bytes]:
+    """Run _build_export_invocation in cloud mode and return (argv, stdin_bytes)."""
+    _patch_secret(monkeypatch)
+    _patch_k8s_settings(monkeypatch)
+    argv, stdin_bytes = _build_export_invocation(
+        cloud=True,
+        user_id=_USER_ID,
+        org_id=_ORG_ID,
+        session_id=_SESSION_ID,
+        project_id=_PROJECT_ID,
+        branch=_BRANCH,
+        export_target=_EXPORT_TARGET,
+    )
+    assert stdin_bytes is not None
+    return argv, stdin_bytes
+
+
+class TestRunNotebookPodEnvScopedJWT:
+    """L-3: export step pipes a scoped session JWT — never the caller's raw key."""
+
+    def test_cloud_mode_pod_stdin_contains_session_jwt_not_raw_key(self, monkeypatch):
+        """Cloud path: stdin contains a valid JWT, not the raw MCP key."""
+        argv, stdin_bytes = _invoke_cloud(monkeypatch)
+
+        # stdin must be a JWT (three dot-separated base64url segments)
+        token = stdin_bytes.decode("utf-8").strip()
+        assert token.count(".") == 2, "stdin should be a JWT (three parts)"
+
+        # Decode without verifying signature to inspect claims
+        claims = jwt.decode(token, options={"verify_signature": False})
+        assert isinstance(claims, dict)
+
+        # The raw MCP key must NOT appear anywhere in the stdin bytes
+        assert _RAW_MCP_KEY.encode() not in stdin_bytes
+        assert b"sp_admin_raw_key_xxx" not in stdin_bytes
+
+    def test_cloud_mode_jwt_scopes_are_exactly_subset(self, monkeypatch):
+        """Cloud path: JWT scopes are exactly {read, write, query, execute}."""
+        _, stdin_bytes = _invoke_cloud(monkeypatch)
+        token = stdin_bytes.decode("utf-8").strip()
+        claims = jwt.decode(token, options={"verify_signature": False})
+
+        assert set(claims["scopes"]) == set(NOTEBOOK_SESSION_SCOPES)
+        assert set(claims["scopes"]) == {"read", "write", "query", "execute"}
+
+        # Defense-in-depth: exact-set equality already covers these, but explicit
+        # negatives document intent (no admin/billing/secret-write escalation).
+        assert "admin" not in claims["scopes"]
+        assert "write:secret" not in claims["scopes"]
+        assert "billing" not in claims["scopes"]
+
+    def test_cloud_mode_jwt_claims_match_session(self, monkeypatch):
+        """Cloud path: JWT claims match the session parameters passed in."""
+        _, stdin_bytes = _invoke_cloud(monkeypatch)
+        token = stdin_bytes.decode("utf-8").strip()
+
+        # Verify with the test secret to get trusted claims
+        claims = jwt.decode(
+            token,
+            _TEST_SECRET,
+            algorithms=["HS256"],
+            audience=NOTEBOOK_SESSION_AUD,
+            issuer=NOTEBOOK_SESSION_ISS,
+        )
+
+        assert claims["sub"] == _USER_ID
+        assert claims["org_id"] == _ORG_ID
+        assert claims["session_id"] == _SESSION_ID
+        assert claims["project_id"] == _PROJECT_ID
+        assert claims["branch"] == _BRANCH
+        assert claims["iss"] == NOTEBOOK_SESSION_ISS
+        assert claims["aud"] == NOTEBOOK_SESSION_AUD
+
+    def test_local_mode_no_stdin_no_jwt(self, monkeypatch):
+        """Local path: no stdin bytes and argv uses python -m signalpilot form."""
+        monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+
+        argv, stdin_bytes = _build_export_invocation(
+            cloud=False,
+            user_id=_USER_ID,
+            org_id=_ORG_ID,
+            session_id=_SESSION_ID,
+            project_id=_PROJECT_ID,
+            branch=_BRANCH,
+            export_target=_EXPORT_TARGET,
+        )
+
+        assert stdin_bytes is None
+        # Must use `python -m signalpilot export` form, NOT `python -c wrapper`
+        assert argv[0] == "python"
+        assert "-m" in argv
+        assert "signalpilot" in argv
+        assert "export" in argv
+        assert "-c" not in argv
+
+    def test_raw_mcp_key_never_appears_in_pod_invocation(self, monkeypatch):
+        """Cloud path: the raw MCP key does not appear in argv or stdin_bytes."""
+        argv, stdin_bytes = _invoke_cloud(monkeypatch)
+
+        raw_key = "sp_RAW_KEY_SHOULD_NOT_LEAK"
+
+        # Must not appear in any element of argv
+        assert all(raw_key not in arg for arg in argv)
+
+        # Must not appear in the stdin bytes
+        assert raw_key.encode() not in stdin_bytes

--- a/signalpilot/gateway/tests/test_security_fixes.py
+++ b/signalpilot/gateway/tests/test_security_fixes.py
@@ -1079,3 +1079,131 @@ class TestL6SessionMutationsOrgFilter:
         where_str = self._where_clause_str(captured[0])
         assert "org-a" in where_str
         assert "sess-4" in where_str
+
+
+# ─── I-2: SP_EXPECTED_AZP allowlist enforcement in Clerk verifier ────────────
+
+
+class TestClerkAzpAllowlist:
+    """I-2: SP_EXPECTED_AZP azp allowlist enforcement in the Clerk JWT verifier."""
+
+    @pytest.mark.asyncio
+    async def test_azp_mismatch_rejected_when_allowlist_set(self, monkeypatch) -> None:
+        """azp not in allowlist → 401 Invalid authentication token."""
+        import base64
+        import json
+        import time
+
+        from fastapi import HTTPException
+
+        from gateway.auth.user import resolve_user_id
+
+        monkeypatch.setattr("gateway.auth.user.EXPECTED_AZP", frozenset({"https://app.signalpilot.com"}))
+
+        clerk_payload = {
+            "iss": "https://clerk.example.com",
+            "sub": "user_1",
+            "azp": "https://evil.example.com",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        }
+        header_b64 = base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode()).rstrip(b"=")
+        payload_b64 = base64.urlsafe_b64encode(json.dumps(clerk_payload).encode()).rstrip(b"=")
+        fake_sig = base64.urlsafe_b64encode(b"fakesignature").rstrip(b"=")
+        clerk_token = f"{header_b64.decode()}.{payload_b64.decode()}.{fake_sig.decode()}"
+
+        with patch("gateway.auth.user.is_cloud_mode", return_value=True):
+            mock_client = MagicMock()
+            mock_client.get_signing_key_from_jwt.return_value = MagicMock()
+
+            with patch("gateway.auth.user._get_jwks_client", return_value=mock_client):
+                with patch("gateway.auth.user.jwt.decode", return_value=clerk_payload):
+                    request = MagicMock()
+                    request.headers.get.return_value = f"Bearer {clerk_token}"
+                    request.cookies.get.return_value = None
+                    request.state = MagicMock(spec=[])
+
+                    with pytest.raises(HTTPException) as exc_info:
+                        await resolve_user_id(request)
+
+                    assert exc_info.value.status_code == 401
+                    assert exc_info.value.detail == "Invalid authentication token"
+
+    @pytest.mark.asyncio
+    async def test_azp_missing_rejected_when_allowlist_set(self, monkeypatch) -> None:
+        """azp claim absent → 401 Invalid authentication token when allowlist set."""
+        import base64
+        import json
+        import time
+
+        from fastapi import HTTPException
+
+        from gateway.auth.user import resolve_user_id
+
+        monkeypatch.setattr("gateway.auth.user.EXPECTED_AZP", frozenset({"https://app.signalpilot.com"}))
+
+        clerk_payload = {
+            "iss": "https://clerk.example.com",
+            "sub": "user_1",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        }
+        header_b64 = base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode()).rstrip(b"=")
+        payload_b64 = base64.urlsafe_b64encode(json.dumps(clerk_payload).encode()).rstrip(b"=")
+        fake_sig = base64.urlsafe_b64encode(b"fakesignature").rstrip(b"=")
+        clerk_token = f"{header_b64.decode()}.{payload_b64.decode()}.{fake_sig.decode()}"
+
+        with patch("gateway.auth.user.is_cloud_mode", return_value=True):
+            mock_client = MagicMock()
+            mock_client.get_signing_key_from_jwt.return_value = MagicMock()
+
+            with patch("gateway.auth.user._get_jwks_client", return_value=mock_client):
+                with patch("gateway.auth.user.jwt.decode", return_value=clerk_payload):
+                    request = MagicMock()
+                    request.headers.get.return_value = f"Bearer {clerk_token}"
+                    request.cookies.get.return_value = None
+                    request.state = MagicMock(spec=[])
+
+                    with pytest.raises(HTTPException) as exc_info:
+                        await resolve_user_id(request)
+
+                    assert exc_info.value.status_code == 401
+                    assert exc_info.value.detail == "Invalid authentication token"
+
+    @pytest.mark.asyncio
+    async def test_azp_not_enforced_when_env_unset(self, monkeypatch) -> None:
+        """EXPECTED_AZP empty frozenset → azp check is a no-op, returns user_id."""
+        import base64
+        import json
+        import time
+
+        from gateway.auth.user import resolve_user_id
+
+        monkeypatch.setattr("gateway.auth.user.EXPECTED_AZP", frozenset())
+
+        clerk_payload = {
+            "iss": "https://clerk.example.com",
+            "sub": "user_1",
+            "azp": "anything",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        }
+        header_b64 = base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode()).rstrip(b"=")
+        payload_b64 = base64.urlsafe_b64encode(json.dumps(clerk_payload).encode()).rstrip(b"=")
+        fake_sig = base64.urlsafe_b64encode(b"fakesignature").rstrip(b"=")
+        clerk_token = f"{header_b64.decode()}.{payload_b64.decode()}.{fake_sig.decode()}"
+
+        with patch("gateway.auth.user.is_cloud_mode", return_value=True):
+            mock_client = MagicMock()
+            mock_client.get_signing_key_from_jwt.return_value = MagicMock()
+
+            with patch("gateway.auth.user._get_jwks_client", return_value=mock_client):
+                with patch("gateway.auth.user.jwt.decode", return_value=clerk_payload):
+                    request = MagicMock()
+                    request.headers.get.return_value = f"Bearer {clerk_token}"
+                    request.cookies.get.return_value = None
+                    request.state = MagicMock(spec=[])
+
+                    result = await resolve_user_id(request)
+
+                    assert result == "user_1"

--- a/signalpilot/gateway/tests/test_security_fixes.py
+++ b/signalpilot/gateway/tests/test_security_fixes.py
@@ -6,12 +6,14 @@ Each test class covers one vulnerability finding.
 from __future__ import annotations
 
 import asyncio
+import logging
 import struct
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.testclient import TestClient
 
 from gateway.dbt_proxy.tokens import RunTokenClaims
@@ -846,3 +848,234 @@ class TestL1CookieCsrfOriginCheck:
         resp = client.post("/echo", cookies={"__session": "abc"})
         assert resp.status_code == 403
         assert resp.json() == {"detail": "Forbidden."}
+
+
+# ─── L-1: CLERK_JWT_AUDIENCE hard-fail in cloud mode ─────────────────────────
+
+
+# Env vars that must be set to avoid other kill-switches tripping during L-1/I-5 tests.
+_CLOUD_HARDENING_BASE_ENV = {
+    "SP_DEPLOYMENT_MODE": "cloud",
+    "SP_NOTEBOOK_RUNTIME_CLASS": "gvisor",
+    "CLERK_JWT_AUDIENCE": "my-app",
+}
+
+
+def _set_cloud_base(monkeypatch, **overrides) -> None:
+    """Set the minimum env to pass assert_cloud_hardening_intact in cloud mode."""
+    env = {**_CLOUD_HARDENING_BASE_ENV, **overrides}
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    # Ensure vars that should be absent are absent
+    monkeypatch.delenv("SP_NOTEBOOK_DIRECT_URL", raising=False)
+    monkeypatch.delenv("SP_DISABLE_SANDBOX", raising=False)
+    monkeypatch.delenv("SP_NOTEBOOK_NETWORK_POLICY", raising=False)
+    monkeypatch.delenv("SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK", raising=False)
+
+
+class TestL1ClerkAudienceHardFailCloud:
+    """L-1: assert_cloud_hardening_intact() fails fast when CLERK_JWT_AUDIENCE is
+    unset or empty in cloud mode."""
+
+    def test_cloud_mode_missing_audience_raises(self, monkeypatch) -> None:
+        _set_cloud_base(monkeypatch)
+        monkeypatch.delenv("CLERK_JWT_AUDIENCE", raising=False)
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        with pytest.raises(RuntimeError, match="CLERK_JWT_AUDIENCE"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_mode_present_audience_passes(self, monkeypatch) -> None:
+        _set_cloud_base(monkeypatch, CLERK_JWT_AUDIENCE="my-app")
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_local_mode_missing_audience_passes(self, monkeypatch) -> None:
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        monkeypatch.delenv("CLERK_JWT_AUDIENCE", raising=False)
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        assert_cloud_hardening_intact()  # local mode: no checks
+
+    def test_cloud_mode_empty_string_audience_raises(self, monkeypatch) -> None:
+        _set_cloud_base(monkeypatch, CLERK_JWT_AUDIENCE="   ")
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        with pytest.raises(RuntimeError, match="CLERK_JWT_AUDIENCE"):
+            assert_cloud_hardening_intact()
+
+
+# ─── I-5: SP_NOTEBOOK_NETWORK_POLICY=false hard-fail with opt-in ─────────────
+
+
+class TestI5NetworkPolicyOptOutHardFailCloud:
+    """I-5: SP_NOTEBOOK_NETWORK_POLICY=false must trigger RuntimeError in cloud
+    mode unless SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK=1|true|yes is set."""
+
+    def test_cloud_netpol_false_no_ack_raises(self, monkeypatch) -> None:
+        _set_cloud_base(monkeypatch)
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY", "false")
+        monkeypatch.delenv("SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK", raising=False)
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        with pytest.raises(RuntimeError, match="SP_NOTEBOOK_NETWORK_POLICY"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_netpol_false_with_ack_warns_only(self, monkeypatch, caplog) -> None:
+        _set_cloud_base(monkeypatch)
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY", "false")
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK", "1")
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        with caplog.at_level(logging.WARNING, logger="gateway.runtime.mode"):
+            assert_cloud_hardening_intact()  # must not raise
+
+        assert any("SP_NOTEBOOK_NETWORK_POLICY=false" in r.message for r in caplog.records)
+
+    def test_cloud_netpol_true_passes(self, monkeypatch) -> None:
+        _set_cloud_base(monkeypatch)
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY", "true")
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_local_netpol_false_passes(self, monkeypatch) -> None:
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY", "false")
+        monkeypatch.delenv("SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK", raising=False)
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        assert_cloud_hardening_intact()  # local mode: no checks
+
+    @pytest.mark.parametrize(
+        "ack,should_raise",
+        [
+            ("1", False),
+            ("true", False),
+            ("yes", False),
+            ("TRUE", False),
+            ("Yes", False),
+            ("", True),
+            ("0", True),
+            ("false", True),
+            ("no", True),
+        ],
+    )
+    def test_cloud_netpol_false_ack_truthy_variants(
+        self, monkeypatch, ack: str, should_raise: bool
+    ) -> None:
+        _set_cloud_base(monkeypatch)
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY", "false")
+        monkeypatch.setenv("SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK", ack)
+
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        if should_raise:
+            with pytest.raises(RuntimeError, match="SP_NOTEBOOK_NETWORK_POLICY"):
+                assert_cloud_hardening_intact()
+        else:
+            assert_cloud_hardening_intact()  # must not raise
+
+
+# ─── L-6: org_id filter on session mutation helpers ──────────────────────────
+
+
+class TestL6SessionMutationsOrgFilter:
+    """L-6: update_session_status and mark_stopped must pass org_id in the WHERE
+    clause so a cross-org call is a silent no-op (defense-in-depth).
+
+    We capture the SQLAlchemy Update clause passed to session.execute and verify
+    that org_id is present in the WHERE criteria — no live DB required.
+    """
+
+    def _make_async_session_capture(self) -> tuple[AsyncMock, list]:
+        """Return a mock AsyncSession and the list that captures execute calls."""
+        captured: list = []
+
+        async def _fake_execute(stmt, *args, **kwargs):
+            captured.append(stmt)
+            return MagicMock()
+
+        session = AsyncMock(spec=AsyncSession)
+        session.execute.side_effect = _fake_execute
+        session.commit = AsyncMock()
+        return session, captured
+
+    def _where_clause_str(self, stmt) -> str:
+        """Compile the WHERE clause of an Update statement to a string for inspection."""
+        from sqlalchemy.dialects import sqlite
+
+        return str(stmt.whereclause.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True}))
+
+    @pytest.mark.asyncio
+    async def test_update_session_status_includes_org_id_in_where(self) -> None:
+        from gateway.store.notebook_sessions import update_session_status
+
+        session, captured = self._make_async_session_capture()
+
+        await update_session_status(
+            session,
+            session_id="sess-1",
+            org_id="org-b",
+            status="running",
+            pod_ip="1.2.3.4",
+        )
+
+        assert len(captured) == 1
+        where_str = self._where_clause_str(captured[0])
+        assert "org-b" in where_str
+        assert "sess-1" in where_str
+
+    @pytest.mark.asyncio
+    async def test_update_session_status_correct_org_in_where(self) -> None:
+        from gateway.store.notebook_sessions import update_session_status
+
+        session, captured = self._make_async_session_capture()
+
+        await update_session_status(
+            session,
+            session_id="sess-2",
+            org_id="org-a",
+            status="running",
+            pod_ip="10.0.0.1",
+        )
+
+        assert len(captured) == 1
+        where_str = self._where_clause_str(captured[0])
+        assert "org-a" in where_str
+        assert "sess-2" in where_str
+
+    @pytest.mark.asyncio
+    async def test_mark_stopped_wrong_org_includes_org_id_in_where(self) -> None:
+        from gateway.store.notebook_sessions import mark_stopped
+
+        session, captured = self._make_async_session_capture()
+
+        await mark_stopped(session, session_id="sess-3", org_id="org-b")
+
+        assert len(captured) == 1
+        where_str = self._where_clause_str(captured[0])
+        assert "org-b" in where_str
+        assert "sess-3" in where_str
+
+    @pytest.mark.asyncio
+    async def test_mark_stopped_correct_org_in_where(self) -> None:
+        from gateway.store.notebook_sessions import mark_stopped
+
+        session, captured = self._make_async_session_capture()
+
+        await mark_stopped(session, session_id="sess-4", org_id="org-a")
+
+        assert len(captured) == 1
+        where_str = self._where_clause_str(captured[0])
+        assert "org-a" in where_str
+        assert "sess-4" in where_str

--- a/signalpilot/gateway/tests/test_security_fixes.py
+++ b/signalpilot/gateway/tests/test_security_fixes.py
@@ -858,6 +858,9 @@ _CLOUD_HARDENING_BASE_ENV = {
     "SP_DEPLOYMENT_MODE": "cloud",
     "SP_NOTEBOOK_RUNTIME_CLASS": "gvisor",
     "CLERK_JWT_AUDIENCE": "my-app",
+    # R11 added SP_ALLOWED_ORIGINS to assert_cloud_hardening_intact; without it
+    # these L-1/I-5 tests would trip the unrelated SP_ALLOWED_ORIGINS violation.
+    "SP_ALLOWED_ORIGINS": "https://app.signalpilot.ai",
 }
 
 

--- a/signalpilot/gateway/tests/test_security_fixes.py
+++ b/signalpilot/gateway/tests/test_security_fixes.py
@@ -364,6 +364,47 @@ class TestV4DefaultBindHost:
         assert not any("non-loopback" in r.message for r in caplog.records)
 
 
+# ─── L7: Cloud-mode non-loopback bind hard-fail ──────────────────────────────
+
+
+class TestL7CloudModeBindHardFail:
+    """enforce_bind_safety() hard-fails in cloud mode; warns in local mode."""
+
+    def test_cloud_mode_non_loopback_raises(self) -> None:
+        from gateway.dbt_proxy.config import DbtProxyConfig
+
+        config = DbtProxyConfig(sp_dbt_proxy_host="0.0.0.0")
+        with pytest.raises(RuntimeError, match="non-loopback") as exc_info:
+            config.enforce_bind_safety(cloud=True)
+        msg = str(exc_info.value)
+        assert "0.0.0.0" in msg
+        assert "SP_DBT_PROXY_HOST" in msg
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+    def test_cloud_mode_loopback_hosts_ok(self, host: str) -> None:
+        from gateway.dbt_proxy.config import DbtProxyConfig
+
+        config = DbtProxyConfig(sp_dbt_proxy_host=host)
+        config.enforce_bind_safety(cloud=True)  # must not raise
+
+    def test_local_mode_non_loopback_warns_no_raise(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        import logging
+
+        from gateway.dbt_proxy.config import DbtProxyConfig
+
+        config = DbtProxyConfig(sp_dbt_proxy_host="0.0.0.0")
+        with caplog.at_level(logging.WARNING):
+            config.enforce_bind_safety(cloud=False)  # must not raise
+
+        assert any("non-loopback" in r.message for r in caplog.records)
+
+    def test_cloud_mode_default_host_ok(self) -> None:
+        from gateway.dbt_proxy.config import DbtProxyConfig
+
+        config = DbtProxyConfig()  # default 127.0.0.1
+        config.enforce_bind_safety(cloud=True)  # must not raise
+
+
 # ─── V5: Inline param substitution safety ────────────────────────────────────
 
 

--- a/signalpilot/gateway/tests/test_security_fixes.py
+++ b/signalpilot/gateway/tests/test_security_fixes.py
@@ -11,6 +11,8 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
 
 from gateway.dbt_proxy.tokens import RunTokenClaims
 from gateway.engine.dbt_validation import validate_dbt_statement
@@ -662,3 +664,185 @@ class TestAuthErrorSanitization:
             # org_id must NOT appear in the format args of the log line
             log_args = str(info_call)
             assert "SENSITIVE_ORG" not in log_args
+
+
+# ─── L1: Cookie-auth CSRF Origin check ───────────────────────────────────────
+
+
+class TestL1CookieCsrfOriginCheck:
+    """Verify CookieAuthCsrfMiddleware blocks cross-origin cookie-only mutations."""
+
+    @pytest.fixture(scope="class")
+    def client(self) -> TestClient:
+        from gateway.http.middleware.csrf import CookieAuthCsrfMiddleware
+
+        mini = FastAPI()
+        mini.add_middleware(
+            CookieAuthCsrfMiddleware,
+            allowed_origins=["https://app.signalpilot.ai"],
+            enabled=True,
+        )
+
+        @mini.post("/echo")
+        async def echo_post() -> dict[str, str]:
+            return {"ok": "true"}
+
+        @mini.get("/echo")
+        async def echo_get() -> dict[str, str]:
+            return {"ok": "true"}
+
+        @mini.post("/api/webhooks/test")
+        async def webhook_post() -> dict[str, str]:
+            return {"ok": "true"}
+
+        @mini.post("/auth/github/test")
+        async def github_post() -> dict[str, str]:
+            return {"ok": "true"}
+
+        return TestClient(mini, raise_server_exceptions=False)
+
+    @pytest.fixture(scope="class")
+    def disabled_client(self) -> TestClient:
+        from gateway.http.middleware.csrf import CookieAuthCsrfMiddleware
+
+        mini = FastAPI()
+        mini.add_middleware(
+            CookieAuthCsrfMiddleware,
+            allowed_origins=["https://app.signalpilot.ai"],
+            enabled=False,
+        )
+
+        @mini.post("/echo")
+        async def echo_post() -> dict[str, str]:
+            return {"ok": "true"}
+
+        return TestClient(mini, raise_server_exceptions=False)
+
+    def test_cookie_post_no_origin_no_sec_fetch_rejected(self, client: TestClient) -> None:
+        resp = client.post("/echo", cookies={"__session": "abc"})
+        assert resp.status_code == 403
+
+    def test_cookie_post_allowed_origin_ok(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Origin": "https://app.signalpilot.ai"},
+        )
+        assert resp.status_code == 200
+
+    def test_cookie_post_disallowed_origin_rejected(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Origin": "https://evil.example"},
+        )
+        assert resp.status_code == 403
+
+    def test_cookie_post_sec_fetch_same_origin_no_origin_ok(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Sec-Fetch-Site": "same-origin"},
+        )
+        assert resp.status_code == 200
+
+    def test_cookie_post_sec_fetch_cross_site_rejected(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Sec-Fetch-Site": "cross-site"},
+        )
+        assert resp.status_code == 403
+
+    def test_bearer_post_no_origin_ok(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            headers={"Authorization": "Bearer sp_xxx"},
+        )
+        assert resp.status_code == 200
+
+    def test_cookie_plus_bearer_post_no_origin_ok(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Authorization": "Bearer sp_xxx"},
+        )
+        assert resp.status_code == 200
+
+    def test_apikey_header_post_no_origin_ok(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"X-API-Key": "sp_xxx"},
+        )
+        assert resp.status_code == 200
+
+    def test_get_cookie_no_origin_ok(self, client: TestClient) -> None:
+        resp = client.get("/echo", cookies={"__session": "abc"})
+        assert resp.status_code == 200
+
+    def test_options_preflight_ok(self, client: TestClient) -> None:
+        # OPTIONS is a safe method — CSRF check skips it entirely.
+        # Starlette returns 405 for OPTIONS on a POST-only handler in this isolated app
+        # (no CORS middleware); asserting NOT 403 is the meaningful check.
+        resp = client.options("/echo", cookies={"__session": "abc"})
+        assert resp.status_code != 403
+
+    def test_webhook_path_exempt(self, client: TestClient) -> None:
+        resp = client.post("/api/webhooks/test", cookies={"__session": "abc"})
+        assert resp.status_code == 200
+
+    def test_github_callback_path_exempt(self, client: TestClient) -> None:
+        resp = client.post("/auth/github/test", cookies={"__session": "abc"})
+        assert resp.status_code == 200
+
+    def test_referer_fallback_allowed_ok(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Referer": "https://app.signalpilot.ai/dashboard"},
+        )
+        assert resp.status_code == 200
+
+    def test_referer_fallback_disallowed_rejected(self, client: TestClient) -> None:
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Referer": "https://evil.example/x"},
+        )
+        assert resp.status_code == 403
+
+    def test_referer_subdomain_spoofing_rejected(self, client: TestClient) -> None:
+        # Referer: https://app.signalpilot.ai.evil.com/x must NOT match because
+        # urlsplit recomposition produces https://app.signalpilot.ai.evil.com
+        # which is not in the allow-list.
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Referer": "https://app.signalpilot.ai.evil.com/x"},
+        )
+        assert resp.status_code == 403
+
+    def test_referer_schemeless_rejected(self, client: TestClient) -> None:
+        # Referer: //app.signalpilot.ai/x — urlsplit returns empty scheme,
+        # so recomposition produces "" which must never match the allow-list.
+        resp = client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Referer": "//app.signalpilot.ai/x"},
+        )
+        assert resp.status_code == 403
+
+    def test_local_mode_bypass_disallowed_origin_ok(self, disabled_client: TestClient) -> None:
+        # enabled=False → middleware is a pass-through regardless of Origin
+        resp = disabled_client.post(
+            "/echo",
+            cookies={"__session": "abc"},
+            headers={"Origin": "https://evil.example"},
+        )
+        assert resp.status_code == 200
+
+    def test_rejection_response_shape(self, client: TestClient) -> None:
+        resp = client.post("/echo", cookies={"__session": "abc"})
+        assert resp.status_code == 403
+        assert resp.json() == {"detail": "Forbidden."}

--- a/signalpilot/gateway/tests/test_security_hardening.py
+++ b/signalpilot/gateway/tests/test_security_hardening.py
@@ -777,3 +777,178 @@ class TestSseResourceLimits:
 
         metrics_mod.SSE_MAX_DURATION_SECONDS = original_duration
         self._reset_semaphore(20)
+
+
+# ---------------------------------------------------------------------------
+# TestCloudAllowedOriginsHardening
+# ---------------------------------------------------------------------------
+
+
+class TestCloudAllowedOriginsHardening:
+    """Tests for SP_ALLOWED_ORIGINS cloud-mode hard-fail in assert_cloud_hardening_intact."""
+
+    _REQUIRED_ENVS = {
+        "SP_DEPLOYMENT_MODE": "cloud",
+        "CLERK_JWT_AUDIENCE": "test-aud",
+        "SP_NOTEBOOK_RUNTIME_CLASS": "gvisor",
+    }
+
+    def _set_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key, value in self._REQUIRED_ENVS.items():
+            monkeypatch.setenv(key, value)
+        # Remove vars that would trigger other violations
+        monkeypatch.delenv("SP_NOTEBOOK_DIRECT_URL", raising=False)
+        monkeypatch.delenv("SP_DISABLE_SANDBOX", raising=False)
+        monkeypatch.delenv("SP_NOTEBOOK_NETWORK_POLICY", raising=False)
+
+    def test_cloud_missing_sp_allowed_origins_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset SP_ALLOWED_ORIGINS must raise RuntimeError in cloud mode."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.delenv("SP_ALLOWED_ORIGINS", raising=False)
+
+        with pytest.raises(RuntimeError, match="SP_ALLOWED_ORIGINS"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_empty_sp_allowed_origins_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty SP_ALLOWED_ORIGINS must raise RuntimeError in cloud mode."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "")
+
+        with pytest.raises(RuntimeError, match="SP_ALLOWED_ORIGINS"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_bare_wildcard_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SP_ALLOWED_ORIGINS='*' must raise RuntimeError mentioning wildcard."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "*")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_cloud_hardening_intact()
+        msg = str(exc_info.value)
+        assert "SP_ALLOWED_ORIGINS" in msg
+        assert "wildcard" in msg
+
+    def test_cloud_wildcard_among_valid_origins_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """'*' mixed with valid origins still triggers a RuntimeError."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://app.example.com,*")
+
+        with pytest.raises(RuntimeError, match="SP_ALLOWED_ORIGINS"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_subdomain_wildcard_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Subdomain wildcard https://*.example.com must raise (contains '*')."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://*.example.com")
+
+        with pytest.raises(RuntimeError, match="SP_ALLOWED_ORIGINS"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_empty_entry_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty entry in comma-separated list must raise with empty_entry descriptor."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://app.example.com,,https://www.example.com")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_cloud_hardening_intact()
+        assert "empty_entry" in str(exc_info.value)
+
+    def test_cloud_non_https_scheme_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ftp:// origin must raise with non_https descriptor."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "ftp://evil.example.com")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_cloud_hardening_intact()
+        assert "non_https" in str(exc_info.value)
+
+    def test_cloud_http_non_loopback_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """http:// with non-loopback host must raise (only localhost/127.0.0.1 allowed)."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "http://app.example.com")
+
+        with pytest.raises(RuntimeError, match="SP_ALLOWED_ORIGINS"):
+            assert_cloud_hardening_intact()
+
+    def test_cloud_valid_https_origins_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Valid https:// origins must not raise."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://app.example.com,https://www.example.com")
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_cloud_https_plus_localhost_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """https:// origin combined with http://localhost must not raise."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://app.example.com,http://localhost:3000")
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_cloud_127_loopback_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """https:// origin combined with http://127.0.0.1 must not raise."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://app.example.com,http://127.0.0.1:3000")
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_local_mode_wildcard_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """assert_cloud_hardening_intact is a no-op in local mode; wildcard must not raise."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "*")
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_local_mode_unset_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """assert_cloud_hardening_intact is a no-op in local mode; unset must not raise."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        monkeypatch.delenv("SP_ALLOWED_ORIGINS", raising=False)
+
+        assert_cloud_hardening_intact()  # must not raise
+
+    def test_descriptor_includes_var_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RuntimeError message must contain the literal string 'SP_ALLOWED_ORIGINS'."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "http://bad.example.com")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_cloud_hardening_intact()
+        assert "SP_ALLOWED_ORIGINS" in str(exc_info.value)
+
+    def test_no_origin_value_in_exception_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Origin values must NOT appear in the RuntimeError message (names-only invariant)."""
+        from gateway.runtime.mode import assert_cloud_hardening_intact
+
+        self._set_required(monkeypatch)
+        monkeypatch.setenv("SP_ALLOWED_ORIGINS", "https://*.secret-internal.corp,*")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_cloud_hardening_intact()
+        assert "secret-internal" not in str(exc_info.value)

--- a/signalpilot/gateway/tests/test_ssh_tunnel_hardening.py
+++ b/signalpilot/gateway/tests/test_ssh_tunnel_hardening.py
@@ -1,0 +1,149 @@
+"""Tests for SSH tunnel socat ProxyCommand injection hardening.
+
+Covers:
+- _validate_socat_host: accept/reject cases for socat address-spec injection prevention
+- _validate_socat_port: accept/reject cases for port range validation
+- _build_proxy_command: correct output for valid inputs, ValueError for invalid inputs
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.connectors.ssh_tunnel import (
+    _build_proxy_command,
+    _validate_socat_host,
+    _validate_socat_port,
+)
+
+
+class TestValidateSocatHostAccepts:
+    def test_accepts_dns_name(self):
+        assert _validate_socat_host("host", "bastion.example.com") == "bastion.example.com"
+
+    def test_accepts_bare_ipv4(self):
+        assert _validate_socat_host("host", "10.0.0.1") == "10.0.0.1"
+
+    def test_accepts_hyphenated_subdomain(self):
+        assert _validate_socat_host("host", "host-1.sub.example.com") == "host-1.sub.example.com"
+
+    def test_accepts_underscore_host(self):
+        assert _validate_socat_host("host", "my_host") == "my_host"
+
+    def test_strips_leading_trailing_whitespace(self):
+        assert _validate_socat_host("host", "  bastion.corp  ") == "bastion.corp"
+
+    def test_accepts_253_chars(self):
+        val = "a" * 253
+        assert _validate_socat_host("host", val) == val
+
+
+class TestValidateSocatHostRejects:
+    def test_rejects_comma_file_injection(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "x,FILE:/tmp/x")
+
+    def test_rejects_comma_reuseaddr(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "x,reuseaddr")
+
+    def test_rejects_colon(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "host:22")
+
+    def test_rejects_equals(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "host=value")
+
+    def test_rejects_slash(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "host/path")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "host\\extra")
+
+    def test_rejects_space(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "a b")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_socat_host("host", "")
+
+    def test_rejects_whitespace_only(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_socat_host("host", "   ")
+
+    def test_rejects_254_chars(self):
+        with pytest.raises(ValueError, match="disallowed characters"):
+            _validate_socat_host("host", "a" * 254)
+
+    def test_error_message_does_not_echo_value(self):
+        """Error messages must not include attacker-controlled input."""
+        malicious = "x,OPEN:/etc/passwd"
+        with pytest.raises(ValueError) as exc_info:
+            _validate_socat_host("host", malicious)
+        assert malicious not in str(exc_info.value)
+
+
+class TestValidateSocatPortAccepts:
+    def test_accepts_int_22(self):
+        assert _validate_socat_port("port", 22) == 22
+
+    def test_accepts_string_3128(self):
+        assert _validate_socat_port("port", "3128") == 3128
+
+    def test_accepts_min_port(self):
+        assert _validate_socat_port("port", 1) == 1
+
+    def test_accepts_max_port(self):
+        assert _validate_socat_port("port", 65535) == 65535
+
+
+class TestValidateSocatPortRejects:
+    def test_rejects_zero(self):
+        with pytest.raises(ValueError, match="must be in range"):
+            _validate_socat_port("port", 0)
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match="must be in range"):
+            _validate_socat_port("port", -1)
+
+    def test_rejects_above_max(self):
+        with pytest.raises(ValueError, match="must be in range"):
+            _validate_socat_port("port", 65536)
+
+    def test_rejects_non_numeric_string(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _validate_socat_port("port", "abc")
+
+    def test_rejects_none(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _validate_socat_port("port", None)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _validate_socat_port("port", "")
+
+
+class TestBuildProxyCommand:
+    def test_returns_correct_socat_string(self):
+        result = _build_proxy_command("proxy.corp", 3128, "bastion.example.com", 22)
+        assert result == "socat - PROXY:proxy.corp:bastion.example.com:22,proxyport=3128"
+
+    def test_raises_on_injected_proxy_host(self):
+        with pytest.raises(ValueError):
+            _build_proxy_command("x,OPEN:/etc/passwd", 3128, "bastion.example.com", 22)
+
+    def test_raises_on_injected_ssh_host(self):
+        with pytest.raises(ValueError):
+            _build_proxy_command("proxy.corp", 3128, "x,EXEC:cmd", 22)
+
+    def test_raises_on_invalid_ssh_port(self):
+        with pytest.raises(ValueError):
+            _build_proxy_command("proxy.corp", 3128, "bastion.example.com", 0)
+
+    def test_raises_on_invalid_proxy_port(self):
+        with pytest.raises(ValueError):
+            _build_proxy_command("proxy.corp", "x;y", "bastion.example.com", 22)

--- a/signalpilot/gateway/tests/test_user_secrets_preview.py
+++ b/signalpilot/gateway/tests/test_user_secrets_preview.py
@@ -1,0 +1,212 @@
+"""Tests for anthropic_key_preview — verifies trailing chars are never included.
+
+Covers R2 L-3: log capture of response body must not reveal the last-4 chars
+of the stored API key.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+
+
+class TestMaskPreviewHelper:
+    """Unit tests for the _mask_preview module helper."""
+
+    def test_long_key_returns_prefix_and_ellipsis(self) -> None:
+        from gateway.api.user_secrets import _mask_preview
+
+        result = _mask_preview("sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9")
+        assert result == "sk-ant-a..."
+
+    def test_long_key_does_not_contain_suffix(self) -> None:
+        from gateway.api.user_secrets import _mask_preview
+
+        result = _mask_preview("sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9")
+        assert "XYZ9" not in result
+
+    def test_exactly_8_chars_returns_prefix_and_ellipsis(self) -> None:
+        from gateway.api.user_secrets import _mask_preview
+
+        result = _mask_preview("12345678")
+        assert result == "12345678..."
+
+    def test_short_key_below_8_returns_masked(self) -> None:
+        from gateway.api.user_secrets import _mask_preview
+
+        result = _mask_preview("short")
+        assert result == "****"
+
+    def test_empty_key_returns_masked(self) -> None:
+        from gateway.api.user_secrets import _mask_preview
+
+        result = _mask_preview("")
+        assert result == "****"
+
+
+class TestUserSecretsPreviewRoutes:
+    """Integration tests: GET and PUT routes must not expose key suffix in preview."""
+
+    def _make_client(self, monkeypatch, tmp_path, plaintext_secret: str):
+        """Return (client, api_key, commit_mock) with a single pre-stored secret row."""
+        encryption_key = Fernet.generate_key()
+        monkeypatch.setenv("SP_ENCRYPTION_KEY", encryption_key.decode())
+        monkeypatch.delenv("SP_ENCRYPTION_KEY_OLD", raising=False)
+        monkeypatch.setenv("SP_DATA_DIR", str(tmp_path))
+        monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+
+        import gateway.store.crypto as crypto
+        monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+
+        from gateway.store.crypto import _encrypt
+        ciphertext = _encrypt(plaintext_secret)
+
+        row = MagicMock()
+        row.org_id = "local"
+        row.user_id = "local"
+        row.anthropic_api_key_enc = ciphertext
+        row.updated_at = time.time()
+
+        commit_mock = AsyncMock()
+
+        async def _mock_db_session():
+            session = AsyncMock()
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = row
+            session.execute = AsyncMock(return_value=result)
+            session.commit = commit_mock
+            yield session
+
+        from gateway.db.engine import get_db
+        from gateway.main import app
+        from gateway.store import get_local_api_key
+
+        app.dependency_overrides[get_db] = _mock_db_session
+
+        from fastapi.testclient import TestClient
+        api_key = get_local_api_key()
+        client = TestClient(app, headers={"Authorization": f"Bearer {api_key}"})
+        return client, app, commit_mock
+
+    def test_get_preview_does_not_expose_last_four(self, tmp_path, monkeypatch) -> None:
+        secret = "sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9"
+        from gateway.main import app
+
+        client, app, _ = self._make_client(monkeypatch, tmp_path, secret)
+        try:
+            resp = client.get("/api/user/secrets")
+        finally:
+            from gateway.db.engine import get_db
+            app.dependency_overrides.pop(get_db, None)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        preview = body["anthropic_key_preview"]
+        assert preview is not None
+        assert preview.startswith("sk-ant-a")
+        assert preview.endswith("...")
+        assert "XYZ9" not in preview
+
+    def test_put_preview_does_not_expose_last_four(self, tmp_path, monkeypatch) -> None:
+        secret = "sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9"
+        from gateway.main import app
+
+        encryption_key = Fernet.generate_key()
+        monkeypatch.setenv("SP_ENCRYPTION_KEY", encryption_key.decode())
+        monkeypatch.delenv("SP_ENCRYPTION_KEY_OLD", raising=False)
+        monkeypatch.setenv("SP_DATA_DIR", str(tmp_path))
+        monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+
+        import gateway.store.crypto as crypto
+        monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+
+        # For PUT, row starts empty (no existing secret)
+        row = MagicMock()
+        row.org_id = "local"
+        row.user_id = "local"
+        row.anthropic_api_key_enc = None
+        row.updated_at = time.time()
+
+        commit_mock = AsyncMock()
+
+        async def _mock_db_session():
+            session = AsyncMock()
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = row
+            session.execute = AsyncMock(return_value=result)
+            session.commit = commit_mock
+            yield session
+
+        from fastapi.testclient import TestClient
+
+        from gateway.db.engine import get_db
+        from gateway.store import get_local_api_key
+
+        app.dependency_overrides[get_db] = _mock_db_session
+        try:
+            api_key = get_local_api_key()
+            client = TestClient(app, headers={"Authorization": f"Bearer {api_key}"})
+
+            resp = client.put(
+                "/api/user/secrets",
+                json={"anthropic_api_key": secret},
+            )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        preview = body["anthropic_key_preview"]
+        assert preview is not None
+        assert preview.startswith("sk-ant-a")
+        assert preview.endswith("...")
+        assert "XYZ9" not in preview
+
+    def test_put_short_key_returns_masked(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("SP_ENCRYPTION_KEY", Fernet.generate_key().decode())
+        monkeypatch.delenv("SP_ENCRYPTION_KEY_OLD", raising=False)
+        monkeypatch.setenv("SP_DATA_DIR", str(tmp_path))
+        monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+
+        import gateway.store.crypto as crypto
+        monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+
+        from gateway.store.crypto import _encrypt
+
+        row = MagicMock()
+        row.org_id = "local"
+        row.user_id = "local"
+        row.anthropic_api_key_enc = None
+        row.updated_at = time.time()
+
+        async def _mock_db_session():
+            session = AsyncMock()
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = row
+            session.execute = AsyncMock(return_value=result)
+            session.commit = AsyncMock()
+            yield session
+
+        from fastapi.testclient import TestClient
+
+        from gateway.db.engine import get_db
+        from gateway.main import app
+        from gateway.store import get_local_api_key
+
+        app.dependency_overrides[get_db] = _mock_db_session
+        try:
+            api_key = get_local_api_key()
+            client = TestClient(app, headers={"Authorization": f"Bearer {api_key}"})
+            resp = client.put(
+                "/api/user/secrets",
+                json={"anthropic_api_key": "short"},
+            )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        preview = body["anthropic_key_preview"]
+        assert preview == "****"


### PR DESCRIPTION
Series of security fixes from a full audit of notebook + cloud-mode gateway features.

- **L-6 XFF unification (R14)** Audit-metadata client-IP derivation in `byok.py`, `keys.py`, `query.py`, `connections/crud.py`, `connections/porting.py` was leftmost-XFF (spoofable). Unified through `gateway/common/ip.py::client_ip` (rightmost XFF → `request.client.host` → `None`), matching `RateLimitMiddleware._client_ip` parity. Middleware delegates to the helper. `x-real-ip` ignored to preserve parity with rate-limit bucketing. 22 unit/parity tests + audit regression (`evil-spoof, 2.2.2.2` → `2.2.2.2`).
- **M-1 (R3)** SSH tunnel SSRF + socat argv injection hardened.
- **M-2/M-3 (R4)** dbt_proxy run-tokens scoped to org; mint path requires admin.
- **M-4 (R5)** GitHub OAuth `state` now HMAC-signed with lazy key + lifespan fail-fast; nonce store with TTL; verify-then-reserve; single generic 400.
- **M-5 (R6)** Audit CSV export neutralizes formula-injection triggers (`= + - @ \t \r`) via `_csv_safe` on every data cell.
- **L-7 (R7)** dbt_proxy hard-fails at startup in cloud mode if `SP_DBT_PROXY_HOST` is non-loopback (pg-wire handshake is cleartext; TLS is R8). Local mode keeps the warning.
- **L-1 cookie-CSRF (R8)** Cross-cutting `CookieAuthCsrfMiddleware` for cookie-auth mutations: rejects non-safe-method requests authed only by `__session` unless Origin / Sec-Fetch-Site / Referer indicate same-site. Bearer + X-API-Key clients pass through; cloud-only via parameter injection; exempt paths mirror existing cookie-less auth surfaces.
- **L-1 Clerk audience / I-5 NetworkPolicy / L-6 org_id filter (R9)** Cloud-mode lifespan now hard-fails when `CLERK_JWT_AUDIENCE` is unset or `SP_NOTEBOOK_NETWORK_POLICY=false` is set without explicit `SP_NOTEBOOK_NETWORK_POLICY_CLOUD_ACK` opt-in. `notebook_sessions.update_session_status` / `mark_stopped` now require `org_id` and enforce it in the WHERE clause (defense-in-depth against future regressions).
- **L-3 scoped pod JWT (R10)** `run_notebook` MCP tool no longer pipes the caller's raw API key into the notebook pod stdin. In cloud mode, mints a session JWT via `mint_session_jwt` locked to `NOTEBOOK_SESSION_SCOPES` (`read/write/query/execute`), matching the in-pod kernel pattern. Local mode keeps the credential-less branch. `_build_export_invocation` extracted as pure helper (parameter-injected `cloud: bool`) with 5 new tests.
- **L-4 security_status org-scoping (R12)** `/api/security/status` previously returned a platform-wide `total_credentials_pending_rotation` to anyone in the admin set. `Store.get_credentials_needing_rotation` now self-scopes via `_require_org_id()` (default `org_scoped=True`); the response key name is preserved for API stability, but the value is now org-scoped. Misconfigured `SP_ADMIN_USER_IDS` containing a customer user_id can no longer reveal cross-org credential counts. New `test_security_status_pending_rotation_is_org_scoped` covers org-A/org-B separation.
- **L-3 user-secret preview (R13)** `/api/user/secrets` preview previously included the last 4 chars of the raw Anthropic key (`f"{key[:8]}...{key[-4:]}"`). Any log capture of the response body persisted ~16 bits of high-entropy identifier. Now prefix-only via `_mask_preview` (`key[:8] + "..."`, `"****"` fallback). Tests assert the last 4 chars of the raw key are absent from the preview on both PUT and GET paths.
- **L-5 SP_ALLOWED_ORIGINS hardening (R11)** Cloud-mode lifespan now hard-fails when `SP_ALLOWED_ORIGINS` is unset, empty, contains a bare or substring `*`, contains a non-https scheme (except `http://localhost` / `http://127.0.0.1`), or has empty entries. Wildcard CORS with credentials is forbidden by browsers, so no ack opt-out is offered. Pure `_validate_cloud_allowed_origins` helper returns name-only violation descriptors (no env values leak into the exception). Local mode keeps the warn-only behavior in `gateway/main.py`.

Each round adds tests. No behavior changes to JSON exports or non-cloud paths.
- **F-1 dbt-cloud discover SSRF (R16)** `/api/dbt-cloud/projects` admin endpoint now routes the request `host` through `validate_connection_host()` in cloud mode before issuing the outbound httpx GET, blocking loopback/link-local/IMDS/CGNAT/RFC1918 targets. Local mode unchanged to preserve private dbt Cloud installations. Mirrors the SSH-tunnel pattern from `api/connections/_validation.py`.
- **I-2 Clerk azp allowlist (R18)** Optional `SP_EXPECTED_AZP` env (comma-separated frozenset) enforced in `_resolve_via_clerk` between `jwt.decode` and the `sub` check. When unset (default), behavior is unchanged. When set, tokens with missing or non-allowlisted `azp` are rejected with the same generic 401. Defense-in-depth against tokens minted for a different frontend origin; opt-in hardening, not a cloud requirement. 3 new tests in `TestClerkAzpAllowlist`.
- **F-2 dbt-cloud rate-limit bucket (R20)** `/api/dbt-cloud/projects` (admin-only outbound httpx GET) added to `RateLimitMiddleware.EXPENSIVE_PATHS`. Now subject to the 30-rpm expensive-tier bucket in addition to the 120-rpm general bucket. Hygiene companion to R16's F-1 SSRF guard; bounds outbound dbt Cloud fan-out per source IP.
- **L-9 Notion total-block cap (R19)** `_fetch_blocks_recursive` in `gateway/notion/client.py` previously bounded only `MAX_DEPTH=4` + 8000-char output cap; an adversary with their own valid Notion token could deeply branch a page to burn quota / pod CPU. New `MAX_TOTAL_BLOCKS = 2000` shared counter (`list[int]`) threaded through the recursion stops further fetching once reached, mirroring the existing soft-truncation pattern (no raise). Self-DoS hardening; 2 new tests in `tests/test_notion_block_cap.py`.

---
**Branch:** `autofyn/run-a-complete-s-1c497f` · **Run:** `62937e1f-5fef-490f-9cc2-10d218a218e0` · *Generated by AutoFyn*