### PR TITLE
docs: update Spider 2.0-DBT score to 65.63% (current run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ⚡ SignalPilot Data Agent
 
-### 🏆 #1 on [Spider 2.0-DBT](https://spider2-sql.github.io/) — **51.56**, +7.45 over JetBrains DataBao (Apr 2026)
+### 🏆 #1 on [Spider 2.0-DBT](https://spider2-sql.github.io/) — **65.63%** (42 of 64 tasks, claude-sonnet-4-6)
 
 **Governed AI agents for your data stack — db, dbt, and more.** Optimized by [AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn).
 
@@ -255,7 +255,7 @@ SignalPilot/
 │   ├── agents/               # Verifier agent (7-check post-build protocol)
 │   └── skills/               # dbt-workflow, sql-workflow, db-specific SQL, etc.
 ├── sp-sandbox/               # gVisor sandboxed Python execution
-├── benchmark/                # Spider 2.0-DBT benchmark suite (SOTA: 51.56%)
+├── benchmark/                # Spider 2.0-DBT benchmark suite (SOTA: 65.63%)
 └── docker-compose.yml        # Full stack: web, gateway, postgres, sandbox
 ```
 


### PR DESCRIPTION
## What

Updates the benchmark number in the README from the retired **51.56** figure to the current canonical result: **65.63%** (42 of 64 tasks, `claude-sonnet-4-6`, run `dbt-run9`) — matching the live [/benchmark page](https://www.signalpilot.ai/benchmark).

Two lines changed:
- Headline badge (line 5)
- Benchmark-suite tree comment (`SOTA: …`)

## Why

The README, project docs, and memory all still cited 51.56 (+7.45 over JetBrains DataBao) from an earlier run while the site moved to 65.63%. Picking one canonical number.

## Note for reviewer

I **dropped the '+7.45 over JetBrains DataBao' delta** rather than recompute it. That delta was tied to 51.56 vs DataBao's 44.11; at 65.63% it's no longer +7.45, and the current gap should be reverified against the [live leaderboard](https://spider2-sql.github.io/) before re-quoting. Add it back once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)