### PR TITLE
Fix Notion webhook routing for multiple installs

### DIFF
--- a/signalpilot/gateway/gateway/api/notion.py
+++ b/signalpilot/gateway/gateway/api/notion.py
@@ -41,6 +41,43 @@ logger = logging.getLogger(__name__)
 _notion_event_tasks: set[asyncio.Task[None]] = set()
 
 
+def _notion_webhook_fields(payload: dict | None) -> dict[str, object | None]:
+    payload = payload or {}
+    return {
+        "event_type": payload.get("type"),
+        "attempt_number": payload.get("attempt_number"),
+        "workspace_id": payload.get("workspace_id"),
+        "page_id": (payload.get("data") or {}).get("page_id"),
+    }
+
+
+def _log_notion_webhook_decision(
+    status: str,
+    *,
+    event_id: str | None,
+    payload: dict | None,
+    reason: str,
+    installation_id: str | None = None,
+    org_id: str | None = None,
+    level: int = logging.INFO,
+) -> None:
+    fields = _notion_webhook_fields(payload)
+    logger.log(
+        level,
+        "Notion webhook %s: event_id=%s type=%s attempt=%s workspace_id=%s page_id=%s "
+        "installation_id=%s org_id=%s reason=%s",
+        status,
+        event_id,
+        fields["event_type"],
+        fields["attempt_number"],
+        fields["workspace_id"],
+        fields["page_id"],
+        installation_id,
+        org_id,
+        reason,
+    )
+
+
 def _notion_oauth_client_id() -> str:
     value = os.getenv("NOTION_OAUTH_CLIENT_ID")
     if not value:
