### PR TITLE
feat(snowflake): support multiple auth methods

### DIFF
--- a/signalpilot/gateway/gateway/api/connections/testing.py
+++ b/signalpilot/gateway/gateway/api/connections/testing.py
@@ -105,7 +105,21 @@ async def test_credentials(_: UserID, request: Request):
         try:
             parsed = urlparse(conn_str if "://" in conn_str else f"dummy://{conn_str}")
             host = parsed.hostname or conn.host or "localhost"
-            port = parsed.port or conn.port or 5432
+            # Default TCP port per engine — do NOT fall back to 5432 for everything
+            # (that probed Snowflake's account identifier on the Postgres port).
+            _default_ports = {
+                "postgres": 5432, "mysql": 3306, "mssql": 1433, "redshift": 5439,
+                "snowflake": 443, "databricks": 443, "clickhouse": 9000, "trino": 8080,
+            }
+            port = parsed.port or conn.port or _default_ports.get(db_type, 5432)
+            # Snowflake's "host" in the URL is an account identifier (e.g. org-account),
+            # not a resolvable name. The real endpoint is <account>.snowflakecomputing.com:443.
+            # An explicit host override (PrivateLink / China / gov / VPS) wins verbatim.
+            if db_type == "snowflake":
+                if getattr(conn, "snowflake_host", None):
+                    host = conn.snowflake_host
+                elif host and "snowflakecomputing.com" not in host:
+                    host = f"{host}.snowflakecomputing.com"
 
             # Resolve DNS and validate IPs in one step, then connect to the
             # validated IP directly. This prevents DNS rebinding TOCTOU attacks

--- a/signalpilot/gateway/gateway/connectors/base.py
+++ b/signalpilot/gateway/gateway/connectors/base.py
@@ -38,7 +38,9 @@ class BaseConnector(ABC):
         self._ssl_config: dict | None = None
         self._temp_files: list[str] = []
         self._connection_timeout: int = 15
-        self._query_timeout: int = 30
+        # Default per-query/introspection timeout. Schema pulls on large warehouses
+        # (thousands of tables) can exceed 30s, so the floor is 150s.
+        self._query_timeout: int = 150
 
     # ─── Abstract methods (must implement) ────────────────────────────
 

--- a/signalpilot/gateway/gateway/connectors/drivers/postgres.py
+++ b/signalpilot/gateway/gateway/connectors/drivers/postgres.py
@@ -19,7 +19,7 @@ class PostgresConnector(BaseConnector):
     def __init__(self):
         super().__init__()
         self._pool = None
-        self._command_timeout: int = 30
+        self._command_timeout: int = 150  # was 30 — large-warehouse schema pulls need headroom
         self._pool_min_size: int = 1
         self._pool_max_size: int = 5
         self._iam_auth: bool = False

--- a/signalpilot/gateway/gateway/connectors/drivers/snowflake.py
+++ b/signalpilot/gateway/gateway/connectors/drivers/snowflake.py
@@ -27,7 +27,7 @@ class SnowflakeConnector(BaseConnector):
         self._connect_params: dict = {}
         self._credential_extras: dict = {}
         self._login_timeout: int = 15
-        self._network_timeout: int = 120
+        self._network_timeout: int = 150  # was 120 — large-warehouse schema pulls need headroom
         self._keepalive: bool = True
         self._keepalive_heartbeat: int = 900  # 15 min default
 
@@ -78,6 +78,10 @@ class SnowflakeConnector(BaseConnector):
                 "private_key_passphrase",
                 "oauth_access_token",
                 "auth_method",
+                "authenticator",
+                "passcode",
+                "snowflake_host",
+                "snowflake_protocol",
             ):
                 val = self._credential_extras.get(key)
                 if val:
@@ -98,15 +102,28 @@ class SnowflakeConnector(BaseConnector):
             "disable_ocsp_checks": params.get("disable_ocsp_checks", False),
         }
 
