### PR TITLE
Restore stock marimo styling in notebook product

### DIFF
--- a/signalpilot/web/notebook/components/editor/chrome/wrapper/sidebar.tsx
+++ b/signalpilot/web/notebook/components/editor/chrome/wrapper/sidebar.tsx
@@ -122,7 +122,7 @@ export const Sidebar: React.FC = () => {
   ]);
 
   return (
-    <div className="h-full pt-4 pb-1 px-1 flex flex-col items-start text-muted-foreground text-md select-none text-sm z-50 bg-[#030303] border-r border-border print:hidden hide-on-fullscreen">
+    <div className="h-full pt-4 pb-1 px-1 flex flex-col items-start text-muted-foreground text-md select-none text-sm z-50 bg-card border-r border-border print:hidden hide-on-fullscreen">
       <ReorderableList<PanelDescriptor>
         value={sidebarItems}
         setValue={handleSetSidebarItems}

--- a/signalpilot/web/notebook/components/editor/dbt/dbt-console-panel.tsx
+++ b/signalpilot/web/notebook/components/editor/dbt/dbt-console-panel.tsx
@@ -48,7 +48,7 @@ export const DbtConsolePanel: React.FC<DbtConsolePanelProps> = ({
   ];
 
   return (
-    <div className="flex flex-col h-full bg-[#050505]">
+    <div className="flex flex-col h-full bg-background">
       {/* Tab bar */}
       <div className="flex items-center border-b border-border px-2 shrink-0">
         {tabs.map((tab) => (

--- a/signalpilot/web/notebook/components/editor/dbt/dbt-console-panel.tsx
+++ b/signalpilot/web/notebook/components/editor/dbt/dbt-console-panel.tsx
@@ -58,7 +58,7 @@ export const DbtConsolePanel: React.FC<DbtConsolePanelProps> = ({
             className={cn(
               "flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider transition-colors border-b-2 -mb-px cursor-pointer",
               activeTab === tab.id
-                ? "text-foreground border-emerald-500"
+                ? "text-foreground border-primary"
                 : "text-muted-foreground border-transparent hover:text-foreground hover:border-border",
             )}
             onClick={() => onTabChange(tab.id)}

--- a/signalpilot/web/notebook/components/editor/dbt/sql-editor-toolbar.tsx
+++ b/signalpilot/web/notebook/components/editor/dbt/sql-editor-toolbar.tsx
@@ -59,7 +59,7 @@ export const SqlEditorToolbar: React.FC<SqlEditorToolbarProps> = ({
         <span className="text-sm font-mono font-medium truncate max-w-md">
           {relativePath}
         </span>
-        <span className="text-[10px] font-bold uppercase tracking-widest text-emerald-500 bg-emerald-500/10 px-2 py-0.5 rounded">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-primary bg-primary/10 px-2 py-0.5 rounded">
           MODEL
         </span>
         {isDirty && (

--- a/signalpilot/web/notebook/components/editor/raw-file-editor.tsx
+++ b/signalpilot/web/notebook/components/editor/raw-file-editor.tsx
@@ -339,7 +339,7 @@ export const RawFileEditor: React.FC<RawFileEditorProps> = ({ filePath }) => {
             <span className="text-sm font-mono font-medium truncate max-w-lg">
               {relativePath}
             </span>
-            <span className="text-[10px] font-bold uppercase tracking-widest text-emerald-500 bg-emerald-500/10 px-2 py-0.5 rounded">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-primary bg-primary/10 px-2 py-0.5 rounded">
               MODEL
             </span>
             {isDirty && (
@@ -365,7 +365,7 @@ export const RawFileEditor: React.FC<RawFileEditorProps> = ({ filePath }) => {
             </div>
           </Panel>
           <PanelResizeHandle className="group relative h-3 flex items-center justify-center cursor-row-resize bg-background hover:bg-muted transition-colors border-y border-border">
-            <div className="w-12 h-1 rounded-full bg-muted-foreground/40 group-hover:bg-muted-foreground/60 group-active:bg-emerald-500/50 transition-colors" />
+            <div className="w-12 h-1 rounded-full bg-muted-foreground/40 group-hover:bg-muted-foreground/60 group-active:bg-primary/50 transition-colors" />
           </PanelResizeHandle>
           <Panel defaultSize={40} minSize={10}>
             <DbtConsolePanel
@@ -420,7 +420,7 @@ export const RawFileEditor: React.FC<RawFileEditorProps> = ({ filePath }) => {
             className={cn(
               "flex items-center gap-1.5 px-3 py-2 text-xs font-semibold uppercase tracking-wider transition-colors border-b-2 -mb-px",
               mdViewMode === "rendered"
-                ? "text-foreground border-emerald-500"
+                ? "text-foreground border-primary"
                 : "text-muted-foreground border-transparent hover:text-foreground",
             )}
             onClick={() => setMdViewMode("rendered")}
@@ -433,7 +433,7 @@ export const RawFileEditor: React.FC<RawFileEditorProps> = ({ filePath }) => {
             className={cn(
               "flex items-center gap-1.5 px-3 py-2 text-xs font-semibold uppercase tracking-wider transition-colors border-b-2 -mb-px",
               mdViewMode === "raw"
-                ? "text-foreground border-emerald-500"
+                ? "text-foreground border-primary"
                 : "text-muted-foreground border-transparent hover:text-foreground",
             )}
             onClick={() => setMdViewMode("raw")}

--- a/signalpilot/web/notebook/components/editor/raw-file-editor.tsx
+++ b/signalpilot/web/notebook/components/editor/raw-file-editor.tsx
@@ -364,8 +364,8 @@ export const RawFileEditor: React.FC<RawFileEditorProps> = ({ filePath }) => {
               </Suspense>
             </div>
           </Panel>
-          <PanelResizeHandle className="group relative h-3 flex items-center justify-center cursor-row-resize bg-[#080808] hover:bg-[#111111] transition-colors border-y border-border">
-            <div className="w-12 h-1 rounded-full bg-[#333333] group-hover:bg-[#555555] group-active:bg-emerald-500/50 transition-colors" />
+          <PanelResizeHandle className="group relative h-3 flex items-center justify-center cursor-row-resize bg-background hover:bg-muted transition-colors border-y border-border">
+            <div className="w-12 h-1 rounded-full bg-muted-foreground/40 group-hover:bg-muted-foreground/60 group-active:bg-emerald-500/50 transition-colors" />
           </PanelResizeHandle>
           <Panel defaultSize={40} minSize={10}>
             <DbtConsolePanel
@@ -414,7 +414,7 @@ export const RawFileEditor: React.FC<RawFileEditorProps> = ({ filePath }) => {
         </div>
       </div>
       {isMarkdown && (
-        <div className="flex items-center gap-0 border-b border-border shrink-0 bg-[#080808] px-4">
+        <div className="flex items-center gap-0 border-b border-border shrink-0 bg-background px-4">
           <button
             type="button"
             className={cn(

--- a/signalpilot/web/notebook/components/editor/tab-bar.tsx
+++ b/signalpilot/web/notebook/components/editor/tab-bar.tsx
@@ -32,7 +32,7 @@ export const TabBar: React.FC = () => {
   if (tabs.length === 0) {return null;}
 
   return (
-    <div className="flex items-center border-b border-border bg-[#080808] overflow-x-auto shrink-0">
+    <div className="flex items-center border-b border-border bg-card overflow-x-auto shrink-0">
       {tabs.map((tab) => (
         <TabItem
           key={tab.id}

--- a/signalpilot/web/notebook/components/editor/tab-bar.tsx
+++ b/signalpilot/web/notebook/components/editor/tab-bar.tsx
@@ -64,8 +64,8 @@ const TabItem: React.FC<{
       className={cn(
         "flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono cursor-pointer border-r border-border/50 shrink-0 max-w-[200px] group",
         isActive
-          ? "bg-background text-foreground border-b-2 border-b-emerald-500 -mb-px"
-          : "bg-[#060606] text-muted-foreground hover:bg-[#0a0a0a] hover:text-foreground",
+          ? "bg-background text-foreground border-b-2 border-b-primary -mb-px"
+          : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",
       )}
       onClick={handleClick}
     >

--- a/signalpilot/web/notebook/components/pages/home-page.tsx
+++ b/signalpilot/web/notebook/components/pages/home-page.tsx
@@ -774,7 +774,7 @@ const SpFileComponent = ({ file }: { file: SpFile }) => {
 
   return (
     <a
-      className="py-1.5 px-4 hover:bg-[#111111] transition-all duration-200 cursor-pointer group relative flex gap-4 items-center"
+      className="py-1.5 px-4 hover:bg-muted transition-all duration-200 cursor-pointer group relative flex gap-4 items-center"
       key={file.path}
       href={href.toString()}
       target="_self"

--- a/signalpilot/web/notebook/components/pages/home-page.tsx
+++ b/signalpilot/web/notebook/components/pages/home-page.tsx
@@ -888,7 +888,7 @@ export const CreateNewNotebook: React.FC = () => {
   const url = newNotebookURL();
   return (
     <a
-      className="relative p-5 group border border-border hover:border-[#333] bg-card transition-all duration-200 cursor-pointer"
+      className="relative p-5 group border border-border hover:border-muted-foreground bg-card transition-all duration-200 cursor-pointer"
       href={url}
       target="_blank"
       rel="noreferrer"

--- a/signalpilot/web/notebook/components/pages/run-page.tsx
+++ b/signalpilot/web/notebook/components/pages/run-page.tsx
@@ -38,7 +38,7 @@ const Watermark = () => {
       <a
         href={Constants.githubPage}
         target="_blank"
-        className="text-[11px] font-bold tracking-[0.15em] uppercase transition-colors bg-card hover:bg-[#111111] border-t border-l border-border px-3 py-1 flex items-center gap-2 text-muted-foreground hover:text-foreground"
+        className="text-[11px] font-bold tracking-[0.15em] uppercase transition-colors bg-card hover:bg-muted border-t border-l border-border px-3 py-1 flex items-center gap-2 text-muted-foreground hover:text-foreground"
       >
         <span>SignalPilot</span>
       </a>

--- a/signalpilot/web/notebook/components/ui/button.tsx
+++ b/signalpilot/web/notebook/components/ui/button.tsx
@@ -48,9 +48,9 @@ const buttonVariants = cva(
         ),
         outline: cn(
           "border border-border",
-          "hover:bg-[#111111] hover:text-foreground",
-          "hover:border-[#333]",
-          "aria-selected:text-foreground aria-selected:border-[#444]",
+          "hover:bg-muted hover:text-foreground",
+          "hover:border-border",
+          "aria-selected:text-foreground aria-selected:border-border",
           activeCommon,
         ),
         secondary: cn(

--- a/signalpilot/web/notebook/components/ui/table.tsx
+++ b/signalpilot/web/notebook/components/ui/table.tsx
@@ -59,7 +59,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors bg-background hover:bg-[#111111] data-[state=selected]:bg-[#1a1a1a]",
+      "border-b transition-colors bg-background hover:bg-muted data-[state=selected]:bg-accent",
       className,
     )}
     {...props}

--- a/signalpilot/web/notebook/core/SpApp.tsx
+++ b/signalpilot/web/notebook/core/SpApp.tsx
@@ -9,7 +9,7 @@ import { useAtomValue } from "jotai";
 import { TailwindIndicator } from "@/components/debug/indicator";
 import { useAppConfig, useResolvedSpConfig } from "@/core/config/config";
 import { currentModeAtom } from "@/core/mode";
-import { CssVariables } from "@/theme/ThemeProvider";
+import { CssVariables, ThemeProvider } from "@/theme/ThemeProvider";
 import { reactLazyWithPreload } from "@/utils/lazy";
 import { ErrorBoundary } from "../components/editor/boundary/ErrorBoundary";
 import { KernelStartupErrorModal } from "../components/editor/KernelStartupErrorModal";
@@ -89,11 +89,13 @@ export const SpApp: React.FC = memo(() => {
 
   return (
     <Providers>
-      <CssVariables
-        variables={{ "--sp-code-editor-font-size": editorFontSize }}
-      >
-        <LocaleProvider>{renderBody()}</LocaleProvider>
-      </CssVariables>
+      <ThemeProvider>
+        <CssVariables
+          variables={{ "--sp-code-editor-font-size": editorFontSize }}
+        >
+          <LocaleProvider>{renderBody()}</LocaleProvider>
+        </CssVariables>
+      </ThemeProvider>
     </Providers>
   );
 });

--- a/signalpilot/web/notebook/core/codemirror/theme/dark.ts
+++ b/signalpilot/web/notebook/core/codemirror/theme/dark.ts
@@ -6,30 +6,30 @@ export const darkTheme = [
   createTheme({
     variant: "dark",
     settings: {
-      background: "#0a0a0a",
-      foreground: "#eeeeee",
-      caret: "#00ff88",
-      selection: "rgba(0, 255, 136, 0.12)",
-      lineHighlight: "rgba(255, 255, 255, 0.03)",
-      gutterBackground: "#050505",
-      gutterForeground: "#666666",
+      background: "var(--cm-background)",
+      foreground: "#abb2bf",
+      caret: "#528bff",
+      selection: "#3E4451",
+      lineHighlight: "#2c313c",
+      gutterBackground: "var(--color-background)",
+      gutterForeground: "var(--gray-10)",
     },
     styles: [
-      { tag: t.comment, color: "#666666" },
-      { tag: t.variableName, color: "#eeeeee" },
-      { tag: [t.string, t.special(t.brace)], color: "#00ff88" },
-      { tag: t.number, color: "#ffaa00" },
-      { tag: t.bool, color: "#ffaa00" },
-      { tag: t.null, color: "#666666" },
+      { tag: t.comment, color: "var(--cm-comment)" },
+      { tag: t.variableName, color: "#abb2bf" },
+      { tag: [t.string, t.special(t.brace)], color: "#98c379" },
+      { tag: t.number, color: "#d19a66" },
+      { tag: t.bool, color: "#d19a66" },
+      { tag: t.null, color: "#d19a66" },
       { tag: t.keyword, color: "#c678dd", fontWeight: 500 },
-      { tag: t.className, color: "#60a5fa" },
-      { tag: t.definition(t.typeName), color: "#60a5fa" },
+      { tag: t.className, color: "#61afef" },
+      { tag: t.definition(t.typeName), color: "#61afef" },
       { tag: t.typeName, color: "#56b6c2" },
-      { tag: t.angleBracket, color: "#999999" },
-      { tag: t.tagName, color: "#ff4444" },
-      { tag: t.attributeName, color: "#ffaa00" },
+      { tag: t.angleBracket, color: "#abb2bf" },
+      { tag: t.tagName, color: "#e06c75" },
+      { tag: t.attributeName, color: "#d19a66" },
       { tag: t.operator, color: "#56b6c2", fontWeight: 500 },
-      { tag: [t.function(t.variableName)], color: "#60a5fa" },
+      { tag: [t.function(t.variableName)], color: "#61afef" },
       { tag: [t.propertyName], color: "#e5c07b" },
     ],
   }),
@@ -39,37 +39,15 @@ export const darkTheme = [
       fontFamily:
         '"JetBrains Mono", "SF Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace',
     },
-    ".cm-gutters": {
-      borderRight: "1px solid #222222",
+    ".mo-cm-reactive-reference": {
+      fontWeight: "400",
+      color: "#2a7aa5",
+      borderBottom: "2px solid #bad3de",
     },
-    ".cm-activeLineGutter": {
-      background: "rgba(255, 255, 255, 0.04)",
-    },
-    ".cm-activeLine": {
-      background: "rgba(255, 255, 255, 0.03)",
-    },
-    ".cm-selectionMatch": {
-      background: "rgba(0, 255, 136, 0.08)",
-    },
-    ".cm-cursor": {
-      borderLeftColor: "#00ff88",
-    },
-    ".cm-matchingBracket": {
-      background: "rgba(0, 255, 136, 0.15)",
-      outline: "1px solid rgba(0, 255, 136, 0.3)",
-    },
-    ".cm-foldGutter": {
-      color: "#444444",
-    },
-    ".cm-foldGutter:hover": {
-      color: "#999999",
-    },
-    ".cm-searchMatch": {
-      background: "rgba(255, 170, 0, 0.2)",
-      outline: "1px solid rgba(255, 170, 0, 0.4)",
-    },
-    ".cm-searchMatch.cm-searchMatch-selected": {
-      background: "rgba(255, 170, 0, 0.35)",
+    ".mo-cm-reactive-reference-hover": {
+      cursor: "pointer",
+      borderBottomWidth: "3px",
+      borderBottomColor: "#4a90a5",
     },
   }),
 ];

--- a/signalpilot/web/notebook/core/codemirror/theme/light.ts
+++ b/signalpilot/web/notebook/core/codemirror/theme/light.ts
@@ -1,2 +1,52 @@
-// SP is always dark-themed — light theme matches dark for consistency
-export { darkTheme as lightTheme } from "./dark";
+import { EditorView } from "@codemirror/view";
+import { tags as t } from "@lezer/highlight";
+import { createTheme } from "thememirror";
+
+export const lightTheme = [
+  createTheme({
+    variant: "light",
+    settings: {
+      background: "#ffffff",
+      foreground: "#000000",
+      caret: "#000000",
+      selection: "#d7d4f0",
+      lineHighlight: "#cceeff44",
+      gutterBackground: "var(--color-background)",
+      gutterForeground: "var(--gray-10)",
+    },
+    styles: [
+      { tag: t.comment, color: "var(--cm-comment)" },
+      { tag: t.variableName, color: "#000000" },
+      { tag: [t.string, t.special(t.brace)], color: "#a11" },
+      { tag: t.number, color: "#164" },
+      { tag: t.bool, color: "#219" },
+      { tag: t.null, color: "#219" },
+      { tag: t.keyword, color: "#708", fontWeight: 500 },
+      { tag: t.className, color: "#00f" },
+      { tag: t.definition(t.typeName), color: "#00f" },
+      { tag: t.typeName, color: "#085" },
+      { tag: t.angleBracket, color: "#000000" },
+      { tag: t.tagName, color: "#170" },
+      { tag: t.attributeName, color: "#00c" },
+      { tag: t.operator, color: "#a2f", fontWeight: 500 },
+      { tag: [t.function(t.variableName)], color: "#00c" },
+      { tag: [t.propertyName], color: "#05a" },
+    ],
+  }),
+  EditorView.theme({
+    "&": {
+      fontSize: "var(--sp-code-editor-font-size, 14px)",
+      fontFamily:
+        '"JetBrains Mono", "SF Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace',
+    },
+    ".mo-cm-reactive-reference": {
+      fontWeight: "400",
+      color: "#005f87",
+      borderBottom: "2px solid #bad3de",
+    },
+    ".mo-cm-reactive-reference-hover": {
+      cursor: "pointer",
+      borderBottomWidth: "3px",
+    },
+  }),
+];

--- a/signalpilot/web/notebook/css/app/Cell.css
+++ b/signalpilot/web/notebook/css/app/Cell.css
@@ -12,15 +12,18 @@
   border-radius: 10px;
   max-width: inherit;
   width: 100%;
-  border: 1px solid #222222;
+  border: 1px solid var(--gray-4);
 
-  @apply divide-y divide-border;
+  @apply divide-y divide-(--gray-5);
 
   &:hover {
-    border-color: #333333;
+    border-color: var(--gray-6);
   }
 
   &:focus-visible {
+    /* focus-visible outlines the entire cell body in black, but the cell's
+     * body is an irregular shape because of pseudo-elements that extend
+     * its hit-box / hover area. */
     outline: none;
   }
 
@@ -47,9 +50,10 @@
     .output-area,
     .cm-gutters,
     .cm {
-      background-color: rgba(255, 68, 68, 0.05);
+      background-color: var(--red-2);
     }
 
+    /* Add a red glow to indicate deletion */
     &::before {
       content: "";
       position: absolute;
@@ -57,13 +61,14 @@
       border-radius: 10px;
       pointer-events: none;
       opacity: 0.6;
-      box-shadow: 0px 0px 10px 0px #ff4444;
+      box-shadow: 0px 0px 10px 0px var(--red-9);
       z-index: 1;
     }
 
+    /* Add strikethrough effect to the code */
     .cm-content {
       text-decoration: line-through;
-      text-decoration-color: #ff4444;
+      text-decoration-color: var(--red-9);
       text-decoration-thickness: 1px;
     }
   }
@@ -73,7 +78,7 @@
     .output-area,
     .cm-gutters,
     .cm {
-      background-color: #0a0a0a;
+      background-color: var(--gray-2);
       opacity: 0.55;
     }
   }
@@ -82,6 +87,11 @@
     z-index: 20;
   }
 
+  /* Hover z-index is higher than focus-within z-index
+     * This is because you may hover for tooltip docs while
+     * not focused in another cell.
+     */
+
   &:hover {
     z-index: 30;
   }
@@ -89,11 +99,15 @@
   /* Interactive */
 
   &.interactive {
+    /* Only restrain output length in edit mode. */
+
     .output-area,
     .console-output-area {
       max-height: 610px;
       overflow: auto;
     }
+
+    /* Special case for particular components */
 
     .output-area:has(
       > .output:only-child > sp-ui-element:only-child > sp-table
@@ -102,6 +116,7 @@
       max-height: none;
       overflow: hidden;
 
+      /* Flush table: remove border and configure edge padding via CSS variable */
       --sp-table-edge-padding: 0.75rem;
 
       sp-table::part(table-tabs) {
@@ -159,7 +174,7 @@
     .output-area,
     .cm-gutters,
     .cm {
-      background-color: #0a0a0a;
+      background-color: var(--gray-2);
       opacity: 0.5;
     }
   }
@@ -173,13 +188,13 @@
     .output-area,
     .cm-gutters,
     .cm {
-      background-color: #080808;
+      background-color: var(--gray-1);
       opacity: 0.5;
     }
   }
 
   &.disabled:hover {
-    border-color: #333333;
+    border-color: var(--gray-6);
   }
 
   /* Error styles for Cell, less precedence than needs run */
@@ -199,12 +214,12 @@
   &.error-outline,
   &.error-outline:focus-within {
     box-shadow: 8px 8px 0 0 color-mix(in srgb, var(--error), transparent 80%);
-    background-color: rgba(255, 68, 68, 0.05);
   }
 
   /* Needs Run */
 
   &.needs-run {
+    /* TODO(akshayka): Can give this an outline to make more visible. */
     @apply border-stale border-1 divide-stale outline-1 outline-stale;
 
     &:hover {
@@ -224,12 +239,14 @@
     }
   }
 
-  /* Focus state — SignalPilot green accent */
+  /* Focus state */
 
   &.focus-outline {
     transition: all 0.6s;
-    border-color: #00ff88 !important;
-    @apply shadow-lg shadow-[#00ff88];
+    border-color: var(--blue-8) !important;
+
+    /* custom shadow until our theme overrides can support colored shadow */
+    @apply shadow-lg shadow-[var(--blue-8)];
   }
 
   /* Published - when its just the output */
@@ -239,11 +256,21 @@
     box-shadow: none;
 
     .output-area {
+      /* flow-root interferes with margin collapsing, but appears to be unneeded
+            * when cell outlines are hidden; clear:both is sufficient.
+            *
+            * if developers just use css-grid instead of float, this won't matter.
+            * */
       display: block;
       padding-top: 0;
       padding-bottom: 0;
       border: none;
       box-shadow: none;
+
+      /*
+                do not restrict the dimensions when outlines are hidden，
+                otherwise text with a scrollbar w/o a container looks weird
+            */
       overflow: visible;
     }
 
@@ -265,8 +292,9 @@
       border-bottom: none;
     }
 
-    &:hover {
-      border: 1px solid #222222;
+    /* Apply the original styles */
+    &:focus {
+      border: 1px solid var(--gray-4);
     }
   }
 
@@ -296,7 +324,7 @@
   @apply border-border;
 
   &:hover {
-    border: 1px solid #444444;
+    border: 1px solid var(--gray-9);
   }
 
   &.needs-run:hover {
@@ -314,8 +342,9 @@
       border-bottom: none;
     }
 
+    /* Apply the original styles */
     &:hover {
-      border: 1px solid #222222;
+      border: 1px solid var(--gray-4);
     }
   }
 
@@ -332,10 +361,12 @@
 #cell-setup,
 #cell-setup .cm-editor,
 #cell-setup .cm-gutter {
-  background-color: #080808;
+  background-color: var(--gray-2);
 }
 
 #App.disconnected {
+  /* Background determined by disconnected gradient/noise. */
+
   .sp-cell,
   .console-output-area,
   .cm .cm-gutters,
@@ -344,6 +375,8 @@
   .sp-cell .shoulder-button {
     background-color: transparent;
   }
+
+  /* Hide when disconnected. */
 
   .cell-running-icon,
   .cell-queued-icon,
@@ -362,6 +395,7 @@
   position: relative;
   z-index: 1;
 
+  /* Round the top of the code editor unless there is output above or the AI prompt input is open */
   &[data-has-output-above="false"] .cm-editor {
     border-top-left-radius: 9px;
     border-top-right-radius: 9px;
@@ -406,6 +440,8 @@
 }
 
 :root {
+  /* Set a fixed gutter width to ensure the hover area is always wide enough */
+  /* And make the gutter bigger when the window is super wide */
   --gutter-width: 100px;
 }
 
@@ -422,6 +458,7 @@
   font-size: var(--sp-code-editor-font-size, 0.9rem);
 }
 
+/* .sp-cell is needed to take precedence over codemirror's generated class ... */
 .sp-cell .cm-editor {
   border: 1px solid transparent;
   padding: 3px;
@@ -429,16 +466,18 @@
 
   &.cm-focused {
     .cm-activeLineGutter {
-      background: #0e1e25;
+      background: #e2f2ff;
     }
 
     .cm-activeLine:not(.cm-error-line) {
-      background: hsl(210deg 100% 2% / 20%);
+      background: hsl(210deg 100% 50% / 3%);
     }
   }
 
   .cm-activeLine:not(.cm-error-line) {
     background: transparent;
+
+    /* Soften the corners of the active-line highlight. */
     border-radius: 2px;
   }
 
@@ -452,14 +491,26 @@
   }
 }
 
+.dark .sp-cell .cm-editor.cm-focused .cm-activeLineGutter {
+  background: #0e1e25;
+}
+
+.dark .sp-cell .cm-editor.cm-focused .cm-activeLine {
+  background: hsl(210deg 100% 2% / 20%);
+}
+
 /* ------------------------------ Output Areas ------------------------------ */
 
 .output-area {
   max-width: inherit;
   width: 100%;
   padding: 1rem;
+
+  /* Prevent floated elements from extending out of the output areas and into
+     * the editor. */
   clear: both;
   display: flow-root;
+
   overflow: auto;
 }
 
@@ -483,5 +534,5 @@
 }
 
 .console-output-area {
-  background-color: #080808;
+  background-color: var(--gray-1);
 }

--- a/signalpilot/web/notebook/css/app/fonts.css
+++ b/signalpilot/web/notebook/css/app/fonts.css
@@ -1,3 +1,6 @@
+/* This must be kept in sync with the fonts used in the static HTML download,
+but instead use the Google Fonts CDN.
+see frontend/src/core/static/download-html.ts */
 @font-face {
   font-family: Lora;
   font-style: normal;

--- a/signalpilot/web/notebook/css/globals.css
+++ b/signalpilot/web/notebook/css/globals.css
@@ -35,7 +35,7 @@
 
 @layer base {
   :root {
-    color-scheme: dark;
+    color-scheme: light;
   }
 
   :root,
@@ -47,49 +47,66 @@
     /* stylelint-disable-next-line unit-allowed-list */
     --markdown-max-width: 80ch;
 
-    /* SignalPilot dark palette */
+    /* Radix light colors: https://github.com/radix-ui/colors/blob/main/src/light.ts */
 
-    /* Base colors — near-black dark theme */
-    --background: #050505;
-    --foreground: #eeeeee;
-    --muted: #0a0a0a;
-    --muted-foreground: #999999;
-    --popover: #0d0d0d;
-    --popover-foreground: #999999;
-    --card: #0a0a0a;
-    --card-foreground: #eeeeee;
-    --border: #222222;
-    --input: #222222;
-    --primary: #00ff88;
-    --primary-foreground: #050505;
-    --secondary: #111111;
-    --secondary-foreground: #eeeeee;
-    --accent: #111111;
-    --accent-foreground: #eeeeee;
-    --ring: #333333;
+    /* Radix dark colors: https://github.com/radix-ui/colors/blob/main/src/dark.ts */
+
+    /* Base colors. */
+    --background: light-dark(hsl(0deg 0% 100%), hsl(150deg 7.7% 10.2%));
+    --foreground: light-dark(hsl(222.2deg 47.4% 11.2%), hsl(155deg 7% 93%));
+    --muted: light-dark(hsl(210deg 40% 96.1%), hsl(180deg 14% 1%));
+    --muted-foreground: light-dark(
+      hsl(215.4deg 16.3% 46.9%),
+      hsl(155deg 5% 68.3%)
+    );
+    --popover: light-dark(hsl(0deg 0% 100%), hsl(151deg 5.5% 15.2%));
+    --popover-foreground: light-dark(
+      hsl(222.2deg 47.4% 11.2%),
+      hsl(155deg 5% 68.3%)
+    );
+    --card: light-dark(hsl(0deg 0% 100%), hsl(151deg 5.5% 15.2%));
+    --card-foreground: light-dark(
+      hsl(222.2deg 47.4% 11.2%),
+      hsl(155deg 5% 76.3%)
+    );
+    --border: light-dark(hsl(214.3deg 31.8% 91.4%), hsl(153deg 3.7% 24.2%));
+    --input: light-dark(hsl(0deg 0% 64%), hsl(154deg 3.3% 28.7%));
+    --primary: light-dark(hsl(208deg 93.5% 47.4%), hsl(192deg 59.8% 39%));
+    --primary-foreground: light-dark(hsl(210deg 40% 98%), hsl(190deg 80% 84%));
+    --secondary: light-dark(hsl(210deg 40% 96.1%), hsl(155deg 7% 93%));
+    --secondary-foreground: light-dark(
+      hsl(222.2deg 47.4% 11.2%),
+      hsl(151deg 5.5% 15.2%)
+    );
+    --accent: light-dark(hsl(209deg 100% 96.5%), hsl(192deg 56.6% 26.5%));
+    --accent-foreground: light-dark(hsl(211deg 90% 42%), hsl(190deg 80% 84%));
+    --ring: hsl(215deg 20.2% 65.1%);
 
     /* Semantic colors. */
-    --destructive: #ff4444;
-    --destructive-foreground: #050505;
-    --error: #ff4444;
-    --error-foreground: #050505;
-    --success: #00ff88;
-    --success-foreground: #050505;
-    --action: #ffaa00;
-    --action-hover: #ffcc44;
-    --action-foreground: #050505;
-    --link: #00ff88;
-    --link-visited: #999999;
-    --stale: rgba(255, 170, 0, 0.25);
+    --destructive: hsl(0deg 100% 70%);
+    --destructive-foreground: hsl(210deg 40% 98%);
+    --error: hsl(0deg 77% 64%);
+    --error-foreground: hsl(210deg 40% 98%);
+    --success: hsl(130deg 100% 70%);
+    --success-foreground: hsl(210deg 40% 98%);
+    --action: hsl(52deg 96.8% 82%);
+    --action-hover: hsl(54deg 100% 86.7%);
+    --action-foreground: hsl(42deg 100% 29%);
+    --link: light-dark(hsl(211deg 90% 42%), hsl(211deg 90% 62%));
+    --link-visited: light-dark(hsl(272deg 51% 54%), hsl(272deg 51% 74%));
+    --stale: hsl(42deg 56% 44% / 25%);
 
-    /* Base shadows — soft, depth styling */
-    --base-shadow: hsla(0deg 0% 36% / 60%);
-    --base-shadow-darker: hsl(0deg 0% 50% / 60%);
+    /* Base shadows. */
+    --base-shadow: light-dark(hsl(0deg 0% 85% / 40%), hsla(0deg 0% 36% / 60%));
+    --base-shadow-darker: light-dark(
+      hsl(0deg 0% 50% / 40%),
+      hsl(0deg 0% 50% / 60%)
+    );
     --base-shadow-opacity: 5%;
 
     /* Codemirror editor */
-    --cm-background: #0a0a0a;
-    --cm-comment: #666666;
+    --cm-background: light-dark(var(--background), #282c34);
+    --cm-comment: light-dark(#708090, #6b7280);
   }
 
   .dark,
@@ -122,28 +139,6 @@
   button:not(:disabled),
   [role="button"]:not(:disabled) {
     cursor: pointer;
-  }
-
-  /* Scrollbar — thin, dark, with rounded thumb */
-  ::-webkit-scrollbar { width: 6px; height: 6px; }
-  ::-webkit-scrollbar-track { background: transparent; }
-  ::-webkit-scrollbar-thumb { background: #222222; border-radius: 4px; }
-  ::-webkit-scrollbar-thumb:hover { background: #333333; }
-
-  /* Selection — SignalPilot green tint */
-  ::selection {
-    background: rgba(0, 255, 136, 0.15);
-    color: #fff;
-  }
-
-  /* Smooth transitions on interactive elements */
-  a, button, input, select, textarea {
-    transition: all 0.15s ease;
-  }
-
-  /* Button press effect */
-  button:active:not(:disabled) {
-    transform: scale(0.98);
   }
 }
 

--- a/signalpilot/web/notebook/css/md.css
+++ b/signalpilot/web/notebook/css/md.css
@@ -117,7 +117,7 @@ button .markdown .paragraph {
 
 /*
 Disable max-width for prose in buttons
-This change includes accordions https://github.com/SignalPilot-Labs/SignalPilot/issues/2217
+This change includes accordions https://github.com/marimo-team/marimo/issues/2217
 */
 button .prose.prose {
   max-width: none;

--- a/signalpilot/web/notebook/css/table.css
+++ b/signalpilot/web/notebook/css/table.css
@@ -38,17 +38,17 @@ table.dataframe thead {
 
 .markdown table tbody tr:nth-child(odd),
 table.dataframe tbody tr:nth-child(odd) {
-  background: #0a0a0a;
+  background: var(--lime-2);
 }
 
 .markdown table tbody tr:nth-child(even),
 table.dataframe tbody tr:nth-child(even) {
-  background: #050505;
+  @apply bg-card;
 }
 
 .markdown table tbody tr:hover,
 table.dataframe tbody tr:hover {
-  background: #111111;
+  background: var(--yellow-4);
 }
 
 .markdown table tr,

--- a/signalpilot/web/notebook/embed/SignalpilotEditor.tsx
+++ b/signalpilot/web/notebook/embed/SignalpilotEditor.tsx
@@ -10,8 +10,10 @@ import type { SignalpilotEditorProps } from "./types";
  * `<SpEmbedProviders>`. The `mode` field is injected automatically — do not
  * include it in the `config` prop.
  *
- * The `.sp-root.dark.dark-theme` wrapper scopes all rescoped CSS selectors
- * to this subtree so embed and host page styles don't bleed into each other.
+ * The `.sp-root` wrapper scopes all rescoped CSS selectors to this subtree
+ * so embed and host page styles don't bleed into each other. Theme classes
+ * (`dark`/`light`, `dark-theme`/`light-theme`) are applied reactively by
+ * `ThemeProvider` via `document.body`.
  *
  * Phase E: `SignalpilotEditorProps` will gain a `navigate` prop for host-
  * controlled routing. Today's embed inherits standalone navigation
@@ -26,8 +28,7 @@ export function SignalpilotEditor({
 
   return (
     <div
-      className={`sp-root dark dark-theme${className ? ` ${className}` : ""}`}
-      data-theme="dark"
+      className={`sp-root${className ? ` ${className}` : ""}`}
     >
       <SpEmbedProviders client={client} options={options}>
         <SpApp />

--- a/signalpilot/web/notebook/embed/SignalpilotHome.tsx
+++ b/signalpilot/web/notebook/embed/SignalpilotHome.tsx
@@ -11,8 +11,10 @@ import type { SignalpilotHomeProps } from "./types";
  * `config` prop because `initStore` will receive `mode: "home"` with an
  * otherwise empty blob.
  *
- * The `.sp-root.dark.dark-theme` wrapper scopes all rescoped CSS selectors
- * to this subtree so embed and host page styles don't bleed into each other.
+ * The `.sp-root` wrapper scopes all rescoped CSS selectors to this subtree
+ * so embed and host page styles don't bleed into each other. Theme classes
+ * (`dark`/`light`, `dark-theme`/`light-theme`) are applied reactively by
+ * `ThemeProvider` via `document.body`.
  */
 export function SignalpilotHome({
   client,
@@ -26,8 +28,7 @@ export function SignalpilotHome({
 
   return (
     <div
-      className={`sp-root dark dark-theme${className ? ` ${className}` : ""}`}
-      data-theme="dark"
+      className={`sp-root${className ? ` ${className}` : ""}`}
     >
       <SpEmbedProviders client={client} options={options}>
         <SpApp />

--- a/signalpilot/web/notebook/mount.tsx
+++ b/signalpilot/web/notebook/mount.tsx
@@ -91,8 +91,7 @@ export async function mount(
 
   // Standalone: #root becomes the .sp-root container so rescoped CSS selectors
   // (body → .sp-root, :root → .sp-root) match without poisoning the host page.
-  (el as HTMLElement).classList.add("sp-root", "dark", "dark-theme");
-  (el as HTMLElement).dataset.theme = "dark";
+  (el as HTMLElement).classList.add("sp-root");
 
   let initResult: InitStoreResult;
 

--- a/signalpilot/web/notebook/theme/ThemeProvider.tsx
+++ b/signalpilot/web/notebook/theme/ThemeProvider.tsx
@@ -1,3 +1,32 @@
+import { memo, type PropsWithChildren, useLayoutEffect } from "react";
+import { useTheme } from "./useTheme";
+
+/**
+ * SignalPilot theme provider.
+ *
+ * Reactively adds/removes `${theme}` and `${theme}-theme` class tokens on
+ * `document.body` and sets `document.body.dataset.theme` whenever the resolved
+ * theme atom changes. Cleanup removes exactly what it added — no silent
+ * defaults if `theme` is somehow undefined (upstream types guarantee it is
+ * "light" | "dark").
+ */
+export const ThemeProvider: React.FC<PropsWithChildren> = memo(
+  ({ children }) => {
+    const { theme } = useTheme();
+    useLayoutEffect(() => {
+      document.body.classList.add(theme, `${theme}-theme`);
+      document.body.dataset.theme = theme;
+      return () => {
+        document.body.classList.remove(theme, `${theme}-theme`);
+        delete document.body.dataset.theme;
+      };
+    }, [theme]);
+
+    return children;
+  },
+);
+ThemeProvider.displayName = "ThemeProvider";
+
 export const CssVariables: React.FC<{
   variables: Record<`--sp-${string}`, string>;
   children: React.ReactNode;


### PR DESCRIPTION
## Summary

Reverts the notebook product (`signalpilot/web/notebook/`) styling to stock marimo and restores the light/dark mode toggle. Main app, shared components, and `lib/` are untouched.

## What changed

**CSS / tokens**
- `css/globals.css` ported to upstream `light-dark(...)` HSL tokens with `:root { color-scheme: light }` and `.dark { color-scheme: dark }`. Custom scrollbar/selection/transition/active-scale rules removed. The `.sp` namespace and `--sp-*` font-var prefix are preserved (logic in `notebook/core/dom/*` queries by these exact strings).
- `css/app/Cell.css`, `css/table.css`, `css/md.css`, `css/app/fonts.css` re-skinned against upstream. Hardcoded brand hex (`#00ff88`, `#050505`, `#0a0a0a`, `#222222`, `#333333`, `#ff4444`, etc.) replaced with Radix CSS vars (`var(--gray-*)`, `var(--red-9)`, `var(--blue-8)`, `var(--lime-2)`, `var(--yellow-4)`).
- `--sp-table-edge-padding`, `--sp-code-editor-font-size`, and all `sp-cell` / `sp-ui-element` / `sp-table` selectors preserved.

**TSX className / inline-style swap**
- 11 hardcoded brand-hex classNames and `style={{ }}` color literals across 7 notebook TSX files replaced with semantic tokens (`bg-background`, `bg-muted`, `bg-accent`, `border-border`, `text-primary`, `bg-muted-foreground/40`).
- `tab-bar.tsx`: `border-b-emerald-500` → `border-b-primary`; tab strip `bg-[#080808]` → `bg-card`.
- `home-page.tsx`: card `hover:border-[#333]` → `hover:border-muted-foreground`.
- `raw-file-editor.tsx`: MODEL badge and active-tab borders moved from `emerald-500` to `primary` tokens.
- `dbt/sql-editor-toolbar.tsx`, `dbt/dbt-console-panel.tsx`: emerald active-tab indicators → `primary`.
- `chrome/wrapper/sidebar.tsx`: `bg-[#030303]` → `bg-card`.

**CodeMirror dark theme**
- `core/codemirror/theme/dark.ts` rewritten to upstream marimo One Dark palette (`#abb2bf` fg, `#528bff` caret, `#3E4451` selection, plus the standard `#98c379` / `#d19a66` / `#c678dd` / `#61afef` / `#56b6c2` / `#e06c75` / `#e5c07b` highlight slots). The fork's brand-green caret/gutter/match blocks are dropped; `darkTheme` named export and array shape preserved so all importers keep working.

**Light/dark toggle restoration**
- Re-added the upstream `ThemeProvider` component to `theme/ThemeProvider.tsx` (memo + `useLayoutEffect` adding/removing `${theme}` and `${theme}-theme` on `document.body`). `CssVariables` is unchanged.
- `core/SpApp.tsx` now wraps `<CssVariables>` in `<ThemeProvider>`.
- Removed the hardcoded `dark dark-theme` / `data-theme="dark"` from `mount.tsx`, `embed/SignalpilotEditor.tsx`, `embed/SignalpilotHome.tsx`.
- `core/codemirror/theme/light.ts` reverted from a `darkTheme` re-export to a real upstream-aligned light theme.

## Scope guardrails

- Only files under `signalpilot/web/notebook/` were modified.
- No edits to `signalpilot/web/app/**`, `signalpilot/web/components/**`, `signalpilot/web/lib/**`.
- `sp-*` selectors and `--sp-*` CSS-var prefix preserved everywhere (logic depends on them).
- One intentional skip: `boot-error.tsx`'s `#050505` in `style.cssText` is pre-React, runs before CSS variables resolve, and was left as-is.

## Test plan
- [ ] `cd signalpilot/web && npx tsc --noEmit` — 44 pre-existing errors, zero new (verified).
- [ ] Notebook opens in light mode by default (white background, dark text).
- [ ] Toggling `display.theme` between `light`, `dark`, and `system` flips the body class and the visible palette without reload.
- [ ] Cell hover/focus/selected states render with stock marimo's gray Radix palette.
- [ ] CodeMirror editor renders with the upstream light theme in light mode.
- [ ] Main app pages (outside the notebook) and shared components are visually unchanged.


---
**Branch:** `autofyn/re-do-all-the-st-00c7f9` · **Run:** `c8560ede-c4e7-41c0-b02a-9c5e0bb879b9` · *Generated by AutoFyn*