### PR TITLE
docs: embed Notion setup walkthrough

### DIFF
--- a/docs/docs/connect-notion.mdx
+++ b/docs/docs/connect-notion.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6 
+sidebar_position: 6
 ---
 
 # Connect Notion
@@ -61,3 +61,15 @@ Paste your Anthropic API key in the SignalPilot agent panel. The Notion trigger 
 **Integration page is blocked**
 
 In SignalPilot Cloud, Notion integrations are a paid subscription feature. Upgrade the workspace plan, then return to **Integrations**.
+
+## Video walkthrough
+
+<iframe
+  src="https://www.loom.com/embed/e6af775f10f1431fb7eba4c760eafa48"
+  title="Connect Notion to SignalPilot"
+  frameBorder="0"
+  allowFullScreen
+  style={{ width: '100%', aspectRatio: '16 / 9', border: 0 }}
+/>
+
+If the embedded video does not load, open the [Notion setup walkthrough](https://www.loom.com/share/e6af775f10f1431fb7eba4c760eafa48) on Loom.

--- a/docs/docs/connect-notion.mdx
+++ b/docs/docs/connect-notion.mdx
@@ -72,4 +72,4 @@ In SignalPilot Cloud, Notion integrations are a paid subscription feature. Upgra
   style={{ width: '100%', aspectRatio: '16 / 9', border: 0 }}
 />
 
-If the embedded video does not load, open the [Notion setup walkthrough](https://www.loom.com/share/e6af775f10f1431fb7eba4c760eafa48) on Loom.
+Open the [Notion setup walkthrough](https://www.loom.com/share/e6af775f10f1431fb7eba4c760eafa48) on Loom.


### PR DESCRIPTION
## Summary
- embed the Loom Notion setup walkthrough at the end of the Notion integration docs
- keep a direct Loom link as fallback

## Verification
- npm run build
- npm run typecheck