### PR TITLE
Encrypt notebook session access tokens

### DIFF
--- a/signalpilot/gateway/gateway/db/engine.py
+++ b/signalpilot/gateway/gateway/db/engine.py
@@ -380,9 +380,12 @@ async def _ensure_branch_columns(engine) -> None:
 
 
 async def _ensure_notebook_session_columns(engine) -> None:
-    """Add access_token column to gateway_notebook_sessions if it doesn't exist."""
+    """Add notebook session token columns if they don't exist."""
     async with engine.begin() as conn:
         await conn.execute(text("ALTER TABLE gateway_notebook_sessions ADD COLUMN IF NOT EXISTS access_token VARCHAR"))
+        await conn.execute(
+            text("ALTER TABLE gateway_notebook_sessions ADD COLUMN IF NOT EXISTS access_token_enc BYTEA")
+        )
     logger.info("Ensured notebook session columns")
 
 

--- a/signalpilot/gateway/gateway/db/models.py
+++ b/signalpilot/gateway/gateway/db/models.py
@@ -710,6 +710,7 @@ class GatewayNotebookSession(GatewayBase):
     # the cluster. Distinct from pod_ip which is the legacy NodePort address.
     pod_ip_internal: Mapped[str | None] = mapped_column(Text, nullable=True)
     access_token: Mapped[str | None] = mapped_column(String)
+    access_token_enc: Mapped[bytes | None] = mapped_column(LargeBinary)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="creating")
     last_ping: Mapped[float | None] = mapped_column(Float)
     created_at: Mapped[float] = mapped_column(Float, nullable=False)

--- a/signalpilot/gateway/gateway/store/notebook_sessions.py
+++ b/signalpilot/gateway/gateway/store/notebook_sessions.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db.models import GatewayNotebookSession
 from ..models.notebook_sessions import NotebookSessionInfo
+from .crypto import _decrypt_with_migration, _encrypt
 
 
 @dataclass(frozen=True)