-        # Auth method priority: OAuth > Key-pair > Password (HEX pattern)
-        auth_method = params.get("auth_method", "").lower()
-        if auth_method == "oauth" or params.get("oauth_access_token"):
-            token = params.get("oauth_access_token")
+        # Host override + port/protocol — required for PrivateLink, China (.cn),
+        # SnowGov, and VPS accounts where the account identifier alone is insufficient.
+        # account is still passed (the connector requires it even with an explicit host).
+        if params.get("snowflake_host"):
+            connect_args["host"] = params["snowflake_host"]
+        if params.get("port"):
+            connect_args["port"] = int(params["port"])
+        if params.get("snowflake_protocol"):
+            connect_args["protocol"] = params["snowflake_protocol"]
+
+        # Auth dispatch. `authenticator` (or legacy `auth_method`) selects the method:
+        #   oauth | key_pair | pat | mfa | password | <Okta URL https://...>.
+        # Back-compat: an oauth token or a private_key alone still picks the right path.
+        authr = (params.get("authenticator") or params.get("auth_method") or "").strip()
+        al = authr.lower()
+        token = params.get("oauth_access_token")
+        if al == "oauth" or (token and al in ("", "oauth")):
             if not token:
                 raise RuntimeError("OAuth auth requires an access token (oauth_access_token)")
             connect_args["authenticator"] = "oauth"
             connect_args["token"] = token