@@ -171,8 +208,23 @@ async def _run_notion_operation_with_refresh(store: Store, installation_id: str,
 async def _process_notion_event_task(event_id: str, installation_id: str, payload: dict) -> None:
     factory = get_session_factory()
     async with factory() as session:
+        _log_notion_webhook_decision(
+            "processing",
+            event_id=event_id,
+            payload=payload,
+            installation_id=installation_id,
+            reason="background_task_started",
+        )
         record = await notion_store.get_installation_record(session, installation_id)
         if record is None:
+            _log_notion_webhook_decision(
+                "failed",
+                event_id=event_id,
+                payload=payload,
+                installation_id=installation_id,
+                reason="installation_missing_before_processing",
+                level=logging.WARNING,
+            )
             await notion_store.record_webhook_delivery(
                 session,
                 event_id,
@@ -184,6 +236,15 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
             return
         installation, config, token = record
         if config is None:
+            _log_notion_webhook_decision(
+                "failed",
+                event_id=event_id,
+                payload=payload,
+                installation_id=installation_id,
+                org_id=installation.org_id,
+                reason="installation_not_provisioned",
+                level=logging.WARNING,
+            )
             await notion_store.record_webhook_delivery(
                 session,
                 event_id,
@@ -197,7 +258,35 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
         routed = notion_webhooks.RoutedNotionInstallation(installation=installation, config=config, access_token=token)
         try:
             result = await notion_analysis.process_routed_comment_event(routed, payload, db=session)
+        except httpx.HTTPStatusError as exc:
+            error = notion_client.http_error_summary(exc)
+            logger.warning(
+                "Notion webhook processing failed: event_id=%s installation_id=%s org_id=%s error=%s",
+                event_id,
+                installation_id,
+                installation.org_id,
+                error,
+                exc_info=True,
+            )
+            await notion_store.record_webhook_delivery(
+                session,
+                event_id,
+                status="failed",
+                installation_id=installation_id,
+                org_id=installation.org_id,
+                error=error[:1000],
+                processed=True,
+            )
+            return
         except Exception as exc:
+            logger.warning(
+                "Notion webhook processing failed: event_id=%s installation_id=%s org_id=%s error=%s",
+                event_id,
+                installation_id,
+                installation.org_id,
+                str(exc)[:500],
+                exc_info=True,
+            )
             await notion_store.record_webhook_delivery(
                 session,
                 event_id,
@@ -209,6 +298,14 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
             )
             return
         if result.status == "ignored":
+            _log_notion_webhook_decision(
+                "ignored",
+                event_id=event_id,
+                payload=payload,
+                installation_id=installation_id,
+                org_id=installation.org_id,
+                reason=result.reason or "processor_ignored",
+            )
             await notion_store.record_webhook_delivery(
                 session,
                 event_id,
@@ -219,6 +316,14 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
                 processed=True,
             )
             return
+        _log_notion_webhook_decision(
+            "processed",
+            event_id=event_id,
+            payload=payload,
+            installation_id=installation_id,
+            org_id=installation.org_id,
+            reason="processor_completed",
+        )
         await notion_store.record_webhook_delivery(
             session,
             event_id,
@@ -338,14 +443,40 @@ async def provision_notion_oauth_installation(
     user's private Notion section. A parent_page_id can still be supplied for
     the older advanced setup path.
     """
+    existing = await store.get_notion_oauth_installation(installation_id)
+    existing_config = existing.config if existing else None
+    existing_is_provisioned = bool(
+        existing_config
+        and existing_config.trigger_page_id
+        and existing_config.requests_data_source_id
+        and existing_config.requests_database_page_id
+    )
 
     async def _operation(token: str):
-        return await notion_client.provision_signalpilot_resources(token, body.parent_page_id)
+        if existing_is_provisioned and existing_config is not None:
+            provisioned = {
+                "parent_page_id": existing_config.parent_page_id,
+                "trigger_page_id": existing_config.trigger_page_id,
+                "requests_data_source_id": existing_config.requests_data_source_id,
+                "requests_database_page_id": existing_config.requests_database_page_id,
+            }
+        else:
+            provisioned = await notion_client.provision_signalpilot_resources(token, body.parent_page_id)
+        await notion_client.list_comments(token, str(provisioned["trigger_page_id"]))
+        return provisioned
 
     try:
         provisioned = await _run_notion_operation_with_refresh(store, installation_id, _operation)
     except httpx.HTTPStatusError as exc:
-        raise HTTPException(status_code=exc.response.status_code, detail=exc.response.text[:500]) from exc
+        if notion_client.is_comment_read_capability_error(exc):
+            raise HTTPException(
+                status_code=424,
+                detail=(
+                    "Notion connection is missing Read comments capability. Enable comment capabilities "
+                    "for the public integration in the Notion developer portal, then reconnect Notion."
+                ),
+            ) from exc
+        raise HTTPException(status_code=exc.response.status_code, detail=notion_client.http_error_summary(exc)) from exc
 
     installation = await store.save_notion_oauth_installation_config(
         installation_id,
@@ -468,14 +599,35 @@ async def receive_notion_webhook(
 
     event_id = payload.get("id")
     if not event_id:
+        _log_notion_webhook_decision(
+            "ignored",
+            event_id=None,
+            payload=payload,
+            reason="missing_event_id",
+            level=logging.WARNING,
+        )
         return NotionWebhookResponse(status="ignored")
 
     existing = await notion_store.get_webhook_delivery(db, str(event_id))
     if existing and existing.status in {"queued", "processing", "processed", "ignored"}:
+        _log_notion_webhook_decision(
+            "duplicate",
+            event_id=str(event_id),
+            payload=payload,
+            reason=f"existing_status_{existing.status}",
+            installation_id=existing.installation_id,
+            org_id=existing.org_id,
+        )
         return NotionWebhookResponse(status="duplicate", event_id=str(event_id))
 
     attempt_number = payload.get("attempt_number")
     if payload.get("type") != "comment.created":
+        _log_notion_webhook_decision(
+            "ignored",
+            event_id=str(event_id),
+            payload=payload,
+            reason="unsupported_event_type",
+        )
         await notion_store.record_webhook_delivery(
             db,
             str(event_id),
@@ -486,6 +638,12 @@ async def receive_notion_webhook(
         return NotionWebhookResponse(status="ignored", event_id=str(event_id))
 
     if notion_webhooks.is_bot_authored(payload):
+        _log_notion_webhook_decision(
+            "ignored",
+            event_id=str(event_id),
+            payload=payload,
+            reason="bot_authored",
+        )
         await notion_store.record_webhook_delivery(
             db,
             str(event_id),
@@ -498,6 +656,13 @@ async def receive_notion_webhook(
     try:
         routed = await notion_webhooks.route_comment_event(db, payload)
     except notion_webhooks.AmbiguousNotionInstallation as exc:
+        _log_notion_webhook_decision(
+            "ambiguous",
+            event_id=str(event_id),
+            payload=payload,
+            reason=str(exc),
+            level=logging.WARNING,
+        )
         await notion_store.record_webhook_delivery(
             db,
             str(event_id),
@@ -509,6 +674,12 @@ async def receive_notion_webhook(
         return NotionWebhookResponse(status="ambiguous", event_id=str(event_id))
 
     if routed is None:
+        _log_notion_webhook_decision(
+            "ignored",
+            event_id=str(event_id),
+            payload=payload,
+            reason="no_matching_active_provisioned_installation",
+        )
         await notion_store.record_webhook_delivery(
             db,
             str(event_id),
@@ -525,6 +696,14 @@ async def receive_notion_webhook(
         attempt_number=attempt_number,
         installation_id=routed.installation.id,
         org_id=routed.installation.org_id,
+    )
+    _log_notion_webhook_decision(
+        "queued",
+        event_id=str(event_id),
+        payload=payload,
+        installation_id=routed.installation.id,
+        org_id=routed.installation.org_id,
+        reason="matched_installation",
     )
     _schedule_notion_event_processing(str(event_id), routed.installation.id, payload)
     return NotionWebhookResponse(status="queued", event_id=str(event_id))

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -201,6 +201,48 @@ def _start_comment_rich_text(request_page_url: str) -> list[dict[str, Any]]:
     ]
 
 
+async def _create_start_comment(
+    token: str,
+    *,
+    discussion_id: str,
+    request_page_url: str,
+    event_id: str | None,
+    comment_id: str | None,
+    request_page_id: str,
+) -> None:
+    logger.info(
+        "Posting Notion start comment: event_id=%s comment_id=%s discussion_id=%s request_page_id=%s",
+        event_id,
+        comment_id,
+        discussion_id,
+        request_page_id,
+    )
+    try:
+        await notion_client.create_comment(
+            token,
+            discussion_id=discussion_id,
+            rich_text=_start_comment_rich_text(request_page_url),
+        )
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "Could not post Notion start comment: event_id=%s comment_id=%s discussion_id=%s request_page_id=%s error=%s",
+            event_id,
+            comment_id,
+            discussion_id,
+            request_page_id,
+            notion_client.http_error_summary(exc),
+            exc_info=True,
+        )
+        raise
+    logger.info(
+        "Posted Notion start comment: event_id=%s comment_id=%s discussion_id=%s request_page_id=%s",
+        event_id,
+        comment_id,
+        discussion_id,
+        request_page_id,
+    )
+
+
 def _final_comment_rich_text(status: dict[str, Any], request_page_url: str) -> list[dict[str, Any]]:
     raw_answer = (
         (status.get("notionComment") or "").strip()
@@ -251,12 +293,7 @@ def _public_web_base_url(runtime: NotebookRuntime) -> str:
 
 def _is_notebooks_path(path: str) -> bool:
     normalized = f"/{path.lstrip('/')}".rstrip("/") or "/"
-    return (
-        normalized == "/notebooks"
-        or normalized.startswith("/notebooks/")
-        or normalized == "/projects"
-        or normalized.startswith("/projects/")
-    )
+    return normalized in {"/notebooks", "/projects"} or normalized.startswith(("/notebooks/", "/projects/"))
 
 
 def _path_query_fragment(parsed: Any) -> str:
@@ -629,7 +666,14 @@ async def process_routed_comment_event(
     request_page_url = request_page.get("url") or _request_page_url(request_page_id)
 
     await notion_client.update_page_properties(token, request_page_id, {"Status": {"rich_text": _rich_text("Analyzing")}})
-    await notion_client.create_comment(token, discussion_id=discussion_id, rich_text=_start_comment_rich_text(request_page_url))
+    await _create_start_comment(
+        token,
+        discussion_id=discussion_id,
+        request_page_url=request_page_url,
+        event_id=payload.get("id"),
+        comment_id=comment_id,
+        request_page_id=request_page_id,
+    )
     try:
         runtime = await ensure_notion_notebook_session(
             db,

--- a/signalpilot/gateway/gateway/notion/client.py
+++ b/signalpilot/gateway/gateway/notion/client.py
@@ -29,6 +29,31 @@ def _headers(api_key: str) -> dict[str, str]:
     }
 
 
+def http_error_summary(exc: httpx.HTTPStatusError) -> str:
+    """Return a sanitized Notion API error summary safe for logs/UI."""
+    response = exc.response
+    request = response.request
+    try:
+        body = response.json()
+    except ValueError:
+        body = {}
+    if isinstance(body, dict):
+        message = str(body.get("message") or body.get("code") or response.text[:500])
+    else:
+        message = response.text[:500]
+    path = request.url.path
+    return f"Notion API {response.status_code} {request.method} {path}: {message[:500]}"
+
+
+def is_comment_read_capability_error(exc: httpx.HTTPStatusError) -> bool:
+    request = exc.response.request
+    return (
+        exc.response.status_code == 403
+        and request.method.upper() == "GET"
+        and request.url.path.rstrip("/") == "/v1/comments"
+    )
+
+
 def _multipart_headers(api_key: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {api_key}",

--- a/signalpilot/gateway/gateway/notion/webhooks.py
+++ b/signalpilot/gateway/gateway/notion/webhooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,6 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from gateway.db.models import NotionInstallation, NotionInstallationConfig
 from gateway.notion import client as notion_client
 from gateway.store import notion as notion_store
+
+logger = logging.getLogger(__name__)
 
 
 class NotionWebhookError(Exception):
@@ -67,14 +70,42 @@ async def route_comment_event(
     workspace_id = payload.get("workspace_id")
     page_id = (payload.get("data") or {}).get("page_id")
     if not workspace_id or not page_id:
+        logger.info(
+            "Notion webhook route skipped: workspace_id=%s page_id=%s reason=missing_workspace_or_page",
+            workspace_id,
+            page_id,
+        )
         return None
 
     candidates = await notion_store.list_active_installation_records_for_workspace(session, str(workspace_id))
+    if not candidates:
+        logger.info(
+            "Notion webhook route skipped: workspace_id=%s page_id=%s reason=no_active_installations",
+            workspace_id,
+            page_id,
+        )
     matched: list[RoutedNotionInstallation] = []
     for installation, config, access_token in candidates:
         if config is None or not config.enabled:
+            logger.info(
+                "Notion webhook route skipped candidate: workspace_id=%s page_id=%s installation_id=%s "
+                "org_id=%s reason=%s",
+                workspace_id,
+                page_id,
+                installation.id,
+                installation.org_id,
+                "installation_not_provisioned" if config is None else "installation_disabled",
+            )
             continue
         if not _ownership_matches(installation, payload):
+            logger.info(
+                "Notion webhook route skipped candidate: workspace_id=%s page_id=%s installation_id=%s "
+                "org_id=%s reason=ownership_mismatch",
+                workspace_id,
+                page_id,
+                installation.id,
+                installation.org_id,
+            )
             continue
         belongs = await notion_client.page_belongs_to_scope(
             access_token,
@@ -86,7 +117,45 @@ async def route_comment_event(
         )
         if belongs:
             matched.append(RoutedNotionInstallation(installation, config, access_token))
+        else:
+            logger.info(
+                "Notion webhook route skipped candidate: workspace_id=%s page_id=%s installation_id=%s "
+                "org_id=%s reason=page_outside_scope",
+                workspace_id,
+                page_id,
+                installation.id,
+                installation.org_id,
+            )
 
     if len(matched) > 1:
+        matched_by_mention = await _filter_by_trigger_page_mention(matched, payload)
+        if len(matched_by_mention) == 1:
+            return matched_by_mention[0]
+        if len(matched_by_mention) > 1:
+            raise AmbiguousNotionInstallation(
+                f"Notion event mentioned trigger pages for {len(matched_by_mention)} active installations"
+            )
         raise AmbiguousNotionInstallation(f"Notion event matched {len(matched)} active installations")
     return matched[0] if matched else None
+
+
+async def _filter_by_trigger_page_mention(
+    candidates: list[RoutedNotionInstallation],
+    payload: dict,
+) -> list[RoutedNotionInstallation]:
+    comment_id = (payload.get("entity") or {}).get("id")
+    page_id = (payload.get("data") or {}).get("page_id")
+    parent_block_id = ((payload.get("data") or {}).get("parent") or {}).get("id")
+    if not comment_id or not page_id:
+        return []
+
+    result: list[RoutedNotionInstallation] = []
+    for candidate in candidates:
+        block_id = parent_block_id or page_id
+        comments = await notion_client.list_comments(candidate.access_token, str(block_id))
+        comment = next((item for item in comments if item.get("id") == comment_id), None)
+        if comment is None:
+            comment = await notion_client.retrieve_comment(candidate.access_token, str(comment_id))
+        if notion_client.comment_has_page_mention(comment, candidate.config.trigger_page_id or ""):
+            result.append(candidate)
+    return result

--- a/signalpilot/gateway/tests/test_notion_oauth.py
+++ b/signalpilot/gateway/tests/test_notion_oauth.py
@@ -4,13 +4,18 @@ import asyncio
 import hashlib
 import hmac
 import json
+import logging
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
+from fastapi import HTTPException
 from starlette.requests import Request
 
 from gateway.api import notion as notion_api
 from gateway.db.models import NotionInstallation, NotionInstallationConfig
+from gateway.models.notion import NotionProvisionRequest
 from gateway.notion import client as notion_client
 from gateway.notion import webhooks as notion_webhooks
 from gateway.store import notion as notion_store
@@ -31,6 +36,16 @@ def _json_request(payload: dict) -> Request:
         },
         receive,
     )
+
+
+def _notion_http_error(status_code: int, method: str = "GET", path: str = "/v1/comments") -> httpx.HTTPStatusError:
+    request = httpx.Request(method, f"https://api.notion.com{path}")
+    response = httpx.Response(
+        status_code,
+        json={"message": "missing comment capability"},
+        request=request,
+    )
+    return httpx.HTTPStatusError("Notion API error", request=request, response=response)
 
 
 def test_authorize_url_includes_state_and_required_oauth_fields() -> None:
@@ -119,6 +134,115 @@ async def test_webhook_verification_token_is_logged(
 
     assert response.status == "verification_received"
     assert "NOTION WEBHOOK VERIFICATION TOKEN RECEIVED: verify-secret" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_webhook_logs_when_comment_event_has_no_route(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def no_existing_delivery(*_args, **_kwargs):
+        return None
+
+    async def no_route(*_args, **_kwargs):
+        return None
+
+    async def record_delivery(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(notion_store, "get_webhook_delivery", no_existing_delivery)
+    monkeypatch.setattr(notion_store, "record_webhook_delivery", record_delivery)
+    monkeypatch.setattr(notion_webhooks, "route_comment_event", no_route)
+
+    payload = {
+        "id": "evt-unrouted",
+        "type": "comment.created",
+        "attempt_number": 1,
+        "workspace_id": "workspace-1",
+        "data": {"page_id": "page-1"},
+        "authors": [{"id": "person-1", "type": "person"}],
+    }
+
+    with caplog.at_level(logging.INFO, logger="gateway.api.notion"):
+        response = await notion_api.receive_notion_webhook(_json_request(payload), db=object())
+
+    assert response.status == "ignored"
+    assert response.event_id == "evt-unrouted"
+    assert "no_matching_active_provisioned_installation" in caplog.text
+    assert "workspace-1" in caplog.text
+    assert "page-1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_route_comment_event_logs_unprovisioned_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    install = NotionInstallation(
+        id="install-1",
+        org_id="org-1",
+        user_id="user-1",
+        workspace_id="workspace-1",
+        workspace_name="Workspace",
+        bot_id="bot-1",
+        access_token_enc=b"encrypted",
+        status="connected",
+    )
+
+    async def records(*_args, **_kwargs):
+        return [(install, None, "token-1")]
+
+    monkeypatch.setattr(notion_store, "list_active_installation_records_for_workspace", records)
+
+    payload = {
+        "id": "evt-unprovisioned",
+        "type": "comment.created",
+        "workspace_id": "workspace-1",
+        "integration_id": "bot-1",
+        "data": {"page_id": "page-1"},
+    }
+
+    with caplog.at_level(logging.INFO, logger="gateway.notion.webhooks"):
+        routed = await notion_webhooks.route_comment_event(object(), payload)
+
+    assert routed is None
+    assert "installation_not_provisioned" in caplog.text
+    assert "install-1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_provisioning_reports_missing_comment_read_capability(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Store:
+        async def get_notion_oauth_installation(self, installation_id: str):
+            assert installation_id == "install-1"
+            return SimpleNamespace(
+                config=SimpleNamespace(
+                    parent_page_id=None,
+                    trigger_page_id="trigger-1",
+                    requests_data_source_id="ds-1",
+                    requests_database_page_id="db-1",
+                )
+            )
+
+        async def get_notion_oauth_installation_token(self, installation_id: str):
+            assert installation_id == "install-1"
+            return "token-1"
+
+    async def list_comments(*_args, **_kwargs):
+        raise _notion_http_error(403)
+
+    monkeypatch.setattr(notion_client, "list_comments", list_comments)
+
+    with pytest.raises(HTTPException) as exc:
+        await notion_api.provision_notion_oauth_installation(
+            "install-1",
+            NotionProvisionRequest(),
+            Store(),
+            object(),
+        )
+
+    assert exc.value.status_code == 424
+    assert "Read comments capability" in exc.value.detail
 
 
 def test_comment_page_mention_matches_trigger_page_id() -> None:
@@ -327,17 +451,102 @@ async def test_webhook_routing_rejects_ambiguous_installations(monkeypatch: pyte
     async def fake_belongs(*args, **kwargs):
         return True
 
+    async def fake_list_comments(*args, **kwargs):
+        return [
+            {
+                "id": "comment-1",
+                "rich_text": [
+                    {"type": "mention", "mention": {"type": "page", "page": {"id": "trigger-1"}}},
+                    {"type": "mention", "mention": {"type": "page", "page": {"id": "trigger-2"}}},
+                ],
+            }
+        ]
+
     monkeypatch.setattr(notion_store, "list_active_installation_records_for_workspace", fake_records)
     monkeypatch.setattr(notion_client, "page_belongs_to_scope", fake_belongs)
+    monkeypatch.setattr(notion_client, "list_comments", fake_list_comments)
 
     payload = {
         "workspace_id": "workspace-1",
         "integration_id": "bot-1",
         "type": "comment.created",
-        "data": {"page_id": "page-1"},
+        "entity": {"id": "comment-1", "type": "comment"},
+        "data": {"page_id": "page-1", "parent": {"id": "page-1", "type": "page"}},
     }
     with pytest.raises(notion_webhooks.AmbiguousNotionInstallation):
         await notion_webhooks.route_comment_event(object(), payload)
+
+
+@pytest.mark.asyncio
+async def test_webhook_routing_uses_trigger_page_mention_to_disambiguate(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_1 = NotionInstallation(
+        id="install-1",
+        org_id="org-1",
+        user_id="user-1",
+        workspace_id="workspace-1",
+        workspace_name="Workspace",
+        bot_id="bot-1",
+        access_token_enc=b"encrypted",
+        status="active",
+    )
+    install_2 = NotionInstallation(
+        id="install-2",
+        org_id="org-2",
+        user_id="user-2",
+        workspace_id="workspace-1",
+        workspace_name="Workspace",
+        bot_id="bot-1",
+        access_token_enc=b"encrypted",
+        status="active",
+    )
+    config_1 = NotionInstallationConfig(
+        installation_id="install-1",
+        parent_page_id=None,
+        trigger_page_id="trigger-1",
+        requests_data_source_id="ds-1",
+        requests_database_page_id="db-1",
+        enabled=True,
+    )
+    config_2 = NotionInstallationConfig(
+        installation_id="install-2",
+        parent_page_id=None,
+        trigger_page_id="trigger-2",
+        requests_data_source_id="ds-2",
+        requests_database_page_id="db-2",
+        enabled=True,
+    )
+
+    async def fake_records(session, workspace_id: str):
+        assert workspace_id == "workspace-1"
+        return [(install_1, config_1, "token-1"), (install_2, config_2, "token-2")]
+
+    async def fake_belongs(*args, **kwargs):
+        return True
+
+    async def fake_list_comments(*args, **kwargs):
+        return [
+            {
+                "id": "comment-1",
+                "rich_text": [{"type": "mention", "mention": {"type": "page", "page": {"id": "trigger-2"}}}],
+            }
+        ]
+
+    monkeypatch.setattr(notion_store, "list_active_installation_records_for_workspace", fake_records)
+    monkeypatch.setattr(notion_client, "page_belongs_to_scope", fake_belongs)
+    monkeypatch.setattr(notion_client, "list_comments", fake_list_comments)
+
+    payload = {
+        "workspace_id": "workspace-1",
+        "integration_id": "bot-1",
+        "type": "comment.created",
+        "entity": {"id": "comment-1", "type": "comment"},
+        "data": {"page_id": "page-1", "parent": {"id": "page-1", "type": "page"}},
+    }
+
+    routed = await notion_webhooks.route_comment_event(object(), payload)
+
+    assert routed is not None
+    assert routed.installation.id == "install-2"
 
 
 def test_bot_authored_comment_events_are_ignored() -> None:

--- a/signalpilot/web/app/integrations/page.tsx
+++ b/signalpilot/web/app/integrations/page.tsx
@@ -85,13 +85,61 @@ function IntegrationsContent() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const notion = params.get("notion");
+    const installationId = params.get("installation_id");
     if (!notion) return;
-    toast(notion === "connected" ? "notion connected" : `notion ${notion}`, notion === "connected" ? "success" : "error");
     params.delete("notion");
     params.delete("installation_id");
     const next = params.toString();
     window.history.replaceState(null, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
-  }, [toast]);
+
+    if (notion !== "connected" || !installationId) {
+      toast(notion === "connected" ? "notion connected" : `notion ${notion}`, notion === "connected" ? "success" : "error");
+      return;
+    }
+
+    const oauthInstallationId = installationId;
+    let active = true;
+    async function autoProvisionOAuthInstall() {
+      setProvisioningId(oauthInstallationId);
+      toast("notion connected; provisioning workspace", "info", 5000);
+      try {
+        const installations = await getNotionOAuthInstallations();
+        if (active) {
+          setOauthInstallations(installations);
+          setLoadError(false);
+          setLoading(false);
+        }
+
+        const installation = installations.find((candidate) => candidate.id === oauthInstallationId);
+        if (installation?.config?.enabled) {
+          if (active) toast("notion connected", "success");
+          return;
+        }
+        if (!installation) {
+          if (active) toast("notion connected, but installation was not found", "error");
+          return;
+        }
+
+        await provisionNotionOAuthInstallation(oauthInstallationId);
+        if (active) {
+          toast("notion workspace provisioned", "success");
+          await fetchIntegrations();
+        }
+      } catch (e) {
+        if (active) {
+          setLoading(false);
+          toast(`provision failed: ${e}`, "error", 6000);
+        }
+      } finally {
+        if (active) setProvisioningId(null);
+      }
+    }
+
+    autoProvisionOAuthInstall();
+    return () => {
+      active = false;
+    };
+  }, [fetchIntegrations, toast]);
 
   async function handleConnectNotion() {
     setConnecting(true);

--- a/signalpilot/web/components/notebook/notebooks-page.tsx
+++ b/signalpilot/web/components/notebook/notebooks-page.tsx
@@ -136,8 +136,12 @@ function resolveRuntimeMode({
   return "notebook";
 }
 
-function hasUsableNotionInstallation(installations: Array<{ status?: string }>): boolean {
-  return installations.some((installation) => installation.status !== "disconnected");
+function hasUsableNotionInstallation(
+  installations: Array<{ status?: string; config?: { enabled?: boolean } | null }>,
+): boolean {
+  return installations.some(
+    (installation) => installation.status !== "disconnected" && installation.config?.enabled === true,
+  );
 }
 
 function hasUsableGitHubInstallation(data: unknown): boolean {


### PR DESCRIPTION
## Summary
- route ambiguous Notion webhook candidates by the mentioned provisioned trigger page
- add explicit webhook decision and start-comment logging so 200 responses are diagnosable
- validate Notion comment-read capability during provisioning and surface actionable errors
- auto-provision OAuth installs on return and only mark Notion usable when the config is enabled

## Tests
- uv run pytest tests/test_notion_oauth.py tests/test_notion_analysis.py
- uv run ruff check gateway/api/notion.py gateway/notion/analysis.py gateway/notion/client.py gateway/notion/webhooks.py tests/test_notion_oauth.py
- git diff --check

## Notes
- The working tree had pre-existing unstaged changes in docs/plugin/notebook-server/local files; this PR stages only the Notion webhook/integration fix.