@@ -18,7 +19,7 @@ class NotebookSessionInternal:
     """Internal-only session view that includes the real access_token.
 
     NEVER serialize this to JSON or include in any API response.
-    Used only by the gateway proxy for cookie comparison and upstream routing.
+    Used only by the gateway proxy for upstream routing and legacy token access.
     Two distinct read paths off the same DB row:
     - _to_info() -> NotebookSessionInfo  (FE-facing, access_token=None)
     - get_session_internal() -> NotebookSessionInternal  (proxy-only, real token)
@@ -65,13 +66,14 @@ async def get_session_internal(
     row = (await session.execute(q)).scalar_one_or_none()
     if row is None:
         return None
+    access_token = await _get_internal_access_token(session, row)
     return NotebookSessionInternal(
         session_id=row.id,
         org_id=row.org_id,
         user_id=row.user_id,
         status=row.status,
         pod_ip_internal=row.pod_ip_internal,
-        access_token=row.access_token,
+        access_token=access_token,
     )
 
 
@@ -109,7 +111,8 @@ async def create_session(
         pod_name=pod_name,
         pod_ip=None,
         pod_ip_internal=None,
-        access_token=token,
+        access_token=None,
+        access_token_enc=_encrypt(token),
         status="creating",
         last_ping=now,
         created_at=now,
@@ -213,6 +216,30 @@ async def list_stale_sessions(
     )
     rows = (await session.execute(q)).scalars().all()
     return [_to_info(r) for r in rows]
+
+
+async def _get_internal_access_token(
+    session: AsyncSession,
+    row: GatewayNotebookSession,
+) -> str | None:
+    """Return the plaintext token, migrating legacy/plaintext storage in place."""
+    encrypted = getattr(row, "access_token_enc", None)
+    if encrypted:
+        token, needs_migration = _decrypt_with_migration(encrypted)
+        if needs_migration or row.access_token:
+            row.access_token_enc = _encrypt(token)
+            row.access_token = None
+            await session.commit()
+        return token
+
+    if not row.access_token:
+        return None
+
+    token = row.access_token
+    row.access_token_enc = _encrypt(token)
+    row.access_token = None
+    await session.commit()
+    return token
 
 
 def _to_info(row: GatewayNotebookSession) -> NotebookSessionInfo:

--- a/signalpilot/gateway/tests/test_notebook_proxy.py
+++ b/signalpilot/gateway/tests/test_notebook_proxy.py
@@ -23,9 +23,19 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography.fernet import Fernet
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _patch_encryption_key(monkeypatch):
+    import gateway.store.crypto as crypto
+
+    monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+    monkeypatch.setenv("SP_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.delenv("SP_ENCRYPTION_KEY_OLD", raising=False)
+    monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
 
 
 def _make_session_row(
@@ -144,11 +154,14 @@ class TestNotebookSessionInternal:
     """store/notebook_sessions.py: two read paths off the same row."""
 
     @pytest.mark.asyncio
-    async def test_get_session_internal_returns_real_token(self):
-        from gateway.db.models import GatewayNotebookSession
+    async def test_get_session_internal_returns_decrypted_token(self, monkeypatch):
+        _patch_encryption_key(monkeypatch)
+
+        from gateway.store.crypto import _encrypt
         from gateway.store.notebook_sessions import get_session_internal
 
-        row = _make_session_row()
+        row = _make_session_row(access_token=None)
+        row.access_token_enc = _encrypt("secret-token-abc")
         mock_session = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = row
@@ -160,6 +173,35 @@ class TestNotebookSessionInternal:
         assert result is not None
         assert result.access_token == "secret-token-abc"
         assert result.pod_ip_internal == "10.42.0.5"
+        mock_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_session_internal_migrates_legacy_plaintext_token(self, monkeypatch):
+        _patch_encryption_key(monkeypatch)
+
+        from gateway.store.crypto import _decrypt_with_migration
+        from gateway.store.notebook_sessions import get_session_internal
+
+        row = _make_session_row(access_token="legacy-token")
+        assert row.access_token_enc is None
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = row
+        mock_session.execute.return_value = mock_result
+
+        result = await get_session_internal(
+            mock_session, session_id="test-sess-123", org_id="org-1"
+        )
+
+        assert result is not None
+        assert result.access_token == "legacy-token"
+        assert row.access_token is None
+        assert row.access_token_enc is not None
+        assert b"legacy-token" not in row.access_token_enc
+        token, needs_migration = _decrypt_with_migration(row.access_token_enc)
+        assert token == "legacy-token"
+        assert needs_migration is False
+        mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_to_info_hides_access_token(self):
@@ -1018,7 +1060,6 @@ class TestSessionIdValidationOnApiEndpoints:
         with pytest.raises(HTTPException) as exc_info:
             await ns_api_mod.ping_session_by_id("bad,id", store)
         assert exc_info.value.status_code == 404
-
 
 
 

--- a/signalpilot/gateway/tests/test_notebook_sessions.py
+++ b/signalpilot/gateway/tests/test_notebook_sessions.py
@@ -23,6 +23,7 @@ import pytest
 import pytest_asyncio
 from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
+from cryptography.fernet import Fernet
 
 from gateway.auth.notebook_jwt import (
     NOTEBOOK_SESSION_AUD,
@@ -39,6 +40,15 @@ _TEST_SECRET = "integration-test-secret-32-bytes!!"
 def _patch_jwt_secret(monkeypatch):
     monkeypatch.setattr("gateway.auth.notebook_jwt.load_session_jwt_secret", lambda: _TEST_SECRET)
     monkeypatch.setattr("gateway.auth.jwt_secret._cached_secret", _TEST_SECRET)
+
+
+def _patch_encryption_key(monkeypatch):
+    import gateway.store.crypto as crypto
+
+    monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+    monkeypatch.setenv("SP_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.delenv("SP_ENCRYPTION_KEY_OLD", raising=False)
+    monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
 
 
 def _make_nb_jwt(user_id: str, org_id: str, session_id: str, ttl: int = 3600, scopes: list | None = None) -> str:
@@ -118,6 +128,43 @@ class TestStoreGetSessionByIdCrossOrg:
         assert result is not None
         assert result.id == "sess-abc"
         assert result.org_id == "org-1"
+
+
+class TestStoreNotebookSessionTokenStorage:
+    """Direct store-level notebook session token storage tests."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_encrypts_access_token_without_plaintext(self, monkeypatch):
+        _patch_encryption_key(monkeypatch)
+        monkeypatch.setattr("secrets.token_urlsafe", lambda n: "generated-token")
+
+        from gateway.store.crypto import _decrypt_with_migration
+        from gateway.store.notebook_sessions import create_session
+
+        rows = []
+        mock_session = MagicMock()
+        mock_session.add.side_effect = rows.append
+        mock_session.commit = AsyncMock()
+
+        info = await create_session(
+            mock_session,
+            org_id="org-1",
+            user_id="user-1",
+            project_id="proj-1",
+            branch="main",
+            pod_name="nb-test",
+        )
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.access_token is None
+        assert row.access_token_enc is not None
+        assert b"generated-token" not in row.access_token_enc
+        token, needs_migration = _decrypt_with_migration(row.access_token_enc)
+        assert token == "generated-token"
+        assert needs_migration is False
+        assert info.access_token is None
+        mock_session.commit.assert_awaited_once()
 
 
 # ─── JWT dispatch tests ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add encrypted notebook session access-token storage via access_token_enc
- write new notebook session tokens only to encrypted storage
- keep legacy plaintext access_token reads working and migrate them to encrypted storage on internal read

## Compatibility
- non-breaking: access_token remains nullable and is not dropped
- existing plaintext rows continue to work and are re-encrypted opportunistically
- no new env vars required; uses existing SP_ENCRYPTION_KEY

## Tests
- cd signalpilot/gateway && .venv/bin/python -m pytest tests/test_notebook_sessions.py::TestStoreNotebookSessionTokenStorage::test_create_session_encrypts_access_token_without_plaintext tests/test_notebook_proxy.py::TestNotebookSessionInternal::test_get_session_internal_returns_decrypted_token tests/test_notebook_proxy.py::TestNotebookSessionInternal::test_get_session_internal_migrates_legacy_plaintext_token
- git diff --check

Note: full notebook proxy/session files still have unrelated main-branch failures around old signatures/mocks.