-        elif params.get("private_key"):
+        elif al in ("key_pair", "keypair") or params.get("private_key"):
             try:
                 pk_bytes = self._load_private_key(
                     params["private_key"],
@@ -115,6 +132,19 @@ class SnowflakeConnector(BaseConnector):
                 connect_args["private_key"] = pk_bytes
             except Exception as e:
                 raise RuntimeError(f"Invalid private key: {e}") from e
+        elif authr.startswith("https://"):  # Okta native SSO (authenticator = Okta URL)
+            connect_args["authenticator"] = authr
+            if params.get("password"):
+                connect_args["password"] = params["password"]
+        elif al in ("mfa", "username_password_mfa"):
+            connect_args["authenticator"] = "username_password_mfa"
+            connect_args["password"] = params.get("password", "")
+            if params.get("passcode"):
+                connect_args["passcode"] = params["passcode"]
+        elif al == "pat":
+            # Programmatic Access Token — used in place of a password (works across
+            # all account types; bypasses MFA). The PAT is supplied in the password field.
+            connect_args["password"] = params.get("password") or token or ""
         elif params.get("password"):
             connect_args["password"] = params["password"]
 
@@ -258,57 +288,107 @@ class SnowflakeConnector(BaseConnector):
             WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA')
                 AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')
         """
-        fk_sql = """
-            SELECT
-                FK_SCHEMA_NAME, FK_TABLE_NAME, FK_COLUMN_NAME,
-                PK_SCHEMA_NAME, PK_TABLE_NAME, PK_COLUMN_NAME
-            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
-            JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-                ON rc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
-                AND rc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
-            WHERE rc.CONSTRAINT_SCHEMA NOT IN ('INFORMATION_SCHEMA')
-        """
-        pk_sql = """
-            SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME
-            FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-            JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu
-                USING (CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME)
-            WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
-                AND tc.TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA')
-        """
+        # Snowflake's INFORMATION_SCHEMA has NO KEY_COLUMN_USAGE / CONSTRAINT_COLUMN_USAGE
+        # views (those queries error and silently returned no keys). The metadata SHOW
+        # commands are the correct, supported source for keys (cloud-services, no warehouse).
+        fk_sql = "SHOW IMPORTED KEYS IN DATABASE"
+        pk_sql = "SHOW PRIMARY KEYS IN DATABASE"
 
         # Clustering keys — SHOW TABLES returns cluster_by (not in information_schema)
         # Run as a 5th parallel query
         cluster_sql = "SHOW TABLES IN DATABASE"
 
-        # snowflake-connector-python connections are NOT thread-safe —
-        # run all queries sequentially in a single background thread
-        def _fetch(query: str, label: str = "") -> list:
+        # All work runs in one background thread (the connection is not thread-safe),
+        # but the 5 metadata queries are submitted with execute_async so Snowflake runs
+        # them CONCURRENTLY server-side — wall time ≈ the slowest query, not the sum.
+        import time as _t
+
+        def _collect(cur):
+            """Block until an async query finishes, then return its rows. Raises on query error."""
+            qid = cur.sfqid
+            status = self._conn.get_query_status_throw_if_error(qid)
+            while self._conn.is_still_running(status):
+                _t.sleep(0.1)
+                status = self._conn.get_query_status_throw_if_error(qid)
+            cur.get_results_from_sfqid(qid)
+            return cur.fetchall()
+
+        def _columns_per_schema() -> list:
+            # Fallback for massive DBs where the whole-DB INFORMATION_SCHEMA.COLUMNS query
+            # hits the "too much data" cap (or would time out). Each per-schema query is
+            # bounded, so it never caps; batches are submitted async and run in parallel.
             try:
-                cursor = self._conn.cursor(snowflake.connector.DictCursor)
-                cursor.execute(query)
-                result = cursor.fetchall()
-                cursor.close()
-                return result
-            except Exception as e:
-                logger.info("Snowflake metadata query failed (%s): %s", label, e)
+                scur = self._conn.cursor(snowflake.connector.DictCursor)
+                scur.execute("SHOW SCHEMAS IN DATABASE")
+                schemas = [s.get("name") for s in scur.fetchall() if s.get("name") != "INFORMATION_SCHEMA"]
+                scur.close()
+            except Exception:
                 return []
+            per_sql = (
+                "SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, IS_NULLABLE, "
+                "COLUMN_DEFAULT, COMMENT FROM INFORMATION_SCHEMA.COLUMNS "
+                "WHERE TABLE_SCHEMA = %s ORDER BY TABLE_NAME, ORDINAL_POSITION"
+            )
+            out: list = []
+            batch_size = 8
+            for i in range(0, len(schemas), batch_size):
+                curs = []
+                for sch in schemas[i : i + batch_size]:
+                    try:
+                        cu = self._conn.cursor(snowflake.connector.DictCursor)
+                        cu.execute_async(per_sql, (sch,))
+                        curs.append(cu)
+                    except Exception as e:
+                        logger.info("per-schema submit failed: %s", e)
+                for cu in curs:
+                    try:
+                        out.extend(_collect(cu))
+                        cu.close()
+                    except Exception as e:
+                        logger.info("per-schema collect failed: %s", e)
+            return out
 
         def _fetch_all():
-            # Increase statement timeout for metadata queries — large databases
-            # (e.g., STACKOVERFLOW with 23M+ rows) can timeout at the default 30s.
             try:
-                timeout_cursor = self._conn.cursor()
-                timeout_cursor.execute("ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = 120")
-                timeout_cursor.close()
+                tc = self._conn.cursor()
+                tc.execute(f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {self._network_timeout}")
+                tc.close()
             except Exception:
                 pass
+            # Submit all five concurrently, then collect each.
+            submitted: dict[str, Any] = {}
+            for label, q in (
+                ("columns", col_sql), ("tables", rc_sql), ("fk", fk_sql),
+                ("pk", pk_sql), ("cluster", cluster_sql),
+            ):
+                try:
+                    cu = self._conn.cursor(snowflake.connector.DictCursor)
+                    cu.execute_async(q)
+                    submitted[label] = cu
+                except Exception as e:
+                    logger.info("metadata submit failed (%s): %s", label, e)
+                    submitted[label] = None
+            res: dict[str, list] = {}
+            for label, cu in submitted.items():
+                if cu is None:
+                    res[label] = []
+                    continue
+                try:
+                    res[label] = _collect(cu)
+                    cu.close()
+                except Exception as e:
+                    # Columns is the only query that can be too big for one statement
+                    # (cap OR statement-timeout) on a massive DB — recover via bounded,
+                    # parallel per-schema pulls so a huge warehouse never fails the pull.
+                    if label == "columns":
+                        logger.info("columns whole-DB pull failed (%s) — parallel per-schema fallback", e)
+                        res[label] = _columns_per_schema()
+                    else:
+                        logger.info("metadata collect failed (%s): %s", label, e)
+                        res[label] = []
             return (
-                _fetch(col_sql, "columns"),
-                _fetch(rc_sql, "row_counts"),
-                _fetch(fk_sql, "foreign_keys"),
-                _fetch(pk_sql, "primary_keys"),
-                _fetch(cluster_sql, "clustering"),
+                res.get("columns", []), res.get("tables", []), res.get("fk", []),
+                res.get("pk", []), res.get("cluster", []),
             )
 
         t0 = _time.monotonic()
@@ -336,18 +416,18 @@ class SnowflakeConnector(BaseConnector):
             if comment:
                 table_comments_map[key] = comment
 
-        # Build FK map
+        # Build FK map from SHOW IMPORTED KEYS (lowercase column names)
         foreign_keys: dict[str, list[dict]] = {}
         for r in fk_rows_raw:
-            key = f"{r['FK_SCHEMA_NAME']}.{r['FK_TABLE_NAME']}"
-            if key not in foreign_keys:
-                foreign_keys[key] = []
-            foreign_keys[key].append(
+            fk_schema = r.get("fk_schema_name", "")
+            fk_table = r.get("fk_table_name", "")
+            key = f"{fk_schema}.{fk_table}"
+            foreign_keys.setdefault(key, []).append(
                 {
-                    "column": r["FK_COLUMN_NAME"],
-                    "references_schema": r["PK_SCHEMA_NAME"],
-                    "references_table": r["PK_TABLE_NAME"],
-                    "references_column": r["PK_COLUMN_NAME"],
+                    "column": r.get("fk_column_name", ""),
+                    "references_schema": r.get("pk_schema_name", ""),
+                    "references_table": r.get("pk_table_name", ""),
+                    "references_column": r.get("pk_column_name", ""),
                 }
             )
 
@@ -391,8 +471,10 @@ class SnowflakeConnector(BaseConnector):
                 }
             )
 
-        # Enrich with primary key info (already fetched in parallel)
-        pk_set = {(r["TABLE_SCHEMA"], r["TABLE_NAME"], r["COLUMN_NAME"]) for r in pk_rows}
+        # Enrich with primary key info from SHOW PRIMARY KEYS (lowercase column names)
+        pk_set = {
+            (r.get("schema_name"), r.get("table_name"), r.get("column_name")) for r in pk_rows
+        }
         for table_data in schema.values():
             for col in table_data["columns"]:
                 if (table_data["schema"], table_data["name"], col["name"]) in pk_set:

--- a/signalpilot/gateway/gateway/models/connections.py
+++ b/signalpilot/gateway/gateway/models/connections.py
@@ -153,6 +153,15 @@ class ConnectionCreate(BaseModel):
     # ─── Snowflake key-pair auth ───────────────────────────────────
     private_key: str | None = Field(default=None, max_length=16384)  # PEM-encoded private key
     private_key_passphrase: str | None = Field(default=None, max_length=1024)
+    # ─── Snowflake auth method + host override (supports all account types) ──
+    # authenticator: password | key_pair | oauth | pat | mfa, OR an Okta URL
+    # (https://<org>.okta.com). Empty = password.
+    authenticator: str | None = Field(default=None, max_length=512)
+    passcode: str | None = Field(default=None, max_length=16)  # MFA passcode (username_password_mfa)
+    # Explicit host override for PrivateLink / China (.cn) / SnowGov / VPS — when the
+    # account identifier alone does not produce the right <host>.snowflakecomputing.com.
+    snowflake_host: str | None = Field(default=None, max_length=255)
+    snowflake_protocol: str | None = Field(default=None, pattern=r"^https?$")  # default https
     # ─── DuckDB / MotherDuck ──────────────────────────────────────
     motherduck_token: str | None = Field(default=None, max_length=2048)  # MotherDuck personal access token
     # ─── Metadata ───────────────────────────────────────────────────
@@ -301,6 +310,11 @@ class ConnectionUpdate(BaseModel):
     catalog: str | None = Field(default=None, max_length=128)
     private_key: str | None = Field(default=None, max_length=16384)
     private_key_passphrase: str | None = Field(default=None, max_length=1024)
+    # Snowflake auth method + host override
+    authenticator: str | None = Field(default=None, max_length=512)
+    passcode: str | None = Field(default=None, max_length=16)
+    snowflake_host: str | None = Field(default=None, max_length=255)
+    snowflake_protocol: str | None = Field(default=None, pattern=r"^https?$")
     description: str | None = Field(default=None, max_length=500)
     tags: list[str] | None = Field(default=None, max_length=50)
     schema_filter_include: list[str] | None = Field(default=None, max_length=100)
@@ -371,6 +385,9 @@ class ConnectionInfo(BaseModel):
     warehouse: str | None = None
     schema_name: str | None = None
     role: str | None = None
+    authenticator: str | None = None  # auth method or Okta URL (non-secret)
+    snowflake_host: str | None = None  # host override (PrivateLink/China/gov/VPS)
+    snowflake_protocol: str | None = None
     # BigQuery
     project: str | None = None
     dataset: str | None = None

--- a/signalpilot/gateway/gateway/store/connection_strings.py
+++ b/signalpilot/gateway/gateway/store/connection_strings.py
@@ -135,6 +135,14 @@ def _extract_credential_extras(conn: ConnectionCreate) -> dict:
             extras["private_key"] = conn.private_key
         if conn.private_key_passphrase:
             extras["private_key_passphrase"] = conn.private_key_passphrase
+        # auth method + host override (all account types). OAuth token rides in
+        # access_token (set above) → mapped to oauth_access_token for the connector.
+        if conn.access_token:
+            extras["oauth_access_token"] = conn.access_token
+        for attr in ("authenticator", "passcode", "snowflake_host", "snowflake_protocol"):
+            val = getattr(conn, attr, None)
+            if val:
+                extras[attr] = val
     if conn.db_type == DBType.databricks:
         for attr in ("http_path", "access_token", "catalog", "schema_name"):
             extras[attr] = getattr(conn, attr, None)

--- a/signalpilot/web/app/connections/page.tsx
+++ b/signalpilot/web/app/connections/page.tsx
@@ -738,11 +738,17 @@ interface FormState {
   ssh_proxy_enabled: boolean;
   ssh_proxy_host: string;
   ssh_proxy_port: string;
-  // Snowflake auth method (password, key-pair, or OAuth)
-  snowflake_auth_method: "password" | "key_pair" | "oauth";
+  // Snowflake auth method (password, key-pair, OAuth, PAT, Okta SSO, or MFA)
+  snowflake_auth_method: "password" | "key_pair" | "oauth" | "pat" | "okta" | "mfa";
   sf_private_key: string;
   sf_private_key_passphrase: string;
   sf_oauth_token: string;
+  sf_pat: string; // Programmatic access token (sent in password field)
+  sf_passcode: string; // MFA passcode
+  sf_okta_url: string; // Okta SSO URL (sent as authenticator)
+  // Snowflake advanced: explicit host/protocol override (PrivateLink, China, gov, VPS)
+  snowflake_host: string;
+  snowflake_protocol: "https" | "http";
   // AWS IAM auth (PostgreSQL, MySQL on RDS, Redshift)
   iam_auth: boolean;
   aws_region: string;
@@ -802,6 +808,8 @@ const defaultForm: FormState = {
   ssh_password: "", ssh_private_key: "", ssh_key_passphrase: "",
   ssh_proxy_enabled: false, ssh_proxy_host: "", ssh_proxy_port: "3128",
   snowflake_auth_method: "password", sf_private_key: "", sf_private_key_passphrase: "", sf_oauth_token: "",
+  sf_pat: "", sf_passcode: "", sf_okta_url: "",
+  snowflake_host: "", snowflake_protocol: "https",
   iam_auth: false, aws_region: "us-east-1", aws_access_key_id: "", aws_secret_access_key: "",
   redshift_cluster_id: "", redshift_workgroup: "",
   azure_ad_auth: false, azure_tenant_id: "", azure_client_id: "", azure_client_secret: "",
@@ -833,8 +841,20 @@ function buildConnectionPreview(form: FormState): string {
       const chPort = form.port || (form.ch_protocol === "http" ? (form.ssl_enabled ? "8443" : "8123") : (form.ssl_enabled ? "9440" : "9000"));
       return `${chScheme}://${form.username || "default"}:****@${form.host || "host"}:${chPort}/${form.database || "default"}`;
     }
-    case "snowflake":
-      return `snowflake://${form.username || "user"}:****@${form.account || "account"}/${form.database || "db"}/${form.schema_name || "schema"}${form.warehouse ? `?warehouse=${form.warehouse}` : ""}`;
+    case "snowflake": {
+      const sfHost = form.snowflake_host.trim() || form.account || "account";
+      const sfParams: string[] = [];
+      if (form.warehouse) sfParams.push(`warehouse=${form.warehouse}`);
+      if (form.role) sfParams.push(`role=${form.role}`);
+      // Reflect the chosen auth method; secrets stay masked.
+      const sfAuthLabel: Record<FormState["snowflake_auth_method"], string> = {
+        password: "password", key_pair: "key_pair", oauth: "oauth",
+        pat: "pat", okta: "okta", mfa: "mfa",
+      };
+      sfParams.push(`authenticator=${sfAuthLabel[form.snowflake_auth_method]}`);
+      const sfQuery = sfParams.length ? `?${sfParams.join("&")}` : "";
+      return `snowflake://${form.username || "user"}:****@${sfHost}/${form.database || "db"}/${form.schema_name || "schema"}${sfQuery}`;
+    }
     case "bigquery":
       return `bigquery://${form.project || "project"}/${form.dataset || "dataset"}`;
     case "databricks":
@@ -987,6 +1007,23 @@ function validateForm(form: FormState): Record<string, string> {
     }
     if (form.snowflake_auth_method === "oauth" && !form.sf_oauth_token.trim()) {
       errors.sf_oauth_token = "OAuth access token is required";
+    }
+    if (form.snowflake_auth_method === "pat" && !form.sf_pat.trim()) {
+      errors.sf_pat = "programmatic access token is required";
+    }
+    if (form.snowflake_auth_method === "mfa" && !form.password.trim()) {
+      errors.password = "password is required for MFA auth";
+    }
+    if (form.snowflake_auth_method === "okta") {
+      if (!form.sf_okta_url.trim()) {
+        errors.sf_okta_url = "Okta URL is required";
+      } else if (!/^https:\/\/.+\.okta\.com/.test(form.sf_okta_url.trim())) {
+        errors.sf_okta_url = "must be an Okta URL (e.g., https://your-org.okta.com)";
+      }
+      if (!form.password.trim()) errors.password = "password is required for Okta SSO";
+    }
+    if (form.snowflake_protocol === "http" && !form.snowflake_host.trim()) {
+      errors.snowflake_host = "host override is required when protocol is http";
     }
   }
 
@@ -1147,14 +1184,45 @@ function buildCreatePayload(form: FormState): Record<string, unknown> {
     payload.tags = form.tags;
   }
 
-  // Snowflake auth method
+  // Snowflake auth method → maps to the gateway `authenticator` contract.
   if (form.db_type === "snowflake") {
-    payload.auth_method = form.snowflake_auth_method;
-    if (form.snowflake_auth_method === "key_pair") {
-      payload.private_key = form.sf_private_key;
-      if (form.sf_private_key_passphrase) payload.private_key_passphrase = form.sf_private_key_passphrase;
-    } else if (form.snowflake_auth_method === "oauth") {
-      payload.oauth_access_token = form.sf_oauth_token;
+    switch (form.snowflake_auth_method) {
+      case "key_pair":
+        payload.authenticator = "key_pair";
+        payload.private_key = form.sf_private_key;
+        if (form.sf_private_key_passphrase) payload.private_key_passphrase = form.sf_private_key_passphrase;
+        delete payload.password; // key-pair does not use a password
+        break;
+      case "oauth":
+        payload.authenticator = "oauth";
+        payload.access_token = form.sf_oauth_token;
+        delete payload.password; // OAuth does not use a password
+        break;
+      case "pat":
+        // Programmatic access token is supplied in the password field.
+        payload.authenticator = "pat";
+        payload.password = form.sf_pat;
+        break;
+      case "mfa":
+        payload.authenticator = "mfa";
+        payload.password = form.password;
+        if (form.sf_passcode) payload.passcode = form.sf_passcode;
+        break;
+      case "okta":
+        // Okta native SSO: the Okta URL itself is the authenticator value.
+        payload.authenticator = form.sf_okta_url.trim();
+        payload.password = form.password;
+        break;
+      case "password":
+      default:
+        payload.authenticator = "password";
+        payload.password = form.password;
+        break;
+    }
+    // Advanced host/protocol overrides (PrivateLink, China, gov, VPS).
+    if (form.snowflake_host.trim()) payload.snowflake_host = form.snowflake_host.trim();
+    if (form.snowflake_protocol && form.snowflake_protocol !== "https") {
+      payload.snowflake_protocol = form.snowflake_protocol;
     }
   }
 
@@ -1260,6 +1328,7 @@ function ConnectionFieldsForm({
   clearServerError: (key: string) => void;
 }) {
   const config = DB_CONFIGS[form.db_type];
+  const [showSnowflakeAdvanced, setShowSnowflakeAdvanced] = useState(false);
 
   /** Wrap onChange to also clear the server error for this field key. */
   function field(key: keyof FormState, update: (v: string) => void) {
@@ -1345,8 +1414,15 @@ function ConnectionFieldsForm({
         <FormInput label="username" value={form.username} onChange={field("username", (v) => setForm({ ...form, username: v }))} placeholder="ANALYTICS_USER" required {...fieldProps("username", formErrors, fieldRefs)} />
         <div className="col-span-2 mb-1">
           <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">authentication method</label>
-          <div className="flex gap-2">
-            {(["password", "key_pair", "oauth"] as const).map((method) => (
+          <div className="flex flex-wrap gap-2">
+            {([
+              ["password", "password"],
+              ["key_pair", "key pair (RSA)"],
+              ["oauth", "OAuth"],
+              ["pat", "programmatic access token"],
+              ["okta", "Okta SSO"],
+              ["mfa", "username+password+MFA"],
+            ] as const).map(([method, label]) => (
               <button
                 key={method}
                 type="button"
@@ -1357,7 +1433,7 @@ function ConnectionFieldsForm({
                     : "border-[var(--color-border)] text-[var(--color-text-dim)] hover:border-[var(--color-border-hover)]"
                 }`}
               >
-                {method === "password" ? "password" : method === "key_pair" ? "key pair (RSA)" : "OAuth"}
+                {label}
               </button>
             ))}
           </div>
@@ -1384,7 +1460,7 @@ function ConnectionFieldsForm({
             />
             <FormInput label="key passphrase" value={form.sf_private_key_passphrase} onChange={(v) => setForm({ ...form, sf_private_key_passphrase: v })} type="password" hint="leave empty if key is unencrypted" className="col-span-2" />
           </>
-        ) : (
+        ) : form.snowflake_auth_method === "oauth" ? (
           <>
             <FormInput label="OAuth access token" value={form.sf_oauth_token} onChange={(v) => setForm({ ...form, sf_oauth_token: v })} type="password" required className="col-span-2" hint="from your identity provider (Okta, Azure AD, etc.)" {...fieldProps("sf_oauth_token", formErrors, fieldRefs)} />
             <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
@@ -1392,11 +1468,76 @@ function ConnectionFieldsForm({
               <div><span className="text-[var(--color-text-muted)]">local dev:</span> Use Snowflake&apos;s built-in SNOWFLAKE$LOCAL_APPLICATION integration for quick setup without admin involvement.</div>
             </div>
           </>
+        ) : form.snowflake_auth_method === "pat" ? (
+          <>
+            <FormInput label="programmatic access token" value={form.sf_pat} onChange={field("sf_pat", (v) => setForm({ ...form, sf_pat: v }))} type="password" required className="col-span-2" hint="Snowflake PAT (Admin → Users → Programmatic Access Tokens)" {...fieldProps("sf_pat", formErrors, fieldRefs)} />
+          </>
+        ) : form.snowflake_auth_method === "mfa" ? (
+          <>
+            <FormInput label="password" value={form.password} onChange={field("password", (v) => setForm({ ...form, password: v }))} type="password" required className="col-span-2" {...fieldProps("password", formErrors, fieldRefs)} />
+            <FormInput label="MFA passcode" value={form.sf_passcode} onChange={(v) => setForm({ ...form, sf_passcode: v })} placeholder="123456" className="col-span-2" hint="optional — TOTP passcode from your authenticator app. leave empty to receive a Duo push." />
+          </>
+        ) : (
+          <>
+            <FormInput label="Okta URL" value={form.sf_okta_url} onChange={field("sf_okta_url", (v) => setForm({ ...form, sf_okta_url: v }))} placeholder="https://your-org.okta.com" required className="col-span-2" hint="your Okta organization URL — sent as the Snowflake authenticator" {...fieldProps("sf_okta_url", formErrors, fieldRefs)} />
+            <FormInput label="password" value={form.password} onChange={field("password", (v) => setForm({ ...form, password: v }))} type="password" required className="col-span-2" {...fieldProps("password", formErrors, fieldRefs)} />
+            <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
+              <div><span className="text-[var(--color-text-muted)]">native SSO:</span> Snowflake authenticates directly against Okta using your Okta username and password. Requires Snowflake to be federated with this Okta org.</div>
+            </div>
+          </>
         )}
         <FormInput label="warehouse" value={form.warehouse} onChange={(v) => setForm({ ...form, warehouse: v })} placeholder="COMPUTE_WH" hint="optional — default warehouse" />
         <FormInput label="database" value={form.database} onChange={(v) => setForm({ ...form, database: v })} placeholder="PROD_DB" hint="optional — default database" />
         <FormInput label="schema" value={form.schema_name} onChange={(v) => setForm({ ...form, schema_name: v })} placeholder="PUBLIC" hint="optional — default schema" />
         <FormInput label="role" value={form.role} onChange={(v) => setForm({ ...form, role: v })} placeholder="ANALYST_ROLE" hint="optional — Snowflake role" />
+        <div className="col-span-2">
+          <button
+            type="button"
+            onClick={() => setShowSnowflakeAdvanced(!showSnowflakeAdvanced)}
+            className="flex items-center gap-1.5 text-[12px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors tracking-wider mb-2"
+          >
+            {showSnowflakeAdvanced ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+            advanced — host override
+            {(form.snowflake_host.trim() !== "" || form.snowflake_protocol !== "https") && (
+              <span className="text-[var(--color-success)] text-[11px] ml-1">
+                {[form.snowflake_host.trim() !== "" && "host", form.snowflake_protocol !== "https" && "http"].filter(Boolean).join(" + ")}
+              </span>
+            )}
+          </button>
+          {showSnowflakeAdvanced && (
+            <div className="animate-fade-in grid grid-cols-2 gap-3">
+              <FormInput
+                label="host override"
+                value={form.snowflake_host}
+                onChange={field("snowflake_host", (v) => setForm({ ...form, snowflake_host: v }))}
+                placeholder="org-account.privatelink.snowflakecomputing.com"
+                hint="explicit host — for PrivateLink, China (.cn), SnowGov, or VPS"
+                className="col-span-2"
+                {...fieldProps("snowflake_host", formErrors, fieldRefs)}
+              />
+              <div className="col-span-2">
+                <label className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">protocol</label>
+                <div className="flex gap-2">
+                  {(["https", "http"] as const).map((proto) => (
+                    <button
+                      key={proto}
+                      type="button"
+                      onClick={() => setForm({ ...form, snowflake_protocol: proto })}
+                      className={`px-2.5 py-1 text-[12px] tracking-wider border transition-all ${
+                        form.snowflake_protocol === proto
+                          ? "border-[var(--color-text)] text-[var(--color-text)]"
+                          : "border-[var(--color-border)] text-[var(--color-text-dim)] hover:border-[var(--color-border-hover)]"
+                      }`}
+                    >
+                      {proto}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-[11px] text-[var(--color-text-dim)] mt-1 tracking-wider opacity-60">defaults to https — leave host override blank unless you need a non-standard endpoint</p>
+              </div>
+            </div>
+          )}
+        </div>
         <div className="col-span-2 px-3 py-2 bg-[var(--color-bg)]/50 border border-[var(--color-border)] border-dashed text-[11px] text-[var(--color-text-dim)] tracking-wider space-y-1">
           <div><span className="text-[var(--color-text-muted)]">network policy:</span> Add this server&apos;s IP to ALLOWED_IP_LIST. Snowflake Admin → Security → Network Policies.</div>
           <div><span className="text-[var(--color-text-muted)]">private link:</span> For AWS PrivateLink or Azure Private Link, use the private account URL (e.g., org-account.privatelink.snowflakecomputing.com).</div>
@@ -2494,6 +2635,19 @@ export default function ConnectionsPage() {
       warehouse: conn.warehouse || "",
       schema_name: conn.schema_name || "",
       role: conn.role || "",
+      // Snowflake auth method — derived from the gateway `authenticator` value.
+      snowflake_auth_method: (() => {
+        const a = String((conn as any).authenticator || "").toLowerCase();
+        if (a.includes("okta.com")) return "okta";
+        if (a === "key_pair" || a === "snowflake_jwt") return "key_pair";
+        if (a === "oauth") return "oauth";
+        if (a === "pat") return "pat";
+        if (a === "mfa" || a === "username_password_mfa") return "mfa";
+        return "password";
+      })(),
+      sf_okta_url: String((conn as any).authenticator || "").includes("okta.com") ? String((conn as any).authenticator) : "",
+      snowflake_host: (conn as any).snowflake_host || "",
+      snowflake_protocol: (conn as any).snowflake_protocol === "http" ? "http" : "https",
       project: conn.project || "",
       dataset: conn.dataset || "",
       bq_location: (conn as any).location || "",

--- a/signalpilot/web/lib/types.ts
+++ b/signalpilot/web/lib/types.ts
@@ -97,6 +97,11 @@ export interface ConnectionInfo {
   warehouse: string | null;
   schema_name: string | null;
   role: string | null;
+  // Snowflake auth + host/protocol overrides (gateway contract)
+  authenticator: string | null;
+  passcode: string | null;
+  snowflake_host: string | null;
+  snowflake_protocol: "https" | "http" | null;
   // BigQuery
   project: string | null;
   dataset: string | null;


### PR DESCRIPTION
Add an authenticator dispatch to the Snowflake connector covering oauth, key_pair, pat (programmatic access token), mfa, password, and Okta native SSO (authenticator = Okta URL), with back-compat for an oauth token or private key alone. Includes connection model fields, connection-string handling, connection testing, and the web connections UI for selecting the auth method.