### PR TITLE
Fix orchestrated analysis delivery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,5 @@ benchmark/fix_starting_dbs.*
 __pycache__
 *.pyc
 node_modules
+.next
+signalpilot/web/.next

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -24,6 +24,7 @@ services:
       SP_GATEWAY_INTERNAL_URL: http://gateway:3300
       SP_WEB_URL: ${SP_WEB_URL:-http://localhost:3200}
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/home/notebook/.claude}
+      SIGNALPILOT_ANALYSIS_AGENT_MODEL: ${SIGNALPILOT_ANALYSIS_AGENT_MODEL:-claude-sonnet-4-5-20250929}
     volumes:
       - signalpilot-workspace:/workspace
       - signalpilot-shared:/shared:ro
@@ -46,6 +47,7 @@ services:
       SP_NOTEBOOK_DIRECT_URL: http://notebook:2718
       SP_K8S_HOST: ""
       KUBECONFIG: ""
+      SIGNALPILOT_DELIVERY_MODEL: ${SIGNALPILOT_DELIVERY_MODEL:-claude-sonnet-4-5-20250929}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -8,6 +8,9 @@
 services:
   # ─── Notebook Server (replaces K8s pods) ─────────────────────────
   notebook:
+    env_file:
+      - path: ./.slack.local.env
+        required: false
     build:
       context: ./signalpilot/notebook-server
       dockerfile: Dockerfile
@@ -21,8 +24,6 @@ services:
       SP_GATEWAY_INTERNAL_URL: http://gateway:3300
       SP_WEB_URL: ${SP_WEB_URL:-http://localhost:3200}
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/home/notebook/.claude}
-      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:
       - signalpilot-workspace:/workspace
       - signalpilot-shared:/shared:ro
@@ -37,6 +38,9 @@ services:
 
   # ─── Override gateway to use local notebook instead of K8s ───────
   gateway:
+    env_file:
+      - path: ./.slack.local.env
+        required: false
     environment:
       SP_NOTEBOOK_UPSTREAM_MODE: direct
       SP_NOTEBOOK_DIRECT_URL: http://notebook:2718

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       dockerfile: ../../Dockerfile.gateway
     ports:
       - "3300:3300"
+    env_file:
+      - path: ./.slack.local.env
+        required: false
     environment:
       DATABASE_URL: postgresql+asyncpg://signalpilot:changeme_dev_only@db:5432/signalpilot
       SP_DATA_DIR: /data
@@ -59,6 +62,7 @@ services:
       SP_WEB_URL: http://localhost:3200
       SIGNALPILOT_NOTEBOOK_INTERNAL_URL: http://notebook:2718
       SIGNALPILOT_NOTEBOOK_PUBLIC_URL: http://localhost:3200/notebook
+      SIGNALPILOT_DELIVERY_MODEL: ${SIGNALPILOT_DELIVERY_MODEL:-claude-sonnet-4-5-20250929}
       # Sandbox
       SP_SANDBOX_MANAGER_URL: http://sandbox:8080
       SP_SANDBOX_ENABLED: "true"
@@ -92,6 +96,9 @@ services:
       dockerfile: Dockerfile
     ports:
       - "127.0.0.1:2718:2718"
+    env_file:
+      - path: ./.slack.local.env
+        required: false
     entrypoint:
       - sh
       - -c
@@ -109,6 +116,7 @@ services:
       SP_GATEWAY_INTERNAL_URL: http://gateway:3300
       SP_WEB_URL: ${SP_WEB_URL:-http://localhost:3200}
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/home/notebook/.claude}
+      SIGNALPILOT_ANALYSIS_AGENT_MODEL: ${SIGNALPILOT_ANALYSIS_AGENT_MODEL:-claude-sonnet-4-5-20250929}
     volumes:
       - signalpilot-workspace:/workspace
       - signalpilot-shared:/shared:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,8 +109,6 @@ services:
       SP_GATEWAY_INTERNAL_URL: http://gateway:3300
       SP_WEB_URL: ${SP_WEB_URL:-http://localhost:3200}
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/home/notebook/.claude}
-      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:
       - signalpilot-workspace:/workspace
       - signalpilot-shared:/shared:ro

--- a/signalpilot/gateway/gateway/analysis_delivery/__init__.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/__init__.py
@@ -1,0 +1,47 @@
+"""Shared orchestration helpers for notebook-backed external analysis."""
+
+from .preflight import (
+    AnalysisPreflightDecision,
+    AnalysisPreflightKind,
+    classify_analysis_request,
+)
+from .progress import (
+    ANALYSIS_INITIAL_PROGRESS_TEXT,
+    SlackTraceProgressReporter,
+    render_slack_final_message,
+    render_slack_progress_message,
+)
+from .renderer import (
+    DeliveryRenderer,
+    DeliveryResult,
+    delivery_result_to_status,
+    render_delivery,
+)
+from .trace_loader import (
+    DeliveryPacket,
+    FinalStatement,
+    WorkerPlan,
+    WorkerProgress,
+    load_delivery_packet,
+    load_delivery_packet_from_events,
+)
+
+__all__ = [
+    "ANALYSIS_INITIAL_PROGRESS_TEXT",
+    "AnalysisPreflightDecision",
+    "AnalysisPreflightKind",
+    "DeliveryPacket",
+    "DeliveryRenderer",
+    "DeliveryResult",
+    "FinalStatement",
+    "SlackTraceProgressReporter",
+    "WorkerPlan",
+    "WorkerProgress",
+    "classify_analysis_request",
+    "delivery_result_to_status",
+    "load_delivery_packet",
+    "load_delivery_packet_from_events",
+    "render_delivery",
+    "render_slack_final_message",
+    "render_slack_progress_message",
+]

--- a/signalpilot/gateway/gateway/analysis_delivery/preflight.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/preflight.py
@@ -1,0 +1,178 @@
+"""Preflight request classification for external analysis channels."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class AnalysisPreflightKind(StrEnum):
+    DIRECT = "direct"
+    AMBIGUOUS = "ambiguous"
+    ANALYZE = "analyze"
+
+
+@dataclass(frozen=True)
+class AnalysisPreflightDecision:
+    kind: AnalysisPreflightKind
+    response: str | None = None
+
+
+_GREETING_PATTERNS = (
+    r"hi+",
+    r"hello+",
+    r"hey+",
+    r"yo+",
+    r"good\s+(morning|afternoon|evening)",
+)
+_THANKS_PATTERNS = (
+    r"thanks?",
+    r"thank\s+you",
+    r"ty",
+    r"ok(?:ay)?",
+    r"cool",
+)
+_CLEAR_ACTION_TERMS = {
+    "analyze",
+    "analyse",
+    "compare",
+    "calculate",
+    "compute",
+    "find",
+    "show",
+    "plot",
+    "chart",
+    "rank",
+    "summarize",
+    "summarise",
+    "breakdown",
+    "break",
+    "trend",
+    "forecast",
+    "estimate",
+    "evaluate",
+    "investigate",
+    "explain",
+}
+_DATA_TERMS = {
+    "arr",
+    "booking",
+    "bookings",
+    "churn",
+    "cohort",
+    "conversion",
+    "cost",
+    "customer",
+    "customers",
+    "data",
+    "database",
+    "db",
+    "ebitda",
+    "gmv",
+    "growth",
+    "lead",
+    "leads",
+    "margin",
+    "marts",
+    "metric",
+    "metrics",
+    "mrr",
+    "orders",
+    "pipeline",
+    "profit",
+    "revenue",
+    "sales",
+    "schema",
+    "table",
+    "tables",
+    "transfer",
+    "transfers",
+    "usage",
+}
+_SPECIFICITY_TERMS = {
+    "by",
+    "for",
+    "from",
+    "last",
+    "monthly",
+    "quarter",
+    "quarterly",
+    "q1",
+    "q2",
+    "q3",
+    "q4",
+    "this",
+    "top",
+    "trend",
+    "vs",
+    "versus",
+    "week",
+    "weekly",
+    "year",
+    "yearly",
+    "ytd",
+}
+
+DIRECT_GREETING_RESPONSE = (
+    "Hi. Send me a specific data question and I will run it through SignalPilot."
+)
+DIRECT_THANKS_RESPONSE = (
+    "You are welcome. Send a specific data question when you want me to analyze something."
+)
+AMBIGUOUS_ANALYSIS_RESPONSE = (
+    "SignalPilot needs a fresh, specific analysis request before it starts a notebook run. "
+    "For example: `Compare monthly revenue by product for Q2 and show the top drivers.`"
+)
+
+
+def classify_analysis_request(prompt: str) -> AnalysisPreflightDecision:
+    normalized = _normalize(prompt)
+    if not normalized:
+        return AnalysisPreflightDecision(
+            AnalysisPreflightKind.DIRECT,
+            "Ask me a specific data question and I will run it through SignalPilot.",
+        )
+
+    if _matches_any(normalized, _GREETING_PATTERNS):
+        return AnalysisPreflightDecision(AnalysisPreflightKind.DIRECT, DIRECT_GREETING_RESPONSE)
+    if _matches_any(normalized, _THANKS_PATTERNS):
+        return AnalysisPreflightDecision(AnalysisPreflightKind.DIRECT, DIRECT_THANKS_RESPONSE)
+
+    words = re.findall(r"[a-z0-9_.$%-]+", normalized)
+    word_set = set(words)
+    has_data_term = bool(word_set & _DATA_TERMS) or _looks_like_table_reference(normalized)
+    has_clear_action = bool(word_set & _CLEAR_ACTION_TERMS)
+    has_specificity = bool(word_set & _SPECIFICITY_TERMS) or _has_date_or_number(normalized)
+
+    if has_clear_action and (has_data_term or len(words) >= 3):
+        return AnalysisPreflightDecision(AnalysisPreflightKind.ANALYZE)
+    if has_data_term and has_specificity and len(words) >= 4:
+        return AnalysisPreflightDecision(AnalysisPreflightKind.ANALYZE)
+    if normalized.endswith("?") and has_data_term and len(words) >= 4:
+        return AnalysisPreflightDecision(AnalysisPreflightKind.ANALYZE)
+    if has_data_term:
+        return AnalysisPreflightDecision(AnalysisPreflightKind.AMBIGUOUS, AMBIGUOUS_ANALYSIS_RESPONSE)
+
+    if len(words) <= 3:
+        return AnalysisPreflightDecision(
+            AnalysisPreflightKind.DIRECT,
+            "Send me a specific data question and I will run it through SignalPilot.",
+        )
+    return AnalysisPreflightDecision(AnalysisPreflightKind.AMBIGUOUS, AMBIGUOUS_ANALYSIS_RESPONSE)
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.fullmatch(pattern, value) for pattern in patterns)
+
+
+def _looks_like_table_reference(value: str) -> bool:
+    return bool(re.search(r"\b[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\b", value))
+
+
+def _has_date_or_number(value: str) -> bool:
+    return bool(re.search(r"\b(?:20\d{2}|q[1-4]|\d+(?:\.\d+)?%?)\b", value))

--- a/signalpilot/gateway/gateway/analysis_delivery/progress.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/progress.py
@@ -1,0 +1,141 @@
+"""Progress and final-message formatting for delivery channels."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .renderer import DeliveryResult
+from .trace_loader import DeliveryPacket, WorkerProgress, load_delivery_packet
+
+ANALYSIS_INITIAL_PROGRESS_TEXT = "Analyzing your request..."
+SLACK_TEXT_LIMIT = 35000
+LOGGER = logging.getLogger(__name__)
+
+
+class SlackTraceProgressReporter:
+    """Edit one Slack message from worker-authored PLAN/PROGRESS trace entries."""
+
+    def __init__(
+        self,
+        *,
+        slack: Any,
+        session_factory: async_sessionmaker[AsyncSession],
+        org_id: str,
+        user_id: str,
+        thread_id: str,
+        source_prompt: str,
+        channel_id: str,
+        message_ts: str,
+        interval_seconds: float = 15.0,
+    ) -> None:
+        self.slack = slack
+        self.session_factory = session_factory
+        self.org_id = org_id
+        self.user_id = user_id
+        self.thread_id = thread_id
+        self.source_prompt = source_prompt
+        self.channel_id = channel_id
+        self.message_ts = message_ts
+        self.interval_seconds = max(float(interval_seconds or 15.0), 0.1)
+        self.previous_text = ANALYSIS_INITIAL_PROGRESS_TEXT
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=self.interval_seconds)
+                continue
+            except TimeoutError:
+                pass
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                LOGGER.info("Slack trace progress reporter tick failed: %s", exc, exc_info=True)
+
+    async def _tick(self) -> None:
+        async with self.session_factory() as session:
+            packet = await load_delivery_packet(
+                session,
+                org_id=self.org_id,
+                user_id=self.user_id,
+                thread_id=self.thread_id,
+                user_request=self.source_prompt,
+            )
+        text = render_slack_progress_message(packet)
+        if text == self.previous_text:
+            return
+        await self.slack.update_message(channel=self.channel_id, ts=self.message_ts, text=text)
+        self.previous_text = text
+
+
+def render_slack_progress_message(packet: DeliveryPacket) -> str:
+    if packet.plan is None:
+        return ANALYSIS_INITIAL_PROGRESS_TEXT
+    lines = ["*Analyzing your request...*", *_checklist_lines(packet.plan.steps, packet.latest_progress)]
+    if packet.latest_progress and packet.latest_progress.status:
+        lines.append("")
+        lines.append(packet.latest_progress.status)
+    return _clip_text("\n".join(lines))
+
+
+def render_slack_final_message(
+    packet: DeliveryPacket,
+    delivery: DeliveryResult,
+    *,
+    trail_url: str | None = None,
+) -> str:
+    completed = packet.status == "done"
+    parts: list[str] = ["*Analysis complete*" if completed else "*Analysis failed*"]
+    if packet.plan and packet.plan.steps:
+        parts.extend(_checklist_lines(packet.plan.steps, packet.latest_progress, complete_all=completed))
+        parts.append("")
+    answer = _to_slack_mrkdwn(delivery.slack_message or delivery.final_answer or delivery.summary)
+    parts.append(answer or "I finished the analysis, but there was no written answer in the result.")
+    confidence = delivery.confidence_score
+    if confidence is None and packet.final_statement is not None:
+        confidence = packet.final_statement.confidence_score
+    if confidence is not None:
+        parts.append(f"*Confidence:* {confidence}")
+    resolved_trail = trail_url or packet.trail_url
+    if resolved_trail:
+        parts.append(f"*Notebook trail:* {_slack_link(resolved_trail, 'Open authenticated notebook')}")
+    return _clip_text("\n\n".join(part for part in parts if part))
+
+
+def _checklist_lines(
+    steps: list[str],
+    progress: WorkerProgress | None,
+    *,
+    complete_all: bool = False,
+) -> list[str]:
+    completed = set(progress.completed_steps if progress else [])
+    current = progress.current_step if progress else ""
+    lines: list[str] = []
+    for step in steps:
+        checked = complete_all or step in completed
+        marker = "x" if checked else " "
+        suffix = " (current)" if current and step == current and not checked and not complete_all else ""
+        lines.append(f"- [{marker}] {step}{suffix}")
+    return lines
+
+
+def _slack_link(url: str, label: str) -> str:
+    return f"<{url.replace('>', '%3E')}|{label}>"
+
+
+def _to_slack_mrkdwn(text: str) -> str:
+    text = re.sub(r"\*\*([^*\n]+?)\*\*", r"*\1*", text)
+    text = re.sub(r"__([^_\n]+?)__", r"*\1*", text)
+    return re.sub(r"\[([^\]\n]+)\]\((https?://[^)\s]+)\)", r"<\2|\1>", text)
+
+
+def _clip_text(text: str) -> str:
+    if len(text) <= SLACK_TEXT_LIMIT:
+        return text
+    return text[: SLACK_TEXT_LIMIT - 20].rstrip() + "\n\n... truncated"

--- a/signalpilot/gateway/gateway/analysis_delivery/renderer.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/renderer.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import httpx
 
+from gateway.string_utils import string_value as _string
+
 from .trace_loader import DeliveryPacket
 
 LOGGER = logging.getLogger(__name__)
@@ -18,6 +20,10 @@ LOGGER = logging.getLogger(__name__)
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 DEFAULT_DELIVERY_MODEL = "claude-sonnet-4-5-20250929"
+_PLACEHOLDER_CHART_TITLE_RE = re.compile(
+    r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?",
+    flags=re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -125,7 +131,7 @@ def fallback_delivery(packet: DeliveryPacket) -> DeliveryResult:
         final_answer=_string(notebook_outputs.get("finalAnswer") or notebook_outputs.get("final_answer")) or fallback_text,
         gotchas=gotchas,
         analysis_method=method,
-        notion_charts=[dict(chart) for chart in packet.charts],
+        notion_charts=[_clean_chart_labels(chart) for chart in packet.charts],
         confidence_score=packet.final_statement.confidence_score if packet.final_statement else None,
     )
 
@@ -175,7 +181,9 @@ def _delivery_system_prompt() -> str:
         "summary, slackMessage, notionComment, finalAnswer, gotchas, analysisMethod, notionCharts. "
         "notionCharts must reuse packet chart URLs. Include at least the first packet chart when charts are present, "
         "and include the first two packet charts when two are present for the Notion page. You may add concise "
-        "captions only when supported by the packet."
+        "captions only when supported by the packet. Do not label charts as Chart 1, Chart 2, Figure 1, "
+        "Notebook image 1, or similarly generic placeholders; leave chart title/caption fields empty when "
+        "the packet does not support a meaningful label."
     )
 
 
@@ -195,8 +203,8 @@ def _delivery_result_from_payload(payload: dict[str, Any], packet: DeliveryPacke
         key = _string(chart.get("url")) or _string(chart.get("title"))
         if allowed_chart_keys and key not in allowed_chart_keys:
             continue
-        charts.append(dict(chart))
-    packet_charts = [dict(chart) for chart in packet.charts if isinstance(chart, dict)]
+        charts.append(_clean_chart_labels(chart))
+    packet_charts = [_clean_chart_labels(chart) for chart in packet.charts if isinstance(chart, dict)]
     if packet_charts:
         seen_chart_keys = {_string(chart.get("url")) or _string(chart.get("title")) for chart in charts}
         for chart in packet_charts:
@@ -251,6 +259,19 @@ def _clip(value: str, limit: int) -> str:
     return value[: max(0, limit - 3)].rstrip() + "..."
 
 
+def _is_placeholder_chart_label(value: str) -> bool:
+    return bool(_PLACEHOLDER_CHART_TITLE_RE.fullmatch(value.strip()))
+
+
+def _clean_chart_labels(chart: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(chart)
+    for key in ("title", "caption", "altText", "alt_text"):
+        value = _string(cleaned.get(key)).strip()
+        if value and _is_placeholder_chart_label(value):
+            cleaned[key] = ""
+    return cleaned
+
+
 def _compact_bullet_answer(content: str, max_bullets: int = 6) -> str:
     stripped = re.sub(r"^Here's what I found:\s*", "", content.strip(), flags=re.IGNORECASE)
     lines = [line.strip() for line in stripped.splitlines() if line.strip()]
@@ -265,7 +286,3 @@ def _compact_bullet_answer(content: str, max_bullets: int = 6) -> str:
         bullets = re.split(r"(?<=[.!?])\s+", stripped)
     unique = [bullet for index, bullet in enumerate(bullets) if bullet and bullets.index(bullet) == index]
     return "\n".join(f"- {bullet}" for bullet in unique[:max_bullets])
-
-
-def _string(value: Any) -> str:
-    return value if isinstance(value, str) else ""

--- a/signalpilot/gateway/gateway/analysis_delivery/renderer.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/renderer.py
@@ -173,7 +173,9 @@ def _delivery_system_prompt() -> str:
         "facts joined together. "
         "Use gotchas for caveats instead of burying them in the answer. Return only valid JSON with keys: "
         "summary, slackMessage, notionComment, finalAnswer, gotchas, analysisMethod, notionCharts. "
-        "notionCharts must reuse packet chart URLs and may add concise captions only when supported by the packet."
+        "notionCharts must reuse packet chart URLs. Include at least the first packet chart when charts are present, "
+        "and include the first two packet charts when two are present for the Notion page. You may add concise "
+        "captions only when supported by the packet."
     )
 
 
@@ -194,6 +196,15 @@ def _delivery_result_from_payload(payload: dict[str, Any], packet: DeliveryPacke
         if allowed_chart_keys and key not in allowed_chart_keys:
             continue
         charts.append(dict(chart))
+    packet_charts = [dict(chart) for chart in packet.charts if isinstance(chart, dict)]
+    if packet_charts:
+        seen_chart_keys = {_string(chart.get("url")) or _string(chart.get("title")) for chart in charts}
+        for chart in packet_charts:
+            chart_key = _string(chart.get("url")) or _string(chart.get("title"))
+            if not chart_key or chart_key in seen_chart_keys:
+                continue
+            charts.append(chart)
+            seen_chart_keys.add(chart_key)
     return DeliveryResult(
         summary=_string(payload.get("summary")).strip(),
         slack_message=_string(payload.get("slackMessage")).strip(),

--- a/signalpilot/gateway/gateway/analysis_delivery/renderer.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/renderer.py
@@ -1,0 +1,260 @@
+"""Render shared analysis delivery content from a trace loader packet."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from .trace_loader import DeliveryPacket
+
+LOGGER = logging.getLogger(__name__)
+
+_ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+_ANTHROPIC_VERSION = "2023-06-01"
+DEFAULT_DELIVERY_MODEL = "claude-sonnet-4-5-20250929"
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    summary: str = ""
+    slack_message: str = ""
+    notion_comment: str = ""
+    final_answer: str = ""
+    gotchas: list[str] = field(default_factory=list)
+    analysis_method: str = ""
+    notion_charts: list[dict[str, Any]] = field(default_factory=list)
+    confidence_score: float | None = None
+
+
+class DeliveryRenderer:
+    def __init__(
+        self,
+        *,
+        provider: str = "anthropic",
+        model: str | None = None,
+        timeout_seconds: float = 15.0,
+        api_key: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.provider = (provider or "anthropic").strip().lower()
+        self.model = (model or os.getenv("SIGNALPILOT_DELIVERY_MODEL") or DEFAULT_DELIVERY_MODEL).strip()
+        self.timeout_seconds = max(float(timeout_seconds or 15.0), 0.1)
+        self.api_key = api_key if api_key is not None else os.getenv("ANTHROPIC_API_KEY")
+        self._http_client = http_client
+
+    async def render(self, packet: DeliveryPacket) -> DeliveryResult:
+        fallback = fallback_delivery(packet)
+        if self.provider != "anthropic" or not self.model or not self.api_key:
+            return fallback
+        try:
+            rendered = await self._anthropic_render(packet)
+        except Exception as exc:
+            LOGGER.info("Analysis delivery renderer unavailable; using FINAL_STATEMENT fallback: %s", exc)
+            return fallback
+        return rendered or fallback
+
+    async def _anthropic_render(self, packet: DeliveryPacket) -> DeliveryResult | None:
+        request_body = {
+            "model": self.model,
+            "max_tokens": 1400,
+            "temperature": 0,
+            "system": _delivery_system_prompt(),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": json.dumps(packet.to_model_payload(), ensure_ascii=True, separators=(",", ":")),
+                }
+            ],
+        }
+        headers = {
+            "x-api-key": self.api_key or "",
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        if self._http_client is not None:
+            response = await self._http_client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+            response.raise_for_status()
+            data = response.json()
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                response = await client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+                response.raise_for_status()
+                data = response.json()
+        text = _anthropic_text(data)
+        if not text:
+            return None
+        parsed = _parse_json_object(text)
+        return _delivery_result_from_payload(parsed, packet)
+
+
+async def render_delivery(
+    packet: DeliveryPacket,
+    *,
+    renderer: DeliveryRenderer | None = None,
+) -> DeliveryResult:
+    return await (renderer or DeliveryRenderer()).render(packet)
+
+
+def fallback_delivery(packet: DeliveryPacket) -> DeliveryResult:
+    statement = packet.final_statement.statement if packet.final_statement else ""
+    notebook_outputs = packet.final_notebook_outputs
+    fallback_text_raw = (
+        statement
+        or _string(notebook_outputs.get("finalAnswer") or notebook_outputs.get("final_answer"))
+        or _string(notebook_outputs.get("summary"))
+        or ("I could not complete the analysis." if packet.status == "failed" else "The analysis completed.")
+    )
+    fallback_text = _compact_bullet_answer(fallback_text_raw) or fallback_text_raw
+    gotchas = list(packet.final_statement.caveats if packet.final_statement else [])
+    for error in packet.known_errors:
+        if error and error not in gotchas:
+            gotchas.append(error)
+    method = "; ".join(packet.final_statement.handoff_notes) if packet.final_statement else ""
+    if not method:
+        method = _string(notebook_outputs.get("analysisMethod") or notebook_outputs.get("analysis_method"))
+    return DeliveryResult(
+        summary=_clip(_string(notebook_outputs.get("summary")) or fallback_text, 500),
+        slack_message=fallback_text,
+        notion_comment=_clip(_string(notebook_outputs.get("notionComment") or notebook_outputs.get("notion_comment")) or fallback_text, 1200),
+        final_answer=_string(notebook_outputs.get("finalAnswer") or notebook_outputs.get("final_answer")) or fallback_text,
+        gotchas=gotchas,
+        analysis_method=method,
+        notion_charts=[dict(chart) for chart in packet.charts],
+        confidence_score=packet.final_statement.confidence_score if packet.final_statement else None,
+    )
+
+
+def delivery_result_to_status(
+    result: DeliveryResult,
+    packet: DeliveryPacket,
+    *,
+    base_status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    status = dict(base_status or {})
+    status.update(
+        {
+            "status": "Done" if packet.status == "done" else status.get("status", "Done"),
+            "summary": result.summary,
+            "slackMessage": result.slack_message,
+            "notionComment": result.notion_comment,
+            "finalAnswer": result.final_answer,
+            "gotchas": result.gotchas,
+            "analysisMethod": result.analysis_method,
+            "notionCharts": result.notion_charts,
+        }
+    )
+    if result.confidence_score is not None:
+        status["confidenceScore"] = result.confidence_score
+    elif packet.final_statement and packet.final_statement.confidence_score is not None:
+        status["confidenceScore"] = packet.final_statement.confidence_score
+    if packet.trail_url:
+        status["trailUrl"] = packet.trail_url
+    return status
+
+
+def _delivery_system_prompt() -> str:
+    return (
+        "You render SignalPilot analysis delivery copy from a JSON packet. "
+        "Use only facts present in the packet. Do not add external facts, numbers, "
+        "methodology, caveats, chart interpretations, or conclusions that are not in the packet. "
+        "Preserve the worker's meaning. The user audits the final chat thread, so render "
+        "slackMessage, notionComment, and finalAnswer as concise user-friendly Markdown bullets, "
+        "not as one dense paragraph and never as raw FINAL_STATEMENT JSON. Prefer 3-6 bullets. "
+        "Each bullet must be on its own line and must start with '- '. Split independent findings, "
+        "metrics, comparisons, caveats, and dataset-scope notes into separate bullets. If the worker "
+        "statement contains several sentences, do not keep them inside one bullet; turn the key "
+        "sentences into separate bullets. Do not write paragraph-style bullets with multiple unrelated "
+        "facts joined together. "
+        "Use gotchas for caveats instead of burying them in the answer. Return only valid JSON with keys: "
+        "summary, slackMessage, notionComment, finalAnswer, gotchas, analysisMethod, notionCharts. "
+        "notionCharts must reuse packet chart URLs and may add concise captions only when supported by the packet."
+    )
+
+
+def _delivery_result_from_payload(payload: dict[str, Any], packet: DeliveryPacket) -> DeliveryResult | None:
+    required = ("summary", "slackMessage", "notionComment", "finalAnswer", "gotchas", "analysisMethod", "notionCharts")
+    if any(key not in payload for key in required):
+        return None
+    gotchas_raw = payload.get("gotchas")
+    charts_raw = payload.get("notionCharts")
+    if not isinstance(gotchas_raw, list) or not isinstance(charts_raw, list):
+        return None
+    allowed_chart_keys = {_string(chart.get("url")) or _string(chart.get("title")) for chart in packet.charts if isinstance(chart, dict)}
+    charts: list[dict[str, Any]] = []
+    for chart in charts_raw:
+        if not isinstance(chart, dict):
+            continue
+        key = _string(chart.get("url")) or _string(chart.get("title"))
+        if allowed_chart_keys and key not in allowed_chart_keys:
+            continue
+        charts.append(dict(chart))
+    return DeliveryResult(
+        summary=_string(payload.get("summary")).strip(),
+        slack_message=_string(payload.get("slackMessage")).strip(),
+        notion_comment=_string(payload.get("notionComment")).strip(),
+        final_answer=_string(payload.get("finalAnswer")).strip(),
+        gotchas=[_string(item).strip() for item in gotchas_raw if _string(item).strip()],
+        analysis_method=_string(payload.get("analysisMethod")).strip(),
+        notion_charts=charts[:3],
+        confidence_score=packet.final_statement.confidence_score if packet.final_statement else None,
+    )
+
+
+def _anthropic_text(data: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for item in data.get("content") or []:
+        if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    return "\n".join(parts).strip()
+
+
+def _parse_json_object(text: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    stripped = text.strip()
+    if stripped.startswith("{"):
+        parsed, _ = decoder.raw_decode(stripped)
+        if isinstance(parsed, dict):
+            return parsed
+    for index, char in enumerate(stripped):
+        if char != "{":
+            continue
+        try:
+            parsed, _ = decoder.raw_decode(stripped[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    raise ValueError("delivery renderer did not return a JSON object")
+
+
+def _clip(value: str, limit: int) -> str:
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _compact_bullet_answer(content: str, max_bullets: int = 6) -> str:
+    stripped = re.sub(r"^Here's what I found:\s*", "", content.strip(), flags=re.IGNORECASE)
+    lines = [line.strip() for line in stripped.splitlines() if line.strip()]
+    bullets: list[str] = []
+    for line in lines:
+        line = re.sub(r"^#{1,6}\s+", "", line)
+        line = re.sub(r"^[-*]\s+", "", line)
+        line = re.sub(r"^\d+[.)]\s+", "", line)
+        if line:
+            bullets.append(line)
+    if not bullets and stripped:
+        bullets = re.split(r"(?<=[.!?])\s+", stripped)
+    unique = [bullet for index, bullet in enumerate(bullets) if bullet and bullets.index(bullet) == index]
+    return "\n".join(f"- {bullet}" for bullet in unique[:max_bullets])
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/signalpilot/gateway/gateway/analysis_delivery/trace_loader.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/trace_loader.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.store import chat_traces
+from gateway.string_utils import string_value as _string
 from gateway.trace_markers import iter_trace_marker_payloads
 
 
@@ -76,11 +77,16 @@ async def load_delivery_packet(
         user_id=user_id,
         thread_id=thread_id,
     )
-    events = await chat_traces.get_events(
-        session,
-        org_id=org_id,
-        user_id=user_id,
-        thread_id=thread_id,
+    events = (
+        await chat_traces.get_events(
+            session,
+            org_id=org_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            require_thread=False,
+        )
+        if thread
+        else []
     )
     return load_delivery_packet_from_events(
         events,
@@ -262,10 +268,6 @@ def _event_get(event: Any, key: str, default: Any = None) -> Any:
     if isinstance(event, dict):
         return event.get(key, default)
     return getattr(event, key, default)
-
-
-def _string(value: Any) -> str:
-    return value if isinstance(value, str) else ""
 
 
 def _confidence_score(value: Any) -> float | None:

--- a/signalpilot/gateway/gateway/analysis_delivery/trace_loader.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/trace_loader.py
@@ -1,0 +1,286 @@
+"""Load worker-authored analysis trace signals for channel delivery."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.store import chat_traces
+from gateway.trace_markers import iter_trace_marker_payloads
+
+
+@dataclass(frozen=True)
+class WorkerPlan:
+    steps: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WorkerProgress:
+    current_step: str = ""
+    completed_steps: list[str] = field(default_factory=list)
+    status: str = ""
+
+
+@dataclass(frozen=True)
+class FinalStatement:
+    statement: str = ""
+    confidence_score: float | None = None
+    caveats: list[str] = field(default_factory=list)
+    handoff_notes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DeliveryPacket:
+    user_request: str = ""
+    plan: WorkerPlan | None = None
+    latest_progress: WorkerProgress | None = None
+    final_statement: FinalStatement | None = None
+    final_notebook_outputs: dict[str, Any] = field(default_factory=dict)
+    charts: list[dict[str, Any]] = field(default_factory=list)
+    trail_url: str = ""
+    known_errors: list[str] = field(default_factory=list)
+    status: str = "active"
+
+    def to_model_payload(self) -> dict[str, Any]:
+        return {
+            "userRequest": self.user_request,
+            "plan": asdict(self.plan) if self.plan else None,
+            "latestProgress": asdict(self.latest_progress) if self.latest_progress else None,
+            "finalStatement": asdict(self.final_statement) if self.final_statement else None,
+            "finalNotebookOutputs": self.final_notebook_outputs,
+            "charts": self.charts,
+            "trailUrl": self.trail_url,
+            "knownErrors": self.known_errors,
+            "status": self.status,
+        }
+
+
+_GENERIC_REPAIR_TEXT = "Formatting the completed analysis into the required"
+
+
+async def load_delivery_packet(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str,
+    thread_id: str,
+    user_request: str = "",
+    status_payload: dict[str, Any] | None = None,
+    trail_url: str = "",
+) -> DeliveryPacket:
+    thread = await chat_traces.get_thread(
+        session,
+        org_id=org_id,
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+    events = await chat_traces.get_events(
+        session,
+        org_id=org_id,
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+    return load_delivery_packet_from_events(
+        events,
+        user_request=user_request,
+        status_payload=status_payload,
+        trail_url=trail_url,
+        thread_status=thread.status if thread else None,
+    )
+
+
+def load_delivery_packet_from_events(
+    events: list[Any],
+    *,
+    user_request: str = "",
+    status_payload: dict[str, Any] | None = None,
+    trail_url: str = "",
+    thread_status: str | None = None,
+) -> DeliveryPacket:
+    plan: WorkerPlan | None = None
+    plan_idx = -1
+    progress: WorkerProgress | None = None
+    progress_idx = -1
+    final_statement: FinalStatement | None = None
+    final_idx = -1
+    known_errors: list[str] = []
+    latest_result: dict[str, Any] = {}
+
+    for event in events:
+        idx = int(_event_get(event, "idx", -1) or -1)
+        event_type = _string(_event_get(event, "type")).lower()
+        content = _string(_event_get(event, "content"))
+        metadata = _event_get(event, "metadata") or {}
+
+        if not user_request and event_type == "user" and content:
+            user_request = content
+
+        if event_type in {"thinking", "thinking_delta"} or _GENERIC_REPAIR_TEXT in content:
+            continue
+
+        if bool(_event_get(event, "is_error")) or event_type == "error":
+            _append_unique(known_errors, content.strip() or _string(_event_get(event, "tool_name")), 8)
+
+        if event_type == "done" and isinstance(metadata, dict):
+            result = metadata.get("result")
+            if isinstance(result, dict):
+                latest_result = result
+
+        for marker, payload in iter_trace_marker_payloads(content, metadata):
+            if marker == "PLAN" and idx >= plan_idx:
+                parsed_plan = _parse_plan(payload)
+                if parsed_plan is not None:
+                    plan = parsed_plan
+                    plan_idx = idx
+            elif marker == "PROGRESS" and idx >= progress_idx:
+                parsed_progress = _parse_progress(payload)
+                if parsed_progress is not None:
+                    progress = parsed_progress
+                    progress_idx = idx
+            elif marker == "FINAL_STATEMENT" and idx >= final_idx:
+                parsed_final = _parse_final_statement(payload)
+                if parsed_final is not None:
+                    final_statement = parsed_final
+                    final_idx = idx
+
+    status_payload = status_payload or {}
+    notebook_outputs = _compact_notebook_outputs(latest_result, status_payload)
+    charts = _charts_from_sources(status_payload, latest_result)
+    if status_payload.get("error"):
+        _append_unique(known_errors, _string(status_payload.get("error")), 8)
+
+    status = _status_from_sources(thread_status, status_payload, known_errors)
+    return DeliveryPacket(
+        user_request=user_request,
+        plan=plan,
+        latest_progress=progress,
+        final_statement=final_statement,
+        final_notebook_outputs=notebook_outputs,
+        charts=charts,
+        trail_url=trail_url or _string(status_payload.get("trailUrl") or status_payload.get("trail_url")),
+        known_errors=known_errors,
+        status=status,
+    )
+
+def _parse_plan(payload: dict[str, Any]) -> WorkerPlan | None:
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        return None
+    parsed = [_string(step).strip() for step in steps if _string(step).strip()]
+    return WorkerPlan(steps=parsed) if parsed else None
+
+
+def _parse_progress(payload: dict[str, Any]) -> WorkerProgress | None:
+    current = _string(payload.get("currentStep", payload.get("current_step"))).strip()
+    completed_raw = payload.get("completedSteps", payload.get("completed_steps", []))
+    completed = (
+        [_string(step).strip() for step in completed_raw if _string(step).strip()]
+        if isinstance(completed_raw, list)
+        else []
+    )
+    status = _string(payload.get("status")).strip()
+    if not current and not completed and not status:
+        return None
+    return WorkerProgress(current_step=current, completed_steps=completed, status=status)
+
+
+def _parse_final_statement(payload: dict[str, Any]) -> FinalStatement | None:
+    statement = _string(payload.get("statement")).strip()
+    caveats_raw = payload.get("caveats", [])
+    notes_raw = payload.get("handoffNotes", payload.get("handoff_notes", []))
+    confidence = _confidence_score(payload.get("confidenceScore", payload.get("confidence_score")))
+    caveats = [_string(item).strip() for item in caveats_raw if _string(item).strip()] if isinstance(caveats_raw, list) else []
+    notes = [_string(item).strip() for item in notes_raw if _string(item).strip()] if isinstance(notes_raw, list) else []
+    if not statement and confidence is None and not caveats and not notes:
+        return None
+    return FinalStatement(
+        statement=statement,
+        confidence_score=confidence,
+        caveats=caveats,
+        handoff_notes=notes,
+    )
+
+
+def _compact_notebook_outputs(*sources: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    keys = (
+        "summary",
+        "finalAnswer",
+        "final_answer",
+        "gotchas",
+        "analysisMethod",
+        "analysis_method",
+        "notionComment",
+        "notion_comment",
+    )
+    for source in sources:
+        for key in keys:
+            value = source.get(key)
+            if value not in (None, "", []):
+                result[key] = value
+    return result
+
+
+def _charts_from_sources(*sources: dict[str, Any]) -> list[dict[str, Any]]:
+    charts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source in sources:
+        raw_charts = source.get("notionCharts", source.get("notion_charts", []))
+        if not isinstance(raw_charts, list):
+            continue
+        for chart in raw_charts:
+            if not isinstance(chart, dict):
+                continue
+            url = _string(chart.get("url")).strip()
+            title = _string(chart.get("title")).strip()
+            key = url or title
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            charts.append(dict(chart))
+    return charts[:3]
+
+
+def _status_from_sources(
+    thread_status: str | None,
+    status_payload: dict[str, Any],
+    known_errors: list[str],
+) -> str:
+    status = _string(status_payload.get("status")).lower()
+    if status == "done" and not status_payload.get("error"):
+        return "done"
+    if status == "failed" or status_payload.get("error"):
+        return "failed"
+    if thread_status in {"done", "failed", "active"}:
+        return thread_status
+    return "failed" if known_errors else "active"
+
+
+def _event_get(event: Any, key: str, default: Any = None) -> Any:
+    if isinstance(event, dict):
+        return event.get(key, default)
+    return getattr(event, key, default)
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _confidence_score(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(1.0, score))
+
+
+def _append_unique(items: list[str], value: str, limit: int) -> None:
+    value = value.strip()
+    if not value or value in items:
+        return
+    items.append(value)
+    del items[limit:]

--- a/signalpilot/gateway/gateway/api/__init__.py
+++ b/signalpilot/gateway/gateway/api/__init__.py
@@ -31,6 +31,7 @@ from .sandboxes import router as sandboxes_router
 from .schema import router as schema_router
 from .security import router as security_router
 from .settings import router as settings_router
+from .slack import router as slack_router
 from .user_secrets import router as user_secrets_router
 from .workspace_projects import router as workspace_projects_router
 
@@ -60,6 +61,7 @@ def register_routers(app: FastAPI) -> None:
     app.include_router(knowledge_router)
     app.include_router(notion_router)
     app.include_router(notion_webhook_router)
+    app.include_router(slack_router)
     app.include_router(workspace_projects_router)
     app.include_router(chat_router)
     app.include_router(chat_traces_router)

--- a/signalpilot/gateway/gateway/api/slack.py
+++ b/signalpilot/gateway/gateway/api/slack.py
@@ -35,6 +35,7 @@ DEFAULT_SLACK_SCOPES = ",".join(
         "groups:history",
         "im:history",
         "mpim:history",
+        "reactions:write",
     ]
 )
 

--- a/signalpilot/gateway/gateway/api/slack.py
+++ b/signalpilot/gateway/gateway/api/slack.py
@@ -1,0 +1,257 @@
+"""Slack OAuth integration endpoints."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import StoreD
+from gateway.auth import OrgAdmin
+from gateway.db.engine import get_db
+from gateway.models.slack import (
+    SlackOAuthInstallationInfo,
+    SlackOAuthStartResponse,
+    SlackProvisionRequest,
+    SlackProvisionResponse,
+)
+from gateway.security.scope_guard import RequireScope
+from gateway.store import slack as slack_store
+
+router = APIRouter(prefix="/api/integrations/slack")
+
+SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+SLACK_OAUTH_ACCESS_URL = "https://slack.com/api/oauth.v2.access"
+DEFAULT_SLACK_SCOPES = ",".join(
+    [
+        "app_mentions:read",
+        "channels:history",
+        "chat:write",
+        "files:write",
+        "groups:history",
+        "im:history",
+        "mpim:history",
+    ]
+)
+
+
+def _slack_oauth_client_id() -> str:
+    value = os.getenv("SLACK_OAUTH_CLIENT_ID") or os.getenv("SLACK_CLIENT_ID")
+    if not value:
+        raise HTTPException(status_code=503, detail="SLACK_OAUTH_CLIENT_ID is not configured")
+    return value
+
+
+def _slack_oauth_client_secret() -> str:
+    value = os.getenv("SLACK_OAUTH_CLIENT_SECRET") or os.getenv("SLACK_CLIENT_SECRET")
+    if not value:
+        raise HTTPException(status_code=503, detail="SLACK_OAUTH_CLIENT_SECRET is not configured")
+    return value
+
+
+def _slack_redirect_uri(request: Request) -> str:
+    return os.getenv("SLACK_OAUTH_REDIRECT_URI") or str(request.url_for("slack_oauth_callback"))
+
+
+def _slack_oauth_scopes() -> str:
+    return os.getenv("SLACK_OAUTH_SCOPES") or DEFAULT_SLACK_SCOPES
+
+
+def build_slack_authorize_url(client_id: str, redirect_uri: str, state: str, scopes: str | None = None) -> str:
+    query = urlencode(
+        {
+            "client_id": client_id,
+            "scope": scopes or DEFAULT_SLACK_SCOPES,
+            "redirect_uri": redirect_uri,
+            "state": state,
+        }
+    )
+    return f"{SLACK_AUTHORIZE_URL}?{query}"
+
+
+async def exchange_slack_oauth_code(
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+) -> dict:
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(
+            SLACK_OAUTH_ACCESS_URL,
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+        )
+    response.raise_for_status()
+    data = response.json()
+    if not data.get("ok"):
+        detail = data.get("error") or "Slack OAuth failed"
+        raise HTTPException(status_code=400, detail=f"Slack OAuth failed: {detail}")
+    return data
+
+
+def _redirect_fallback_url() -> str:
+    web_url = os.getenv("SIGNALPILOT_WEB_URL") or os.getenv("SP_WEB_URL")
+    if web_url:
+        return f"{web_url.rstrip('/')}/integrations"
+    return "/integrations"
+
+
+def _origin_for_url(value: str) -> str | None:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def _allowed_redirect_origins() -> set[str]:
+    origins: set[str] = set()
+    for value in (os.getenv("SIGNALPILOT_WEB_URL"), os.getenv("SP_WEB_URL")):
+        if value and (origin := _origin_for_url(value)):
+            origins.add(origin)
+    for value in (os.getenv("SP_ALLOWED_ORIGINS") or "").split(","):
+        if value and (origin := _origin_for_url(value.strip())):
+            origins.add(origin)
+    if not origins:
+        origins.update(
+            {
+                "http://localhost:3000",
+                "http://localhost:3200",
+                "http://localhost:3210",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:3200",
+                "http://127.0.0.1:3210",
+            }
+        )
+    return origins
+
+
+def _is_safe_redirect_target(target: str) -> bool:
+    if not target or target.startswith(("//", "\\")):
+        return False
+    parsed = urlparse(target)
+    if not parsed.scheme and not parsed.netloc:
+        return target.startswith("/")
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    return _origin_for_url(target) in _allowed_redirect_origins()
+
+
+def _safe_redirect_url(value: str | None, installation_id: str | None = None, status: str = "connected") -> str:
+    fallback = _redirect_fallback_url()
+    target = value or fallback
+    if not _is_safe_redirect_target(target):
+        target = fallback if _is_safe_redirect_target(fallback) else "/integrations"
+
+    parsed = urlparse(target)
+    params = {"slack": status}
+    if installation_id:
+        params["slack_installation_id"] = installation_id
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    query.extend(params.items())
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+@router.get("/oauth/start", dependencies=[RequireScope("write")])
+async def start_slack_oauth(
+    request: Request,
+    store: StoreD,
+    _role: OrgAdmin,
+    redirect_after: str | None = Query(default=None),
+) -> SlackOAuthStartResponse:
+    """Create OAuth state and return the Slack authorization URL."""
+    redirect_uri = _slack_redirect_uri(request)
+    state = await store.create_slack_oauth_state(redirect_after=redirect_after)
+    return SlackOAuthStartResponse(
+        authorize_url=build_slack_authorize_url(
+            _slack_oauth_client_id(),
+            redirect_uri,
+            state,
+            _slack_oauth_scopes(),
+        ),
+        state=state,
+    )
+
+
+@router.get("/oauth/callback", name="slack_oauth_callback")
+async def slack_oauth_callback(
+    request: Request,
+    code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """OAuth callback from Slack. Tenant context comes from the stored state row."""
+    if error:
+        raise HTTPException(status_code=400, detail=f"Slack OAuth failed: {error}")
+    if not code or not state:
+        raise HTTPException(status_code=400, detail="Missing Slack OAuth code or state")
+
+    state_row = await slack_store.consume_oauth_state(db, state)
+    if state_row is None:
+        raise HTTPException(status_code=400, detail="Invalid or expired Slack OAuth state")
+
+    token_response = await exchange_slack_oauth_code(
+        _slack_oauth_client_id(),
+        _slack_oauth_client_secret(),
+        code,
+        _slack_redirect_uri(request),
+    )
+    try:
+        installation = await slack_store.upsert_oauth_installation(
+            db,
+            org_id=state_row.org_id,
+            user_id=state_row.user_id,
+            token_response=token_response,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return RedirectResponse(_safe_redirect_url(state_row.redirect_after, installation.id, "connected"))
+
+
+@router.get("/oauth/installations", dependencies=[RequireScope("read")])
+async def list_slack_oauth_installations(store: StoreD) -> list[SlackOAuthInstallationInfo]:
+    """List Slack OAuth installations for the current org."""
+    return await store.list_slack_oauth_installations()
+
+
+@router.post("/oauth/{installation_id}/provision", dependencies=[RequireScope("write")])
+async def provision_slack_oauth_installation(
+    installation_id: str,
+    body: SlackProvisionRequest,
+    store: StoreD,
+    _role: OrgAdmin,
+) -> SlackProvisionResponse:
+    """Configure default project routing for a Slack installation."""
+    if await store.get_workspace_project(body.default_project_id) is None:
+        raise HTTPException(status_code=404, detail="Default project not found")
+
+    installation = await store.save_slack_oauth_installation_config(
+        installation_id,
+        enabled=True,
+        default_project_id=body.default_project_id,
+        default_branch=body.default_branch,
+        analysis_branch_mode=body.analysis_branch_mode,
+        allowed_channel_ids=body.allowed_channel_ids,
+    )
+    if installation is None:
+        raise HTTPException(status_code=404, detail="Slack installation not found")
+    return SlackProvisionResponse(installation=installation)
+
+
+@router.delete("/oauth/{installation_id}", status_code=204, dependencies=[RequireScope("write")])
+async def delete_slack_oauth_installation(
+    installation_id: str,
+    store: StoreD,
+    _role: OrgAdmin,
+) -> None:
+    """Disable a Slack OAuth installation without deleting historical analysis trails."""
+    if not await store.disable_slack_oauth_installation(installation_id):
+        raise HTTPException(status_code=404, detail="Slack installation not found")

--- a/signalpilot/gateway/gateway/db/models.py
+++ b/signalpilot/gateway/gateway/db/models.py
@@ -413,6 +413,66 @@ class NotionOAuthState(GatewayBase):
     __table_args__ = (Index("ix_notion_oauth_states_expires", "expires_at"),)
 
 
+class SlackInstallation(GatewayBase):
+    """OAuth-installed Slack app scoped by org."""
+
+    __tablename__ = "slack_installations"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    org_id: Mapped[str] = mapped_column(String, nullable=False)
+    user_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    team_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    team_name: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    enterprise_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    enterprise_name: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    app_id: Mapped[str] = mapped_column(String(100), nullable=False, default="", server_default="")
+    bot_user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    authed_user_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    bot_access_token_enc: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    scopes: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="connected", server_default="connected")
+    created_at: Mapped[datetime] = mapped_column(TZDateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(TZDateTime, server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("org_id", "team_id", "app_id", name="uq_slack_install_org_team_app"),
+        Index("ix_slack_install_team", "team_id"),
+        Index("ix_slack_install_org_status", "org_id", "status"),
+    )
+
+
+class SlackInstallationConfig(GatewayBase):
+    """Setup metadata for a Slack OAuth installation."""
+
+    __tablename__ = "slack_installation_config"
+
+    installation_id: Mapped[str] = mapped_column(String, primary_key=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    default_project_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    default_branch: Mapped[str] = mapped_column(String(100), nullable=False, default="main", server_default="main")
+    analysis_branch_mode: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+        default="per_request",
+        server_default="per_request",
+    )
+    allowed_channel_ids: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+
+
+class SlackOAuthState(GatewayBase):
+    """Short-lived Slack OAuth state for CSRF protection and post-install redirect."""
+
+    __tablename__ = "slack_oauth_states"
+
+    state: Mapped[str] = mapped_column(String(128), primary_key=True)
+    org_id: Mapped[str] = mapped_column(String, nullable=False)
+    user_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    redirect_after: Mapped[str | None] = mapped_column(Text, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+
+    __table_args__ = (Index("ix_slack_oauth_states_expires", "expires_at"),)
+
+
 class GatewayApiKey(GatewayBase):
     __tablename__ = "gateway_api_keys"
 

--- a/signalpilot/gateway/gateway/git/repos.py
+++ b/signalpilot/gateway/gateway/git/repos.py
@@ -21,13 +21,21 @@ def _validate_branch_name(branch: str) -> None:
         raise ValueError(f"Invalid branch name: {branch!r}")
 
 
-def _run_git(*args: str, cwd: Path | str | None = None, timeout: int = 30) -> tuple[int, str, str]:
+def _run_git(
+    *args: str,
+    cwd: Path | str | None = None,
+    timeout: int = 30,
+    input: str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
     result = subprocess.run(
         ["git", *args],
         cwd=str(cwd) if cwd else None,
         capture_output=True,
         text=True,
         timeout=timeout,
+        input=input,
+        env={**os.environ, **env} if env else None,
     )
     return result.returncode, result.stdout, result.stderr
 
@@ -35,7 +43,7 @@ def _run_git(*args: str, cwd: Path | str | None = None, timeout: int = 30) -> tu
 def repo_path(project_id: str) -> Path:
     import re
     if not re.match(r"^[a-f0-9\-]{36}$", project_id):
-        raise ValueError(f"Invalid project_id: must be a UUID")
+        raise ValueError("Invalid project_id: must be a UUID")
     path = REPOS_ROOT / f"{project_id}.git"
     if not str(path.resolve()).startswith(str(REPOS_ROOT.resolve())):
         raise ValueError("Path traversal detected")
@@ -50,9 +58,11 @@ def repo_exists(project_id: str) -> bool:
 
 
 def init_bare_repo(project_id: str, default_branch: str = "main") -> Path:
+    _validate_branch_name(default_branch)
     path = repo_path(project_id)
     if path.exists():
         logger.info("Bare repo already exists: %s", path)
+        _ensure_initial_default_branch(path, default_branch)
         return path
 
     path.mkdir(parents=True, exist_ok=True)
@@ -62,9 +72,49 @@ def init_bare_repo(project_id: str, default_branch: str = "main") -> Path:
 
     _run_git("config", "http.receivepack", "true", cwd=path)
     _run_git("config", "receive.denyCurrentBranch", "updateInstead", cwd=path)
+    _ensure_initial_default_branch(path, default_branch)
 
     logger.info("Created bare repo: %s (default branch: %s)", path, default_branch)
     return path
+
+
+def _ensure_initial_default_branch(path: Path, default_branch: str) -> None:
+    """Make fresh managed repos branchable by giving the default branch a root commit."""
+    rc, out, _ = _run_git("rev-parse", "--verify", f"refs/heads/{default_branch}", cwd=path)
+    if rc == 0 and out.strip():
+        return
+
+    rc, out, err = _run_git("for-each-ref", "--format=%(refname)", "refs/heads/", cwd=path)
+    if rc == 0 and out.strip():
+        return
+
+    rc, tree, err = _run_git("mktree", cwd=path, input="")
+    if rc != 0 or not tree.strip():
+        raise RuntimeError(f"Could not create empty tree for managed repo: {err}")
+
+    rc, commit, err = _run_git(
+        "commit-tree",
+        tree.strip(),
+        "-m",
+        "Initial empty project",
+        cwd=path,
+        env={
+            "GIT_AUTHOR_NAME": "SignalPilot",
+            "GIT_AUTHOR_EMAIL": "local@signalpilot.dev",
+            "GIT_COMMITTER_NAME": "SignalPilot",
+            "GIT_COMMITTER_EMAIL": "local@signalpilot.dev",
+        },
+    )
+    if rc != 0 or not commit.strip():
+        raise RuntimeError(f"Could not create initial commit for managed repo: {err}")
+
+    rc, _, err = _run_git("update-ref", f"refs/heads/{default_branch}", commit.strip(), cwd=path)
+    if rc != 0:
+        raise RuntimeError(f"Could not set initial {default_branch!r} branch: {err}")
+
+    rc, _, err = _run_git("symbolic-ref", "HEAD", f"refs/heads/{default_branch}", cwd=path)
+    if rc != 0:
+        raise RuntimeError(f"Could not point HEAD at {default_branch!r}: {err}")
 
 
 def delete_repo(project_id: str) -> bool:

--- a/signalpilot/gateway/gateway/http/middleware/auth.py
+++ b/signalpilot/gateway/gateway/http/middleware/auth.py
@@ -21,6 +21,7 @@ PUBLIC_PATHS = frozenset(
         "/docs",
         "/openapi.json",
         "/api/integrations/notion/oauth/callback",
+        "/api/integrations/slack/oauth/callback",
         "/api/notion/webhooks/events",
         "/slack/events",
     }

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -508,9 +508,9 @@ register_routers(app)
 
 if (os.getenv("SLACK_DELIVERY_MODE") or "").lower() == "http":
     try:
-        from .slack_poc.worker import load_config_from_env, register_http_routes
+        from .slack_poc.worker import load_http_config_from_env, register_http_routes
 
-        register_http_routes(app, load_config_from_env())
+        register_http_routes(app, load_http_config_from_env())
         logger.info("Slack PoC HTTP endpoint mounted at /slack/events")
     except Exception:
         logger.exception("Failed to mount Slack PoC HTTP endpoint")

--- a/signalpilot/gateway/gateway/models/slack.py
+++ b/signalpilot/gateway/gateway/models/slack.py
@@ -1,0 +1,58 @@
+"""Pydantic models for Slack integration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SlackOAuthStartResponse(BaseModel):
+    """Authorization URL for the Slack app OAuth flow."""
+
+    authorize_url: str
+    state: str
+
+
+class SlackInstallationConfigInfo(BaseModel):
+    """Configured defaults for a Slack OAuth installation."""
+
+    enabled: bool = False
+    default_project_id: str | None = None
+    default_branch: str = "main"
+    analysis_branch_mode: str = "per_request"
+    allowed_channel_ids: list[str] = Field(default_factory=list)
+
+
+class SlackOAuthInstallationInfo(BaseModel):
+    """Read-only Slack OAuth install info returned from API."""
+
+    id: str
+    team_id: str
+    team_name: str | None = None
+    enterprise_id: str | None = None
+    enterprise_name: str | None = None
+    app_id: str | None = None
+    bot_user_id: str
+    authed_user_id: str | None = None
+    scopes: list[str] = Field(default_factory=list)
+    status: str = "connected"
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    org_id: str | None = None
+    config: SlackInstallationConfigInfo | None = None
+
+
+class SlackProvisionRequest(BaseModel):
+    """Configure a Slack installation for notebook-backed analysis."""
+
+    default_project_id: str = Field(..., min_length=1, max_length=200)
+    default_branch: str = Field(default="main", min_length=1, max_length=100)
+    analysis_branch_mode: str = Field(default="per_request", pattern=r"^(per_request|default_branch)$")
+    allowed_channel_ids: list[str] = Field(default_factory=list, max_length=200)
+
+
+class SlackProvisionResponse(BaseModel):
+    """Provisioning result for a Slack OAuth installation."""
+
+    installation: SlackOAuthInstallationInfo

--- a/signalpilot/gateway/gateway/notebooks/session_service.py
+++ b/signalpilot/gateway/gateway/notebooks/session_service.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 OrchestratorFactory = Callable[[], Awaitable[NotebookOrchestrator]]
 _AI_CREDENTIAL_ENV_NAMES = ("CLAUDE_CODE_OAUTH_TOKEN", "OAUTH_TOKEN", "ANTHROPIC_API_KEY")
+_NOTEBOOK_MODEL_ENV_NAMES = ("SIGNALPILOT_ANALYSIS_AGENT_MODEL", "SIGNALPILOT_WORKER_AGENT_MODEL")
 _DEFAULT_CLOUD_WEB_URL = "https://app.signalpilot.ai"
 
 
@@ -114,7 +115,7 @@ async def _pod_extra_env(
 ) -> dict[str, str] | None:
     env: dict[str, str] = {
         name: value
-        for name in _AI_CREDENTIAL_ENV_NAMES
+        for name in (*_AI_CREDENTIAL_ENV_NAMES, *_NOTEBOOK_MODEL_ENV_NAMES)
         if (value := os.getenv(name))
     }
 

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -35,6 +35,10 @@ from gateway.notion.webhooks import RoutedNotionInstallation
 from gateway.store import analysis_trails, workspace_projects
 
 NOTION_RICH_TEXT_MAX_LENGTH = notion_formatting.NOTION_RICH_TEXT_MAX_LENGTH
+_PLACEHOLDER_CHART_TITLE_RE = re.compile(
+    r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?",
+    flags=re.I,
+)
 logger = logging.getLogger(__name__)
 
 
@@ -99,11 +103,20 @@ def _chart_title(chart: dict[str, Any]) -> str:
     return _chart_value(chart, "title") or "Chart"
 
 
+def _is_placeholder_chart_title(value: str) -> bool:
+    return bool(_PLACEHOLDER_CHART_TITLE_RE.fullmatch(value.strip()))
+
+
+def _meaningful_chart_text(chart: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = _chart_value(chart, key)
+        if value and not _is_placeholder_chart_title(value):
+            return value
+    return ""
+
+
 def _chart_comment_title(chart: dict[str, Any]) -> str:
-    title = _chart_title(chart)
-    if re.fullmatch(r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?", title, flags=re.I):
-        return ""
-    return title
+    return _meaningful_chart_text(chart, "title", "caption", "altText", "alt_text")
 
 
 def _selected_charts(status: dict[str, Any], target: str) -> list[dict[str, Any]]:
@@ -120,15 +133,14 @@ def _selected_charts(status: dict[str, Any], target: str) -> list[dict[str, Any]
 
 
 def _chart_image_block(chart: dict[str, Any]) -> dict[str, Any]:
-    title = _chart_title(chart)
-    caption = _chart_value(chart, "caption") or _chart_value(chart, "altText", "alt_text") or title
+    caption = _meaningful_chart_text(chart, "caption", "altText", "alt_text", "title")
     return {
         "object": "block",
         "type": "image",
         "image": {
             "type": "file_upload",
             "file_upload": {"id": _chart_file_upload_id(chart)},
-            "caption": notion_formatting.markdown_rich_text(caption, max_chars=NOTION_RICH_TEXT_MAX_LENGTH),
+            "caption": notion_formatting.markdown_rich_text(caption, max_chars=NOTION_RICH_TEXT_MAX_LENGTH) if caption else [],
         },
     }
 

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -16,6 +16,15 @@ import httpx
 import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from gateway.analysis_delivery import (
+    ANALYSIS_INITIAL_PROGRESS_TEXT,
+    AnalysisPreflightKind,
+    classify_analysis_request,
+    delivery_result_to_status,
+    load_delivery_packet,
+    load_delivery_packet_from_events,
+    render_delivery,
+)
 from gateway.auth.jwt_secret import load_session_jwt_secret
 from gateway.db.models import NotionInstallationConfig
 from gateway.git.repos import ensure_branch_from
@@ -777,6 +786,7 @@ async def _poll_analysis(
     org_id: str,
     user_id: str | None,
     route: AnalysisRoute | None = None,
+    on_tick: Any | None = None,
 ) -> dict:
     max_polls = int(os.getenv("SIGNALPILOT_MAX_POLLS", "300"))
     interval_ms = int(os.getenv("SIGNALPILOT_POLL_INTERVAL_MS", "5000"))
@@ -798,8 +808,77 @@ async def _poll_analysis(
         )
         if status.get("status") in ("Done", "Failed"):
             return status
+        if on_tick is not None:
+            await on_tick(status)
         await asyncio.sleep(interval_ms / 1000)
     raise TimeoutError(f"SignalPilot analysis timed out: {request_id}")
+
+
+class _NotionTraceProgressReporter:
+    def __init__(
+        self,
+        *,
+        token: str,
+        request_page_id: str,
+        db: AsyncSession,
+        org_id: str,
+        user_id: str,
+        thread_id: str,
+        user_request: str,
+    ) -> None:
+        self.token = token
+        self.request_page_id = request_page_id
+        self.db = db
+        self.org_id = org_id
+        self.user_id = user_id
+        self.thread_id = thread_id
+        self.user_request = user_request
+        self._previous_summary = ""
+
+    async def tick(self, _status: dict[str, Any]) -> None:
+        try:
+            packet = await load_delivery_packet(
+                self.db,
+                org_id=self.org_id,
+                user_id=self.user_id,
+                thread_id=self.thread_id,
+                user_request=self.user_request,
+            )
+        except Exception as exc:
+            logger.info("Could not load Notion trace progress: %s", exc, exc_info=True)
+            return
+        summary = _notion_progress_summary(packet)
+        if summary == self._previous_summary:
+            return
+        self._previous_summary = summary
+        properties: dict[str, Any] = {
+            "Status": {"rich_text": _rich_text(_notion_progress_status(packet))},
+            "Summary": {"rich_text": _rich_text(summary)},
+        }
+        try:
+            await notion_client.update_page_properties(self.token, self.request_page_id, properties)
+        except Exception as exc:
+            logger.info("Could not update Notion progress: %s", exc, exc_info=True)
+
+
+def _notion_progress_status(packet: Any) -> str:
+    current = packet.latest_progress.current_step if packet.latest_progress else ""
+    return f"Analyzing: {current}"[:200] if current else "Analyzing"
+
+
+def _notion_progress_summary(packet: Any) -> str:
+    if packet.plan is None:
+        return ANALYSIS_INITIAL_PROGRESS_TEXT
+    completed = set(packet.latest_progress.completed_steps if packet.latest_progress else [])
+    current = packet.latest_progress.current_step if packet.latest_progress else ""
+    lines = []
+    for step in packet.plan.steps:
+        marker = "x" if step in completed else " "
+        suffix = " (current)" if current and step == current and step not in completed else ""
+        lines.append(f"- [{marker}] {step}{suffix}")
+    if packet.latest_progress and packet.latest_progress.status:
+        lines.append(packet.latest_progress.status)
+    return "\n".join(lines)[:1500] or ANALYSIS_INITIAL_PROGRESS_TEXT
 
 
 def _require_config(config: NotionInstallationConfig) -> tuple[str, str]:
@@ -854,6 +933,15 @@ async def process_routed_comment_event(
             comment_id=comment_id,
             discussion_id=discussion_id,
         )
+
+    preflight = classify_analysis_request(prompt)
+    if preflight.kind != AnalysisPreflightKind.ANALYZE:
+        await notion_client.create_comment(
+            token,
+            discussion_id=discussion_id,
+            rich_text=_rich_text(preflight.response or "Send a fresh, specific analysis request to start SignalPilot."),
+        )
+        return NotionCommentProcessResult(status="processed")
 
     previous_messages = [
         notion_client.extract_comment_text(comment)
@@ -995,12 +1083,22 @@ async def process_routed_comment_event(
     await notion_client.update_page_properties(token, request_page_id, {"Trail URL": {"url": start_trail_url or None}})
 
     try:
+        trace_thread_id = f"session-{route.request_id}"
         final_status = await _poll_analysis(
             str(start["requestId"]),
             runtime,
             routed.installation.org_id,
             routed.installation.user_id,
             route,
+            on_tick=_NotionTraceProgressReporter(
+                token=token,
+                request_page_id=request_page_id,
+                db=db,
+                org_id=routed.installation.org_id,
+                user_id=routed.installation.user_id or route.analysis_user_id,
+                thread_id=trace_thread_id,
+                user_request=prompt,
+            ).tick,
         )
         await update_analysis_trail_from_status(
             db,
@@ -1031,7 +1129,30 @@ async def process_routed_comment_event(
         raise
 
     if final_status.get("status") == "Done" and not final_status.get("error"):
-        uploaded_status = await _upload_chart_images_to_notion(token, final_status, runtime)
+        public_status = _with_public_chart_urls(final_status, runtime)
+        public_trail_url = _public_signalpilot_url(public_status.get("trailUrl") or start_trail_url, runtime)
+        try:
+            packet = await load_delivery_packet(
+                db,
+                org_id=routed.installation.org_id,
+                user_id=routed.installation.user_id or route.analysis_user_id,
+                thread_id=f"session-{route.request_id}",
+                user_request=prompt,
+                status_payload=public_status,
+                trail_url=public_trail_url,
+            )
+        except Exception as exc:
+            logger.info("Could not load Notion delivery trace; using status fallback: %s", exc, exc_info=True)
+            packet = load_delivery_packet_from_events(
+                [],
+                user_request=prompt,
+                status_payload=public_status,
+                trail_url=public_trail_url,
+                thread_status="done",
+            )
+        delivery = await render_delivery(packet)
+        rendered_status = delivery_result_to_status(delivery, packet, base_status=public_status)
+        uploaded_status = await _upload_chart_images_to_notion(token, rendered_status, runtime)
         final_status_for_notion = _with_public_chart_urls(uploaded_status, runtime)
         await notion_client.update_page_properties(
             token,

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -24,8 +24,7 @@ from gateway.notebooks.session_service import NotebookRuntime, ensure_analysis_n
 from gateway.notion import client as notion_client
 from gateway.notion import formatting as notion_formatting
 from gateway.notion.webhooks import RoutedNotionInstallation
-from gateway.store import analysis_trails
-from gateway.store import workspace_projects
+from gateway.store import analysis_trails, workspace_projects
 
 NOTION_RICH_TEXT_MAX_LENGTH = notion_formatting.NOTION_RICH_TEXT_MAX_LENGTH
 logger = logging.getLogger(__name__)
@@ -772,11 +771,31 @@ async def _call_notebook(
         return response.json()
 
 
-async def _poll_analysis(request_id: str, runtime: NotebookRuntime, org_id: str, user_id: str | None) -> dict:
+async def _poll_analysis(
+    request_id: str,
+    runtime: NotebookRuntime,
+    org_id: str,
+    user_id: str | None,
+    route: AnalysisRoute | None = None,
+) -> dict:
     max_polls = int(os.getenv("SIGNALPILOT_MAX_POLLS", "300"))
     interval_ms = int(os.getenv("SIGNALPILOT_POLL_INTERVAL_MS", "5000"))
+    headers = (
+        {
+            "X-Gateway-Project-Id": route.project_id,
+            "X-Gateway-Branch-Id": route.branch,
+        }
+        if route is not None
+        else None
+    )
     for _ in range(max_polls):
-        status = await _call_notebook(runtime, f"/api/notion-analysis/status/{request_id}", org_id, user_id)
+        status = await _call_notebook(
+            runtime,
+            f"/api/notion-analysis/status/{request_id}",
+            org_id,
+            user_id,
+            {"headers": headers} if headers else None,
+        )
         if status.get("status") in ("Done", "Failed"):
             return status
         await asyncio.sleep(interval_ms / 1000)
@@ -981,6 +1000,7 @@ async def process_routed_comment_event(
             runtime,
             routed.installation.org_id,
             routed.installation.user_id,
+            route,
         )
         await update_analysis_trail_from_status(
             db,

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -17,7 +17,6 @@ import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.analysis_delivery import (
-    ANALYSIS_INITIAL_PROGRESS_TEXT,
     AnalysisPreflightKind,
     classify_analysis_request,
     delivery_result_to_status,
@@ -98,6 +97,13 @@ def _chart_file_upload_id(chart: dict[str, Any]) -> str:
 
 def _chart_title(chart: dict[str, Any]) -> str:
     return _chart_value(chart, "title") or "Chart"
+
+
+def _chart_comment_title(chart: dict[str, Any]) -> str:
+    title = _chart_title(chart)
+    if re.fullmatch(r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?", title, flags=re.I):
+        return ""
+    return title
 
 
 def _selected_charts(status: dict[str, Any], target: str) -> list[dict[str, Any]]:
@@ -411,6 +417,46 @@ def _start_comment_rich_text(request_page_url: str) -> list[dict[str, Any]]:
     ]
 
 
+def _notion_progress_body(packet: Any) -> str:
+    if packet.plan is None:
+        return ""
+    completed = set(packet.latest_progress.completed_steps if packet.latest_progress else [])
+    current = packet.latest_progress.current_step if packet.latest_progress else ""
+    lines = []
+    for step in packet.plan.steps:
+        marker = "x" if step in completed else " "
+        suffix = " (current)" if current and step == current and step not in completed else ""
+        lines.append(f"- [{marker}] {step}{suffix}")
+    lines.append("")
+    lines.append(_notion_loading_line(packet))
+    return "\n".join(lines).strip()[:1500]
+
+
+def _notion_loading_line(packet: Any) -> str:
+    current = packet.latest_progress.current_step if packet.latest_progress else ""
+    if current:
+        return f"Working on: {current}."
+    status = packet.latest_progress.status if packet.latest_progress else ""
+    if status:
+        return f"Working on: {status.replace('_', ' ')}."
+    return "Working through the analysis."
+
+
+def _notion_progress_text(packet: Any) -> str:
+    body = _notion_progress_body(packet)
+    if not body:
+        return "I'm on it and will post the answer back soon. See your request details."
+    return f"I'm on it and will post the answer back soon. See your request details.\n\n{body}"
+
+
+def _progress_comment_rich_text(packet: Any, request_page_url: str) -> list[dict[str, Any]]:
+    body = _notion_progress_body(packet)
+    rich_text = _start_comment_rich_text(request_page_url)
+    if body:
+        rich_text.extend(notion_formatting.plain_rich_text("\n\n" + body, max_chars=NOTION_RICH_TEXT_MAX_LENGTH))
+    return rich_text
+
+
 async def _create_start_comment(
     token: str,
     *,
@@ -419,7 +465,7 @@ async def _create_start_comment(
     event_id: str | None,
     comment_id: str | None,
     request_page_id: str,
-) -> None:
+) -> str | None:
     logger.info(
         "Posting Notion start comment: event_id=%s comment_id=%s discussion_id=%s request_page_id=%s",
         event_id,
@@ -428,7 +474,7 @@ async def _create_start_comment(
         request_page_id,
     )
     try:
-        await notion_client.create_comment(
+        response = await notion_client.create_comment(
             token,
             discussion_id=discussion_id,
             rich_text=_start_comment_rich_text(request_page_url),
@@ -444,16 +490,23 @@ async def _create_start_comment(
             exc_info=True,
         )
         raise
+    created_comment_id = response.get("id") if isinstance(response, dict) else None
     logger.info(
         "Posted Notion start comment: event_id=%s comment_id=%s discussion_id=%s request_page_id=%s",
         event_id,
-        comment_id,
+        created_comment_id or comment_id,
         discussion_id,
         request_page_id,
     )
+    return str(created_comment_id) if created_comment_id else None
 
 
-def _final_comment_rich_text(status: dict[str, Any], request_page_url: str) -> list[dict[str, Any]]:
+def _final_comment_rich_text(
+    status: dict[str, Any],
+    request_page_url: str,
+    *,
+    include_chart_attachment_note: bool = True,
+) -> list[dict[str, Any]]:
     raw_answer = (
         (status.get("notionComment") or "").strip()
         or (status.get("finalAnswer") or "").strip()
@@ -461,11 +514,15 @@ def _final_comment_rich_text(status: dict[str, Any], request_page_url: str) -> l
         or "I finished the analysis, but there was no written answer in the result."
     )
     answer = _compact_bullet_answer(raw_answer) or raw_answer
-    chart_lines = [
-        f"- {_chart_title(chart)}"
-        for chart in _selected_charts(status, "comment")
-        if _chart_file_upload_id(chart)
-    ]
+    chart_lines = (
+        [
+            f"- {title}"
+            for chart in _selected_charts(status, "comment")
+            if _chart_file_upload_id(chart) and (title := _chart_comment_title(chart))
+        ]
+        if include_chart_attachment_note
+        else []
+    )
     chart_section = "\n\nCharts attached:\n" + "\n".join(chart_lines) if chart_lines else ""
     suffix = "\n\nRequest page: request details" + chart_section
     clipped = _clip_comment_content(answer, len(suffix))
@@ -720,8 +777,21 @@ def _comment_attachments(status: dict[str, Any]) -> list[dict[str, str]]:
     ][:3]
 
 
-async def _create_final_comment(token: str, discussion_id: str, status: dict[str, Any], request_page_url: str) -> None:
+async def _create_final_comment(
+    token: str,
+    discussion_id: str,
+    status: dict[str, Any],
+    request_page_url: str,
+    *,
+    comment_id: str | None = None,
+) -> None:
     attachments = _comment_attachments(status)
+    if comment_id:
+        try:
+            await notion_client.delete_comment(token, comment_id)
+        except Exception:
+            logger.warning("Could not delete Notion progress comment before final delivery", exc_info=True)
+
     try:
         await notion_client.create_comment(
             token,
@@ -736,8 +806,30 @@ async def _create_final_comment(token: str, discussion_id: str, status: dict[str
         await notion_client.create_comment(
             token,
             discussion_id=discussion_id,
-            rich_text=_final_comment_rich_text(status, request_page_url),
+            rich_text=_final_comment_rich_text(status, request_page_url, include_chart_attachment_note=False),
         )
+
+
+async def _create_failure_comment(
+    token: str,
+    discussion_id: str,
+    message: str,
+    request_page_url: str,
+    *,
+    comment_id: str | None = None,
+) -> None:
+    rich_text = _failure_comment_rich_text(message, request_page_url)
+    if comment_id:
+        try:
+            await notion_client.update_comment(token, comment_id, rich_text=rich_text)
+            return
+        except Exception:
+            logger.warning("Could not update Notion failure comment; posting a new failure comment", exc_info=True)
+    await notion_client.create_comment(
+        token,
+        discussion_id=discussion_id,
+        rich_text=rich_text,
+    )
 
 
 def mint_internal_notebook_jwt(org_id: str, user_id: str | None, scopes: list[str] | None = None) -> str:
@@ -819,7 +911,8 @@ class _NotionTraceProgressReporter:
         self,
         *,
         token: str,
-        request_page_id: str,
+        request_page_url: str,
+        progress_comment_id: str | None,
         db: AsyncSession,
         org_id: str,
         user_id: str,
@@ -827,13 +920,14 @@ class _NotionTraceProgressReporter:
         user_request: str,
     ) -> None:
         self.token = token
-        self.request_page_id = request_page_id
+        self.request_page_url = request_page_url
+        self.progress_comment_id = progress_comment_id
         self.db = db
         self.org_id = org_id
         self.user_id = user_id
         self.thread_id = thread_id
         self.user_request = user_request
-        self._previous_summary = ""
+        self._previous_progress_text = "I'm on it and will post the answer back soon. See your request details."
 
     async def tick(self, _status: dict[str, Any]) -> None:
         try:
@@ -847,38 +941,19 @@ class _NotionTraceProgressReporter:
         except Exception as exc:
             logger.info("Could not load Notion trace progress: %s", exc, exc_info=True)
             return
-        summary = _notion_progress_summary(packet)
-        if summary == self._previous_summary:
+        progress_text = _notion_progress_text(packet)
+        if progress_text == self._previous_progress_text:
             return
-        self._previous_summary = summary
-        properties: dict[str, Any] = {
-            "Status": {"rich_text": _rich_text(_notion_progress_status(packet))},
-            "Summary": {"rich_text": _rich_text(summary)},
-        }
-        try:
-            await notion_client.update_page_properties(self.token, self.request_page_id, properties)
-        except Exception as exc:
-            logger.info("Could not update Notion progress: %s", exc, exc_info=True)
-
-
-def _notion_progress_status(packet: Any) -> str:
-    current = packet.latest_progress.current_step if packet.latest_progress else ""
-    return f"Analyzing: {current}"[:200] if current else "Analyzing"
-
-
-def _notion_progress_summary(packet: Any) -> str:
-    if packet.plan is None:
-        return ANALYSIS_INITIAL_PROGRESS_TEXT
-    completed = set(packet.latest_progress.completed_steps if packet.latest_progress else [])
-    current = packet.latest_progress.current_step if packet.latest_progress else ""
-    lines = []
-    for step in packet.plan.steps:
-        marker = "x" if step in completed else " "
-        suffix = " (current)" if current and step == current and step not in completed else ""
-        lines.append(f"- [{marker}] {step}{suffix}")
-    if packet.latest_progress and packet.latest_progress.status:
-        lines.append(packet.latest_progress.status)
-    return "\n".join(lines)[:1500] or ANALYSIS_INITIAL_PROGRESS_TEXT
+        self._previous_progress_text = progress_text
+        if self.progress_comment_id:
+            try:
+                await notion_client.update_comment(
+                    self.token,
+                    self.progress_comment_id,
+                    rich_text=_progress_comment_rich_text(packet, self.request_page_url),
+                )
+            except Exception as exc:
+                logger.info("Could not update Notion progress comment: %s", exc, exc_info=True)
 
 
 def _require_config(config: NotionInstallationConfig) -> tuple[str, str]:
@@ -973,6 +1048,7 @@ async def process_routed_comment_event(
         )
     request_page_id = request_page["id"]
     request_page_url = request_page.get("url") or _request_page_url(request_page_id)
+    progress_comment_id: str | None = None
 
     request_id = _analysis_request_id("notion", discussion_id)
     try:
@@ -1000,7 +1076,7 @@ async def process_routed_comment_event(
         return NotionCommentProcessResult(status="processed")
 
     await notion_client.update_page_properties(token, request_page_id, {"Status": {"rich_text": _rich_text("Analyzing")}})
-    await _create_start_comment(
+    progress_comment_id = await _create_start_comment(
         token,
         discussion_id=discussion_id,
         request_page_url=request_page_url,
@@ -1072,10 +1148,12 @@ async def process_routed_comment_event(
             {"Status": {"rich_text": _rich_text("Failed")}, "Summary": {"rich_text": _rich_text(message)}},
         )
         await notion_client.append_page_blocks(token, request_page_id, _failure_detail_blocks(message))
-        await notion_client.create_comment(
+        await _create_failure_comment(
             token,
-            discussion_id=discussion_id,
-            rich_text=_failure_comment_rich_text(message, request_page_url),
+            discussion_id,
+            message,
+            request_page_url,
+            comment_id=progress_comment_id,
         )
         raise
 
@@ -1092,7 +1170,8 @@ async def process_routed_comment_event(
             route,
             on_tick=_NotionTraceProgressReporter(
                 token=token,
-                request_page_id=request_page_id,
+                request_page_url=request_page_url,
+                progress_comment_id=progress_comment_id,
                 db=db,
                 org_id=routed.installation.org_id,
                 user_id=routed.installation.user_id or route.analysis_user_id,
@@ -1121,10 +1200,12 @@ async def process_routed_comment_event(
             {"Status": {"rich_text": _rich_text("Failed")}, "Summary": {"rich_text": _rich_text(message)}},
         )
         await notion_client.append_page_blocks(token, request_page_id, _failure_detail_blocks(message))
-        await notion_client.create_comment(
+        await _create_failure_comment(
             token,
-            discussion_id=discussion_id,
-            rich_text=_failure_comment_rich_text(message, request_page_url),
+            discussion_id,
+            message,
+            request_page_url,
+            comment_id=progress_comment_id,
         )
         raise
 
@@ -1164,7 +1245,13 @@ async def process_routed_comment_event(
                 "Summary": {"rich_text": _rich_text(final_status_for_notion.get("summary") or final_status_for_notion.get("finalAnswer") or "")},
             },
         )
-        await _create_final_comment(token, discussion_id, final_status_for_notion, request_page_url)
+        await _create_final_comment(
+            token,
+            discussion_id,
+            final_status_for_notion,
+            request_page_url,
+            comment_id=progress_comment_id,
+        )
         await notion_client.append_page_blocks(token, request_page_id, _analysis_detail_blocks(final_status_for_notion))
     else:
         message = final_status.get("error") or "SignalPilot analysis failed."
@@ -1174,9 +1261,11 @@ async def process_routed_comment_event(
             {"Status": {"rich_text": _rich_text("Failed")}, "Summary": {"rich_text": _rich_text(message)}},
         )
         await notion_client.append_page_blocks(token, request_page_id, _failure_detail_blocks(str(message)))
-        await notion_client.create_comment(
+        await _create_failure_comment(
             token,
-            discussion_id=discussion_id,
-            rich_text=_failure_comment_rich_text(str(message), request_page_url),
+            discussion_id,
+            str(message),
+            request_page_url,
+            comment_id=progress_comment_id,
         )
     return NotionCommentProcessResult(status="processed")

--- a/signalpilot/gateway/gateway/notion/client.py
+++ b/signalpilot/gateway/gateway/notion/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from urllib.parse import urlencode
 
 import httpx
@@ -101,7 +102,7 @@ REQUEST_DATABASE_PROPERTIES: dict[str, dict] = {
     "Trail URL": {"url": {}},
     "Confidence score": {"number": {}},
     "Status": {"rich_text": {}},
-    "Created at": {"rich_text": {}},
+    "Created at": {"date": {}},
     "Requester": {"select": {"options": []}},
     "Summary": {"rich_text": {}},
     "Escalated to": {"rich_text": {}},
@@ -580,38 +581,93 @@ async def create_request_page(
 ) -> dict[str, str]:
     body = {
         "parent": {"type": "data_source_id", "data_source_id": data_source_id},
-        "properties": {
-            "Request": {"title": _title(headline)},
-            "Source": {"url": source_url},
-            "Trail URL": {"url": None},
-            "Confidence score": {"number": None},
-            "Status": {"rich_text": _rich_text("New")},
-            "Created at": {"rich_text": _rich_text(created_at)},
-            "Requester": {"select": {"name": requester_id[:100] or "Unknown"}},
-            "Summary": {"rich_text": _rich_text(prompt)},
-            "Escalated to": {"rich_text": []},
-        },
+        "properties": _request_page_properties(
+            headline=headline,
+            source_url=source_url,
+            requester_id=requester_id,
+            prompt=prompt,
+            created_at=created_at,
+            use_date_created_at=True,
+        ),
     }
-    data = await notion_json(
-        api_key,
-        "POST",
-        "/pages",
-        json_body=body,
-    )
+    try:
+        data = await notion_json(
+            api_key,
+            "POST",
+            "/pages",
+            json_body=body,
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 400:
+            raise
+        body["properties"] = _request_page_properties(
+            headline=headline,
+            source_url=source_url,
+            requester_id=requester_id,
+            prompt=prompt,
+            created_at=created_at,
+            use_date_created_at=False,
+        )
+        data = await notion_json(
+            api_key,
+            "POST",
+            "/pages",
+            json_body=body,
+        )
     return {
         "id": data.get("id", ""),
         "url": data.get("url") or f"https://www.notion.so/{normalize_id(data.get('id', ''))}",
     }
 
 
-async def update_page_properties(api_key: str, page_id: str, properties: dict) -> None:
-    await notion_json(api_key, "PATCH", f"/pages/{page_id}", json_body={"properties": properties})
+def _request_page_properties(
+    *,
+    headline: str,
+    source_url: str,
+    requester_id: str,
+    prompt: str,
+    created_at: str,
+    use_date_created_at: bool,
+) -> dict:
+    created_at_property = (
+        {"date": {"start": created_at}}
+        if use_date_created_at
+        else {"rich_text": _rich_text(_created_at_display(created_at))}
+    )
+    return {
+        "Request": {"title": _title(headline)},
+        "Source": {"url": source_url},
+        "Trail URL": {"url": None},
+        "Confidence score": {"number": None},
+        "Status": {"rich_text": _rich_text("New")},
+        "Created at": created_at_property,
+        "Requester": {"select": {"name": requester_id[:100] or "Unknown"}},
+        "Summary": {"rich_text": _rich_text(prompt)},
+        "Escalated to": {"rich_text": []},
+    }
 
 
-async def append_page_blocks(api_key: str, page_id: str, children: list[dict]) -> None:
+def _created_at_display(created_at: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return created_at
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(UTC)
+        zone = " UTC"
+    else:
+        zone = ""
+    return f"{parsed:%b} {parsed.day}, {parsed:%Y %H:%M}{zone}"
+
+
+async def update_page_properties(api_key: str, page_id: str, properties: dict) -> dict:
+    return await notion_json(api_key, "PATCH", f"/pages/{page_id}", json_body={"properties": properties})
+
+
+async def append_page_blocks(api_key: str, page_id: str, children: list[dict]) -> dict:
     if not children:
-        return
-    await notion_json(api_key, "PATCH", f"/blocks/{page_id}/children", json_body={"children": children[:100]})
+        return {"results": []}
+    return await notion_json(api_key, "PATCH", f"/blocks/{page_id}/children", json_body={"children": children[:100]})
 
 
 async def list_comments(api_key: str, block_id: str) -> list[dict]:
@@ -655,18 +711,40 @@ async def create_comment(
     discussion_id: str,
     rich_text: list[dict],
     attachments: list[dict] | None = None,
-) -> None:
+) -> dict:
     body: dict = {
         "discussion_id": discussion_id,
         "rich_text": rich_text,
     }
     if attachments:
         body["attachments"] = attachments[:3]
-    await notion_json(
+    return await notion_json(
         api_key,
         "POST",
         "/comments",
         json_body=body,
+    )
+
+
+async def update_comment(
+    api_key: str,
+    comment_id: str,
+    *,
+    rich_text: list[dict],
+) -> dict:
+    return await notion_json(
+        api_key,
+        "PATCH",
+        f"/comments/{comment_id}",
+        json_body={"rich_text": rich_text},
+    )
+
+
+async def delete_comment(api_key: str, comment_id: str) -> dict:
+    return await notion_json(
+        api_key,
+        "DELETE",
+        f"/comments/{comment_id}",
     )
 
 

--- a/signalpilot/gateway/gateway/slack_poc/progress.py
+++ b/signalpilot/gateway/gateway/slack_poc/progress.py
@@ -15,6 +15,7 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from gateway.store import chat_traces
+from gateway.string_utils import string_value as _string
 
 LOGGER = logging.getLogger(__name__)
 
@@ -945,7 +946,3 @@ def _clip(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 14].rstrip() + "... truncated"
-
-
-def _string(value: Any) -> str:
-    return value if isinstance(value, str) else ""

--- a/signalpilot/gateway/gateway/slack_poc/progress.py
+++ b/signalpilot/gateway/gateway/slack_poc/progress.py
@@ -1,0 +1,951 @@
+"""Slack progress reporting for notebook-backed analysis."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from gateway.store import chat_traces
+
+LOGGER = logging.getLogger(__name__)
+
+INITIAL_PROGRESS_TEXT = "Planning the analysis..."
+COMPLETING_PROGRESS_TEXT = "Generating the final answer..."
+FALLBACK_PROGRESS_TEXT = "Working through the analysis..."
+
+_ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+_ANTHROPIC_VERSION = "2023-06-01"
+_MAX_RECENT_EVENTS = 12
+_SAFE_TEXT_LIMIT = 180
+
+_SIGNAL_ORDER = [
+    "notebook_inspected",
+    "notebook_edited",
+    "runs_notebook_cells",
+    "notebook_error",
+    "uses_sp_connections",
+    "connects_to_fin-db",
+    "contains_db_query",
+    "reads_dbt_project",
+    "uses_dbt_marts",
+    "builds_charts",
+    "validates_notebook",
+    "generates_final_answer",
+]
+
+
+@dataclass(frozen=True)
+class ProgressSummary:
+    status_text: str
+    should_update: bool
+
+
+class SlackProgressSummarizer:
+    """Summarize sanitized trace activity into one Slack-safe status line."""
+
+    def __init__(
+        self,
+        *,
+        provider: str = "anthropic",
+        model: str | None = None,
+        timeout_seconds: float = 8.0,
+        api_key: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.provider = (provider or "anthropic").strip().lower()
+        self.model = (model or "").strip()
+        self.timeout_seconds = max(float(timeout_seconds or 8.0), 0.1)
+        self.api_key = api_key if api_key is not None else os.getenv("ANTHROPIC_API_KEY")
+        self._http_client = http_client
+
+    async def summarize(self, payload: dict[str, Any]) -> ProgressSummary:
+        if self.provider != "anthropic" or not self.model or not self.api_key:
+            return _no_progress_update(payload)
+        try:
+            summary = await self._anthropic_summary(payload)
+        except Exception as exc:
+            LOGGER.info("Slack progress model unavailable; skipping progress update: %s", exc)
+            return _no_progress_update(payload)
+        if summary is None:
+            return _no_progress_update(payload)
+        if _is_generic_status(summary.status_text) and _payload_has_status_hints(payload):
+            retry_payload = {
+                **payload,
+                "rejectedStatusText": summary.status_text,
+                "statusInstruction": (
+                    "The rejectedStatusText was too generic. Return a more specific status from recentEvents.safeText, "
+                    "recentEvents.objects, observedObjects, or the best statusHints example. If no concrete current work "
+                    "is visible, return previousStatus with shouldUpdate false."
+                ),
+            }
+            try:
+                retry_summary = await self._anthropic_summary(retry_payload)
+            except Exception as exc:
+                LOGGER.info("Slack progress model retry unavailable; skipping progress update: %s", exc)
+                retry_summary = None
+            if retry_summary is not None and not _is_generic_status(retry_summary.status_text):
+                return retry_summary
+            LOGGER.info("Slack progress model stayed generic; skipping deterministic fallback")
+            return _no_progress_update(payload)
+        return summary
+
+    async def _anthropic_summary(self, payload: dict[str, Any]) -> ProgressSummary | None:
+        request_body = {
+            "model": self.model,
+            "max_tokens": 80,
+            "temperature": 0,
+            "system": _progress_system_prompt(),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
+                }
+            ],
+        }
+        headers = {
+            "x-api-key": self.api_key or "",
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        if self._http_client is not None:
+            response = await self._http_client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+            response.raise_for_status()
+            data = response.json()
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                response = await client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+                response.raise_for_status()
+                data = response.json()
+
+        raw_text = _anthropic_text(data)
+        if not raw_text:
+            LOGGER.info("Slack progress model returned empty content")
+            return None
+        parsed = _parse_model_json(raw_text)
+        if parsed is None:
+            LOGGER.info("Slack progress model returned non-JSON content: %s", raw_text[:200])
+            return None
+        status_text = _safe_model_status_text(parsed.get("statusText"))
+        should_update = parsed.get("shouldUpdate")
+        if status_text is None or not isinstance(should_update, bool):
+            LOGGER.info("Slack progress model returned invalid status payload: %s", raw_text[:300])
+            return None
+        previous_status = _string(payload.get("previousStatus"))
+        LOGGER.info(
+            "Slack progress AI status=%r should_update=%s hints=%s objects=%s",
+            status_text,
+            should_update,
+            payload.get("statusHints") if isinstance(payload.get("statusHints"), list) else [],
+            payload.get("observedObjects") if isinstance(payload.get("observedObjects"), list) else [],
+        )
+        return ProgressSummary(status_text=status_text, should_update=should_update and status_text != previous_status)
+
+    def _deterministic_summary(self, payload: dict[str, Any]) -> ProgressSummary:
+        hint_summary = _summary_from_status_hints(payload)
+        if hint_summary is not None:
+            return hint_summary
+        previous_status = _string(payload.get("previousStatus"))
+        signals = set(payload.get("observedSignals") if isinstance(payload.get("observedSignals"), list) else [])
+        recent_events = payload.get("recentEvents") if isinstance(payload.get("recentEvents"), list) else []
+        recent_signals = {
+            _string(signal)
+            for event in recent_events
+            if isinstance(event, dict) and isinstance(event.get("signals"), list)
+            for signal in event.get("signals", [])
+        }
+        active_signals = recent_signals or signals
+        recent_objects = [
+            _string(value)
+            for event in recent_events
+            if isinstance(event, dict) and isinstance(event.get("objects"), list)
+            for value in event.get("objects", [])
+            if _string(value)
+        ]
+        table_ref = _first_object(recent_objects, _is_table_ref)
+        connection = _first_object(recent_objects, _is_connection_name)
+        dbt_model = _first_object(recent_objects, _is_dbt_model_path)
+        recent_tool_names = {
+            _string(event.get("toolName"))
+            for event in recent_events
+            if isinstance(event, dict) and _string(event.get("toolName"))
+        }
+        status_text = FALLBACK_PROGRESS_TEXT
+        if "generates_final_answer" in active_signals:
+            status_text = "Generating the final answer..."
+        elif "builds_charts" in active_signals:
+            chart = _best_chart_label(recent_objects)
+            status_text = f"Building {_format_chart_label(chart)}..." if chart else "Building charts..."
+        elif "contains_db_query" in active_signals:
+            if table_ref:
+                status_text = f"Querying {table_ref}..."
+            elif connection:
+                status_text = f"Querying {connection}..."
+            else:
+                status_text = "Querying database..."
+        elif "uses_dbt_marts" in active_signals:
+            status_text = "Finding mart models..."
+        elif "reads_dbt_project" in active_signals:
+            status_text = f"Reading {dbt_model}..." if dbt_model else "Finding dbt models..."
+        elif "connects_to_fin-db" in active_signals or "uses_sp_connections" in active_signals:
+            status_text = f"Checking {connection}..." if connection else "Checking data connections..."
+        elif "runs_notebook_cells" in active_signals or any("run_cells" in name for name in recent_tool_names):
+            status_text = "Running notebook cells..."
+        elif "notebook_edited" in active_signals:
+            status_text = "Writing analysis steps..."
+        elif "notebook_inspected" in active_signals:
+            status_text = "Inspecting the notebook..."
+        return ProgressSummary(status_text=status_text, should_update=status_text != previous_status)
+
+
+class SlackProgressReporter:
+    """Poll gateway chat traces and edit one Slack progress message."""
+
+    def __init__(
+        self,
+        *,
+        slack: Any,
+        session_factory: async_sessionmaker[AsyncSession],
+        org_id: str,
+        user_id: str,
+        thread_id: str,
+        source_prompt: str,
+        channel_id: str,
+        message_ts: str,
+        interval_seconds: float = 15.0,
+        summarizer: SlackProgressSummarizer | None = None,
+        initial_status: str = INITIAL_PROGRESS_TEXT,
+    ) -> None:
+        self.slack = slack
+        self.session_factory = session_factory
+        self.org_id = org_id
+        self.user_id = user_id or "slack-progress"
+        self.thread_id = thread_id
+        self.source_prompt = source_prompt
+        self.channel_id = channel_id
+        self.message_ts = message_ts
+        self.interval_seconds = max(float(interval_seconds or 15.0), 0.1)
+        self.summarizer = summarizer or SlackProgressSummarizer()
+        self.previous_status = initial_status
+        self._started_monotonic = time.monotonic()
+        self._started_wall_time = time.time()
+        self._observed_signals: set[str] = set()
+        self._observed_objects: list[str] = []
+        self._last_index = -1
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=self.interval_seconds)
+                continue
+            except TimeoutError:
+                pass
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                LOGGER.info("Slack progress reporter tick failed: %s", exc, exc_info=True)
+
+    async def _tick(self) -> None:
+        events = await self._fetch_events()
+        if not events:
+            return
+        self._last_index = max(int(_event_get(event, "idx", -1) or -1) for event in events)
+        new_signals = extract_progress_signals(events)
+        self._observed_signals.update(new_signals)
+        recent_events = sanitize_trace_events(events, started_at=self._started_wall_time)
+        for value in [
+            _string(value)
+            for event in recent_events
+            if isinstance(event, dict) and isinstance(event.get("objects"), list)
+            for value in event.get("objects", [])
+        ]:
+            _append_safe_object(self._observed_objects, value, 12, allow_label=True)
+        if not recent_events and not new_signals:
+            return
+        payload = {
+            "sourcePrompt": sanitize_source_prompt(self.source_prompt),
+            "elapsedSeconds": round(time.monotonic() - self._started_monotonic, 2),
+            "previousStatus": self.previous_status,
+            "runStatus": "Analyzing",
+            "recentEvents": recent_events,
+            "observedSignals": [signal for signal in _SIGNAL_ORDER if signal in self._observed_signals],
+            "observedObjects": self._observed_objects[-12:],
+        }
+        payload["statusHints"] = build_status_hints(payload)
+        LOGGER.info(
+            "Slack progress payload thread_id=%s previous=%r signals=%s objects=%s hints=%s events=%s",
+            self.thread_id,
+            self.previous_status,
+            payload["observedSignals"],
+            payload["observedObjects"],
+            payload["statusHints"],
+            _events_for_progress_log(recent_events),
+        )
+        summary = await self.summarizer.summarize(payload)
+        if not summary.should_update or summary.status_text == self.previous_status:
+            return
+        try:
+            await self.slack.update_message(
+                channel=self.channel_id,
+                ts=self.message_ts,
+                text=summary.status_text,
+            )
+        except Exception as exc:
+            LOGGER.info("Could not update Slack progress message: %s", exc, exc_info=True)
+            return
+        self.previous_status = summary.status_text
+
+    async def _fetch_events(self) -> list[Any]:
+        try:
+            async with self.session_factory() as db:
+                return await chat_traces.get_events(
+                    db,
+                    org_id=self.org_id,
+                    user_id=self.user_id,
+                    thread_id=self.thread_id,
+                    after_index=self._last_index,
+                )
+        except ValueError:
+            return []
+
+
+def sanitize_trace_events(
+    events: list[Any] | tuple[Any, ...],
+    *,
+    started_at: float | None = None,
+    max_events: int = _MAX_RECENT_EVENTS,
+) -> list[dict[str, Any]]:
+    sanitized: list[dict[str, Any]] = []
+    if not events:
+        return sanitized
+    event_list = list(events)[-max_events:]
+    base_time = started_at
+    if base_time is None:
+        event_times = [
+            float(value)
+            for event in event_list
+            if isinstance((value := _event_get(event, "created_at")), int | float)
+        ]
+        base_time = min(event_times) if event_times else None
+
+    for event in event_list:
+        event_type = _string(_event_get(event, "type")).strip()
+        tool_name = _string(_event_get(event, "tool_name")).strip()
+        item: dict[str, Any] = {
+            "idx": int(_event_get(event, "idx", -1) or -1),
+            "type": event_type,
+        }
+        elapsed = _elapsed_seconds(event, base_time)
+        if elapsed is not None:
+            item["elapsedSeconds"] = elapsed
+        signals = extract_progress_signals([event])
+        objects = extract_progress_objects([event])
+        if event_type == "tool_use" and tool_name:
+            item["toolName"] = tool_name
+            if signals:
+                item["signals"] = signals
+            if objects:
+                item["objects"] = objects
+            sanitized.append(item)
+            continue
+        if event_type in {"text", "thinking"}:
+            safe_text = _safe_trace_text(_string(_event_get(event, "content")))
+            if safe_text:
+                item["safeText"] = safe_text
+                if signals:
+                    item["signals"] = signals
+                if objects:
+                    item["objects"] = objects
+                sanitized.append(item)
+            continue
+        if event_type == "tool_result":
+            safe_text = _safe_tool_result_text(_string(_event_get(event, "content")))
+            if safe_text:
+                item["safeText"] = safe_text
+                if signals:
+                    item["signals"] = signals
+                if objects:
+                    item["objects"] = objects
+                sanitized.append(item)
+    return sanitized
+
+
+def extract_progress_signals(events: list[Any] | tuple[Any, ...]) -> list[str]:
+    found: set[str] = set()
+    for event in events:
+        tool_name = _string(_event_get(event, "tool_name")).lower()
+        content = _string(_event_get(event, "content"))
+        tool_input = _event_get(event, "tool_input")
+        input_text = _jsonish_text(tool_input)
+        haystack = f"{tool_name}\n{content}\n{input_text}".lower()
+        if "get_lightweight_cell_map" in haystack or "cell map" in haystack:
+            found.add("notebook_inspected")
+        if "edit_notebook" in haystack:
+            found.add("notebook_edited")
+        if "run_cells" in haystack:
+            found.add("runs_notebook_cells")
+        if (
+            "multipledefinitionerror" in haystack
+            or "transaction failed" in haystack
+            or "notebook error" in haystack
+            or "application/vnd.sp+error" in haystack
+        ):
+            found.add("notebook_error")
+        if "sp.connect" in haystack or "sp.connections" in haystack:
+            found.add("uses_sp_connections")
+        if "fin-db" in haystack or "fin db" in haystack:
+            found.add("connects_to_fin-db")
+        if "db.query" in haystack or _looks_like_sql(haystack):
+            found.add("contains_db_query")
+        if "dbt_project.yml" in haystack or "profiles.yml" in haystack or "/models/" in haystack:
+            found.add("reads_dbt_project")
+        if "analytics_marts" in haystack or "fct_" in haystack or "dim_" in haystack or "dbt mart" in haystack:
+            found.add("uses_dbt_marts")
+        if "plotly" in haystack or "matplotlib" in haystack or "chart" in haystack or "notioncharts" in haystack:
+            found.add("builds_charts")
+        if "get_notebook_errors" in haystack or "has_errors" in haystack:
+            found.add("validates_notebook")
+        if "finalanswer" in haystack or "notioncomment" in haystack or "slackmessage" in haystack:
+            found.add("generates_final_answer")
+    return [signal for signal in _SIGNAL_ORDER if signal in found]
+
+
+def extract_progress_objects(events: list[Any] | tuple[Any, ...], *, limit: int = 6) -> list[str]:
+    found: list[str] = []
+    for event in events:
+        content = _redact_sensitive_text(_string(_event_get(event, "content")))
+        tool_input = _redact_sensitive_text(_jsonish_text(_event_get(event, "tool_input")))
+        haystack = f"{content}\n{tool_input}"
+
+        for match in re.finditer(r"\bsp\.connect\(\s*\\*['\"]([^'\"\\]{1,80})\\*['\"]\s*\)", haystack, re.I):
+            _append_safe_object(found, match.group(1), limit)
+
+        for match in re.finditer(r"\b([A-Za-z_][\w]*\.[A-Za-z_][\w]*)\b", haystack):
+            value = match.group(1)
+            if _is_table_ref(value):
+                _append_safe_object(found, value, limit)
+
+        for match in re.finditer(r"(?<![\w/.-])((?:[\w.-]+/)*models/[\w./-]+\.sql)\b", haystack):
+            value = match.group(1)
+            model_index = value.find("models/")
+            if model_index >= 0:
+                _append_safe_object(found, value[model_index:], limit)
+
+        for match in re.finditer(r"(?<![\\\w])build_([A-Za-z0-9_]{2,60})_chart\b", haystack, re.I):
+            _append_safe_object(found, f"{match.group(1).replace('_', ' ')} chart", limit, allow_label=True)
+
+        for match in re.finditer(r"(?<![\\\w])([A-Za-z0-9_]{2,60})_chart\b", haystack, re.I):
+            if match.group(1).lower().startswith("build_"):
+                continue
+            _append_safe_object(found, f"{match.group(1).replace('_', ' ')} chart", limit, allow_label=True)
+
+        for match in re.finditer(r"\.set_title\(\s*['\"]([^'\"]{3,100})['\"]", haystack, re.I):
+            _append_safe_object(found, match.group(1), limit, allow_label=True)
+
+        for match in re.finditer(r"savefig\(\s*['\"][^'\"]*/([^/'\"]{3,80})\.(?:png|jpg|jpeg|webp|svg)['\"]", haystack, re.I):
+            label = match.group(1).replace("_", " ").replace("-", " ")
+            _append_safe_object(found, f"{label} chart", limit, allow_label=True)
+
+        for match in re.finditer(
+            r"\b(?:for|around|about)\s+the\s+([A-Za-z][A-Za-z0-9&/ -]{2,80}?)\s+(?:chart|comparison|visualization)\b",
+            haystack,
+            re.I,
+        ):
+            _append_safe_object(found, f"{match.group(1).strip()} chart", limit, allow_label=True)
+
+        if len(found) >= limit:
+            break
+    return found
+
+
+def build_status_hints(payload: dict[str, Any], *, limit: int = 8) -> list[str]:
+    hints: list[str] = []
+    recent_events = payload.get("recentEvents") if isinstance(payload.get("recentEvents"), list) else []
+    raw_observed_objects = payload.get("observedObjects")
+    observed_objects = [
+        _string(value)
+        for value in (raw_observed_objects if isinstance(raw_observed_objects, list) else [])
+        if _string(value)
+    ]
+
+    for event in recent_events:
+        if not isinstance(event, dict):
+            continue
+        signals = set(event.get("signals") if isinstance(event.get("signals"), list) else [])
+        objects = [
+            _string(value)
+            for value in event.get("objects", [])
+            if isinstance(event.get("objects"), list) and _string(value)
+        ]
+        combined_objects = [value for value in observed_objects if value not in objects] + objects
+        table = _first_object(combined_objects, _is_table_ref)
+        connection = _first_object(combined_objects, _is_connection_name)
+        chart = _best_chart_label(combined_objects)
+        model_path = _first_object(combined_objects, _is_dbt_model_path)
+
+        if "contains_db_query" in signals and table:
+            _append_hint(hints, f"Querying {table}...", limit)
+        if "contains_db_query" in signals and connection:
+            _append_hint(hints, f"Querying {connection}...", limit)
+        if "builds_charts" in signals and chart:
+            _append_hint(hints, f"Building {_format_chart_label(chart)}...", limit)
+        if "runs_notebook_cells" in signals and chart:
+            _append_hint(hints, f"Rendering {_format_chart_label(chart)}...", limit)
+        if "runs_notebook_cells" in signals and table:
+            _append_hint(hints, f"Running {table} query...", limit)
+        if "runs_notebook_cells" in signals and connection:
+            _append_hint(hints, f"Running {connection} notebook cells...", limit)
+        if "reads_dbt_project" in signals and model_path:
+            _append_hint(hints, f"Reading {model_path}...", limit)
+        if "uses_sp_connections" in signals and connection:
+            _append_hint(hints, f"Connecting to {connection}...", limit)
+        if "validates_notebook" in signals:
+            _append_hint(hints, "Checking notebook errors...", limit)
+
+        safe_text = _string(event.get("safeText")).lower()
+        prose_chart = _chart_label_from_text(safe_text)
+        if prose_chart:
+            _append_hint(hints, f"Building {_format_chart_label(prose_chart)}...", limit)
+        if ("run the entire notebook" in safe_text or "execute all queries" in safe_text) and chart:
+            _append_hint(hints, f"Rendering {_format_chart_label(chart)}...", limit)
+        if ("run the entire notebook" in safe_text or "execute all queries" in safe_text) and table:
+            _append_hint(hints, f"Running {table} query...", limit)
+        if "final json" in safe_text or "final response" in safe_text or "final answer" in safe_text:
+            _append_hint(hints, "Generating the final answer...", limit)
+        if "final error check" in safe_text or "remaining errors" in safe_text:
+            _append_hint(hints, "Checking notebook errors...", limit)
+        if "executive summary" in safe_text:
+            _append_hint(hints, "Polishing executive summary...", limit)
+        if "stale" in safe_text and "variable" in safe_text:
+            _append_hint(hints, "Fixing stale variable definitions...", limit)
+        if "multipledefinitionerror" in safe_text or "duplicate definition" in safe_text:
+            duplicate_name = _duplicate_definition_name(safe_text)
+            if duplicate_name:
+                _append_hint(hints, f"Fixing duplicate {duplicate_name} definitions...", limit)
+            else:
+                _append_hint(hints, "Fixing duplicate notebook definitions...", limit)
+        if "stale" in safe_text and ("cell" in safe_text or "kernel" in safe_text or "graph" in safe_text):
+            _append_hint(hints, "Clearing stale notebook state...", limit)
+        if "delete" in safe_text and "cell" in safe_text and ("recreate" in safe_text or "brand new" in safe_text):
+            _append_hint(hints, "Recreating notebook cells...", limit)
+        if "empty output" in safe_text or "suppresses the display" in safe_text or "last expression" in safe_text:
+            _append_hint(hints, "Fixing markdown output rendering...", limit)
+        if "renders correctly" in safe_text or "rendering correctly" in safe_text:
+            _append_hint(hints, "Checking rendered markdown output...", limit)
+
+        if len(hints) >= limit:
+            break
+
+    if not hints:
+        for value in observed_objects[-4:]:
+            if _is_table_ref(value):
+                _append_hint(hints, f"Querying {value}...", limit)
+            elif _is_chart_label(value):
+                _append_hint(hints, f"Building {_format_chart_label(value)}...", limit)
+    return hints
+
+
+def sanitize_source_prompt(prompt: str) -> str:
+    text = _redact_sensitive_text(" ".join(prompt.split()))
+    if _looks_like_sql(text):
+        return ""
+    return _clip(text, _SAFE_TEXT_LIMIT)
+
+
+def _progress_system_prompt() -> str:
+    return (
+        "Return strict JSON only with keys statusText and shouldUpdate. Do not wrap the JSON in Markdown fences. "
+        "statusText must be one short present-tense sentence for a Slack progress update, usually 3-8 words. "
+        "Prefer concrete micro-decisions from recentEvents.safeText, recentEvents.objects, observedObjects, and signals. "
+        "Use statusHints only as fallback examples when they match the current recentEvents. Good statuses include "
+        "'Querying private-equity-db...', 'Finding mart models...', 'Querying staging.fct_revenue...', "
+        "'Building EBITDA chart...', 'Fixing duplicate sp definitions...', 'Clearing stale notebook state...', "
+        "'Recreating markdown cells...', 'Checking rendered markdown output...', or 'Generating the final answer...'. "
+        "When the current event is chart-related, name the chart/metric from recentEvents.objects or observedObjects. "
+        "Avoid generic phrases such as 'Inspecting the notebook', 'Writing analysis steps', 'Running notebook cells', "
+        "'Building charts', 'Querying database', or 'Working through the analysis' whenever statusHints or objects exist. "
+        "Use only object names provided in the payload. Do not invent table names, connection names, findings, "
+        "numbers, SQL, row counts, caveats, stack traces, or draft conclusions. "
+        "If the payload only shows generic tool activity and no concrete current work, return previousStatus and shouldUpdate false."
+    )
+
+
+def _anthropic_text(data: dict[str, Any]) -> str:
+    content = data.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts).strip()
+
+
+def _parse_model_json(raw_text: str) -> dict[str, Any] | None:
+    text = raw_text.strip()
+    candidates = [text]
+    candidates.extend(match.group(1).strip() for match in re.finditer(r"```(?:json)?\s*([\s\S]*?)```", text, re.I))
+    object_text = _first_json_object(text)
+    if object_text:
+        candidates.append(object_text)
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _first_json_object(text: str) -> str:
+    start = text.find("{")
+    while start >= 0:
+        depth = 0
+        in_string = False
+        escaped = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : index + 1]
+        start = text.find("{", start + 1)
+    return ""
+
+
+def _no_progress_update(payload: dict[str, Any]) -> ProgressSummary:
+    status_text = _string(payload.get("previousStatus")) or FALLBACK_PROGRESS_TEXT
+    return ProgressSummary(status_text=status_text, should_update=False)
+
+
+def _events_for_progress_log(events: list[dict[str, Any]], *, limit: int = 8) -> list[dict[str, Any]]:
+    logged: list[dict[str, Any]] = []
+    for event in events[-limit:]:
+        if not isinstance(event, dict):
+            continue
+        item: dict[str, Any] = {
+            "idx": event.get("idx"),
+            "type": event.get("type"),
+        }
+        for key in ("toolName", "signals", "objects"):
+            if event.get(key):
+                item[key] = event[key]
+        safe_text = _string(event.get("safeText"))
+        if safe_text:
+            item["safeText"] = _clip(safe_text, 120)
+        logged.append(item)
+    return logged
+
+
+def _safe_model_status_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = " ".join(value.strip().split())
+    if not text or len(text) > 140 or "\n" in value:
+        return None
+    if (
+        _looks_like_raw_sql_status(text)
+        or _looks_like_stack_trace(text)
+        or _looks_like_result_or_answer(text)
+        or _contains_numeric_finding(text)
+    ):
+        return None
+    if _contains_sensitive_text(text):
+        return None
+    if not text.endswith((".", "...")):
+        text += "..."
+    return text
+
+
+def _safe_trace_text(value: str) -> str:
+    text = _redact_sensitive_text(" ".join(value.split()))
+    if not text:
+        return ""
+    if _looks_like_json_blob(text) or _looks_like_sql(text) or _looks_like_stack_trace(text):
+        return ""
+    if _looks_like_result_or_answer(text) or _contains_numeric_finding(text):
+        return ""
+    return _clip(text, _SAFE_TEXT_LIMIT)
+
+
+def _safe_tool_result_text(value: str) -> str:
+    text = _redact_sensitive_text(" ".join(value.split()))
+    if not text:
+        return ""
+    lower = text.lower()
+    if "multipledefinitionerror" in lower:
+        name = _duplicate_definition_name(text)
+        if name:
+            return f"Notebook error: MultipleDefinitionError for {name}"
+        return "Notebook error: MultipleDefinitionError"
+    if "transaction failed" in lower and "cell" in lower and "not found" in lower:
+        return "Notebook edit failed: cell not found"
+    if "has_errors" in lower:
+        if re.search(r"has_errors[\"']?\s*[:=]\s*true", lower):
+            return "Notebook still has errors"
+        if re.search(r"has_errors[\"']?\s*[:=]\s*false", lower):
+            return "Notebook errors cleared"
+    if "timed_out" in lower and re.search(r"timed_out[\"']?\s*[:=]\s*true", lower):
+        return "Notebook cell run timed out"
+    return ""
+
+
+def _duplicate_definition_name(text: str) -> str:
+    match = re.search(r"multipledefinitionerror\(name=\\*['\"]?([A-Za-z_][\w]*)", text, re.I)
+    if match:
+        return match.group(1)
+    match = re.search(r"multipledefinitionerror\s+for\s+([A-Za-z_][\w]*)", text, re.I)
+    if match:
+        return match.group(1)
+    match = re.search(r"duplicate\s+[`'\"]?([A-Za-z_][\w]*)[`'\"]?\s+definitions?", text, re.I)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def _redact_sensitive_text(text: str) -> str:
+    text = re.sub(r"sk-ant-[A-Za-z0-9_-]+", "[secret]", text)
+    text = re.sub(r"xox[abprs]-[A-Za-z0-9-]+", "[secret]", text)
+    text = re.sub(r"(?i)\bpostgres(?:ql)?://\S+", "[database-url]", text)
+    return re.sub(r"(?i)(api[_-]?key|token|password)\s*[:=]\s*[^\s,;]+", r"\1=[secret]", text)
+
+
+def _contains_sensitive_text(text: str) -> bool:
+    return bool(re.search(r"sk-ant-|xox[abprs]-|postgres(?:ql)?://|api[_-]?key\s*[:=]|password\s*[:=]", text, re.I))
+
+
+def _looks_like_json_blob(text: str) -> bool:
+    stripped = text.strip()
+    if stripped.startswith(("{", "[")):
+        return True
+    return text.count("{") + text.count("[") >= 3 or '":' in text
+
+
+def _looks_like_sql(text: str) -> bool:
+    return bool(
+        re.search(r"\b(select|with)\b[\s\S]{0,500}\b(from|join|where|group\s+by|order\s+by)\b", text, re.I)
+        or re.search(r"\b(insert|update|delete|create|drop|alter)\b[\s\S]{0,300}\b(table|view|schema)\b", text, re.I)
+        or "db.query(" in text
+        or "analytics_marts." in text
+        or "information_schema." in text
+    )
+
+
+def _looks_like_raw_sql_status(text: str) -> bool:
+    return bool(
+        re.search(r"\b(select|with)\b[\s\S]{0,300}\b(from|join|where|group\s+by|order\s+by)\b", text, re.I)
+        or re.search(r"\b(insert|update|delete|create|drop|alter)\b[\s\S]{0,200}\b(table|view|schema)\b", text, re.I)
+        or "db.query(" in text.lower()
+        or "information_schema." in text.lower()
+    )
+
+
+def _looks_like_stack_trace(text: str) -> bool:
+    return bool(re.search(r"traceback|exception|stack trace|file \"[^\"]+\", line \d+", text, re.I))
+
+
+def _looks_like_result_or_answer(text: str) -> bool:
+    return bool(
+        re.search(r"finalanswer|notioncomment|slackmessage|confidencescore|notioncharts|gotchas", text, re.I)
+        or re.search(r"signalpilot analysis complete|executive summary|bottom line|what i found", text, re.I)
+        or re.search(r"data-initial-value|<sp-table|<table|<span class=", text, re.I)
+    )
+
+
+def _contains_numeric_finding(text: str) -> bool:
+    if re.search(r"[$£€¥]\s*\d|\d+\s*%|\d{1,3}(,\d{3})+|\d+\.\d+", text):
+        return True
+    if re.search(r"\b(revenue|transfers?|customers?|rows?|count|total|sum)\b", text, re.I):
+        return len(re.findall(r"\d+", text)) >= 2
+    return False
+
+
+def _append_hint(hints: list[str], value: str, limit: int) -> None:
+    value = _safe_model_status_text(value) or ""
+    if value and value not in hints and len(hints) < limit:
+        hints.append(value)
+
+
+def _summary_from_status_hints(payload: dict[str, Any]) -> ProgressSummary | None:
+    raw_hints = payload.get("statusHints")
+    if not isinstance(raw_hints, list):
+        return None
+    previous_status = _string(payload.get("previousStatus"))
+    for value in raw_hints:
+        status_text = _safe_model_status_text(value)
+        if status_text and not _is_generic_status(status_text):
+            return ProgressSummary(status_text=status_text, should_update=status_text != previous_status)
+    return None
+
+
+def _payload_has_status_hints(payload: dict[str, Any]) -> bool:
+    return isinstance(payload.get("statusHints"), list) and bool(payload["statusHints"])
+
+
+def _is_generic_status(text: str) -> bool:
+    normalized = text.strip().rstrip(".").lower()
+    return normalized in {
+        "inspecting the notebook",
+        "writing analysis steps",
+        "running notebook cells",
+        "building charts",
+        "querying database",
+        "checking data connections",
+        "working through the analysis",
+        "planning the analysis",
+    }
+
+
+def _first_object(values: list[str], predicate: Any) -> str:
+    for value in reversed(values):
+        if predicate(value):
+            return value
+    return ""
+
+
+def _best_chart_label(values: list[str]) -> str:
+    chart_values = [value for value in values if _is_chart_label(value)]
+    for value in reversed(chart_values):
+        if " " in value and any(char.isupper() for char in value):
+            return value
+    return chart_values[-1] if chart_values else ""
+
+
+def _format_chart_label(value: str) -> str:
+    label = " ".join(value.split())
+    if not re.search(r"\b(chart|trend|comparison|visualization)\b", label, re.I):
+        label = f"{label} chart"
+    return label
+
+
+def _chart_label_from_text(text: str) -> str:
+    for pattern in (
+        r"\b(?:for|around|about)\s+the\s+([a-z][a-z0-9&/ -]{2,80}?)\s+(?:chart|comparison|visualization)\b",
+        r"\b(?:building|rendering|adding|creating)\s+(?:a\s+|the\s+)?([a-z][a-z0-9&/ -]{2,80}?)\s+(?:chart|comparison|visualization)\b",
+    ):
+        match = re.search(pattern, text, re.I)
+        if match:
+            return f"{match.group(1).strip()} chart"
+    return ""
+
+
+def _append_safe_object(found: list[str], value: str, limit: int, *, allow_label: bool = False) -> None:
+    value = _normalize_progress_object(value, allow_label=allow_label)
+    if value and value not in found and len(found) < limit:
+        found.append(value)
+
+
+def _normalize_progress_object(value: str, *, allow_label: bool = False) -> str:
+    value = value.strip().strip("'\"`),;")
+    if not value or len(value) > 100:
+        return ""
+    if _contains_sensitive_text(value) or "://" in value:
+        return ""
+    if allow_label:
+        value = " ".join(value.split())
+        if not re.fullmatch(r"[A-Za-z0-9_./@%&() -]+", value):
+            return ""
+        if _looks_like_sql(value) or _looks_like_result_or_answer(value) or _contains_numeric_finding(value):
+            return ""
+        return value
+    if any(char.isspace() for char in value) or not re.fullmatch(r"[A-Za-z0-9_./@-]+", value):
+        return ""
+    return value
+
+
+def _is_table_ref(value: str) -> bool:
+    if value.lower().endswith(".sql"):
+        return False
+    if not re.fullmatch(r"[A-Za-z_][\w]*\.[A-Za-z_][\w]*", value):
+        return False
+    schema, table = value.split(".", 1)
+    schema_lower = schema.lower()
+    table_lower = table.lower()
+    if schema_lower in {"http", "https", "www", "api", "slack"}:
+        return False
+    return (
+        schema_lower in {"raw", "staging", "analytics", "analytics_marts", "marts", "intermediate", "portfolio", "public"}
+        or table_lower.startswith(("fct_", "dim_", "stg_", "int_"))
+        or table_lower.endswith(("_metrics", "_financials", "_companies", "_pipeline", "_initiatives", "_notes"))
+    )
+
+
+def _is_connection_name(value: str) -> bool:
+    return bool("-" in value and "." not in value and "/" not in value and len(value) <= 80)
+
+
+def _is_dbt_model_path(value: str) -> bool:
+    return value.startswith("models/") and value.endswith(".sql")
+
+
+def _is_chart_label(value: str) -> bool:
+    lower = value.lower()
+    if "chart" in lower or "trend" in lower or "comparison" in lower or "visualization" in lower:
+        return True
+    return " " in value and bool(
+        re.search(r"\b(ebitda|revenue|arr|nrr|churn|margin|pipeline|financial|customer|retention)\b", lower)
+    )
+
+
+def _event_get(event: Any, key: str, default: Any = None) -> Any:
+    if isinstance(event, dict):
+        return event.get(key, default)
+    return getattr(event, key, default)
+
+
+def _elapsed_seconds(event: Any, started_at: float | None) -> float | None:
+    created_at = _event_get(event, "created_at")
+    if started_at is None or not isinstance(created_at, int | float):
+        return None
+    return round(max(float(created_at) - float(started_at), 0.0), 2)
+
+
+def _jsonish_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value[:50_000]
+    try:
+        return json.dumps(value, ensure_ascii=True, default=str)[:50_000]
+    except TypeError:
+        return str(value)[:50_000]
+
+
+def _clip(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 14].rstrip() + "... truncated"
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/signalpilot/gateway/gateway/slack_poc/progress.py
+++ b/signalpilot/gateway/gateway/slack_poc/progress.py
@@ -18,7 +18,7 @@ from gateway.store import chat_traces
 
 LOGGER = logging.getLogger(__name__)
 
-INITIAL_PROGRESS_TEXT = "Planning the analysis..."
+INITIAL_PROGRESS_TEXT = "Analyzing your request..."
 COMPLETING_PROGRESS_TEXT = "Generating the final answer..."
 FALLBACK_PROGRESS_TEXT = "Working through the analysis..."
 

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -43,6 +43,7 @@ from gateway.slack_poc.progress import (
     INITIAL_PROGRESS_TEXT,
 )
 from gateway.store import slack as slack_store
+from gateway.string_utils import string_value as _string
 
 LOGGER = logging.getLogger(__name__)
 SLACK_API_BASE = "https://slack.com/api"
@@ -51,10 +52,57 @@ SLACK_CHART_LIMIT = 3
 SLACK_ACK_REACTION = "eyes"
 SLACK_DONE_REACTION = "white_check_mark"
 SLACK_ERROR_REACTION = "x"
+SLACK_EVENT_DEDUPE_MAX_SIZE = 10_000
+SLACK_EVENT_DEDUPE_TTL_SECONDS = 6 * 60 * 60
+_PLACEHOLDER_CHART_TITLE_RE = re.compile(
+    r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?",
+    flags=re.I,
+)
 
 
 class SlackApiError(RuntimeError):
     """Raised when Slack Web API returns ok=false or a non-2xx response."""
+
+
+class _EventDeduper:
+    def __init__(
+        self,
+        *,
+        max_size: int = SLACK_EVENT_DEDUPE_MAX_SIZE,
+        ttl_seconds: float = SLACK_EVENT_DEDUPE_TTL_SECONDS,
+    ) -> None:
+        self.max_size = max(1, int(max_size))
+        self.ttl_seconds = max(1.0, float(ttl_seconds))
+        self._seen: dict[str, float] = {}
+
+    def add(self, event_id: str, *, now: float | None = None) -> bool:
+        if not event_id:
+            return True
+        current = time.monotonic() if now is None else now
+        self._prune(current)
+        if event_id in self._seen:
+            self._seen[event_id] = current
+            return False
+        self._seen[event_id] = current
+        self._prune_to_size()
+        return True
+
+    def __len__(self) -> int:
+        return len(self._seen)
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - self.ttl_seconds
+        for event_id, seen_at in list(self._seen.items()):
+            if seen_at < cutoff:
+                self._seen.pop(event_id, None)
+
+    def _prune_to_size(self) -> None:
+        overflow = len(self._seen) - self.max_size
+        if overflow <= 0:
+            return
+        oldest = sorted(self._seen, key=self._seen.get)
+        for event_id in oldest[:overflow]:
+            self._seen.pop(event_id, None)
 
 
 def _slack_api_error(method: str, data: dict[str, Any]) -> SlackApiError:
@@ -209,7 +257,7 @@ class SlackApiClient:
         channel: str,
         thread_ts: str,
         filename: str,
-        title: str,
+        title: str | None,
         content: bytes,
         content_type: str,
     ) -> None:
@@ -229,10 +277,13 @@ class SlackApiClient:
         )
         response.raise_for_status()
 
+        file_payload = {"id": file_id}
+        if title:
+            file_payload["title"] = title
         await self._api_form(
             "files.completeUploadExternal",
             {
-                "files": json.dumps([{"id": file_id, "title": title}]),
+                "files": json.dumps([file_payload]),
                 "channel_id": channel,
                 "thread_ts": thread_ts,
             },
@@ -263,17 +314,16 @@ class SlackPoCWorker:
         self.config = config
         self.slack = slack
         self.session_factory = session_factory
-        self._seen_event_ids: set[str] = set()
+        self._seen_event_ids = _EventDeduper()
         self._tasks: set[asyncio.Task[None]] = set()
 
     async def handle_events_api_payload(self, payload: dict[str, Any]) -> None:
         request = await self._request_from_payload(payload)
         if request is None:
             return
-        if request.event_id in self._seen_event_ids:
+        if not self._seen_event_ids.add(request.event_id):
             LOGGER.info("Ignoring duplicate Slack event_id=%s", request.event_id)
             return
-        self._seen_event_ids.add(request.event_id)
         if await self._handle_preflight(request):
             return
         task = asyncio.create_task(self._process_request(request), name=f"slack-poc-{request.event_id}")
@@ -639,7 +689,7 @@ class SlackPoCWorker:
         attached = 0
         errors: list[str] = []
         for index, chart in enumerate(charts):
-            title = _chart_value(chart, "title") or f"Chart {index + 1}"
+            title = _chart_attachment_title(chart)
             source_url = _chart_value(chart, "url")
             if not source_url:
                 continue
@@ -661,7 +711,7 @@ class SlackPoCWorker:
                 LOGGER.warning(
                     "Could not attach Slack chart event_id=%s title=%s url=%s: %s",
                     request.event_id,
-                    title,
+                    title or _chart_value(chart, "title") or f"chart-{index + 1}",
                     source_url,
                     exc,
                     exc_info=True,
@@ -814,7 +864,7 @@ def register_http_routes(
         app.state.slack_poc_client = None
     app.state.slack_poc_worker = None
     app.state.slack_poc_worker_lock = asyncio.Lock()
-    app.state.slack_poc_selfserve_event_ids = set()
+    app.state.slack_poc_selfserve_event_ids = _EventDeduper()
 
     async def ensure_worker() -> SlackPoCWorker:
         if not config.bot_token:
@@ -866,11 +916,10 @@ def register_http_routes(
 
             event_id = _string(payload.get("event_id"))
             if event_id:
-                seen: set[str] = app.state.slack_poc_selfserve_event_ids
-                if event_id in seen:
+                seen: _EventDeduper = app.state.slack_poc_selfserve_event_ids
+                if not seen.add(event_id):
                     LOGGER.info("Ignoring duplicate Slack event_id=%s", event_id)
                     return
-                seen.add(event_id)
             if initialize_db_on_first_request:
                 await init_db()
             await _dispatch_self_serve_payload(payload, config)
@@ -1173,10 +1222,6 @@ def _channel_defaults_from_env() -> dict[str, SlackAnalysisDefaults]:
     return defaults
 
 
-def _string(value: Any) -> str:
-    return value if isinstance(value, str) else ""
-
-
 def _first_authorization_team_id(payload: dict[str, Any]) -> str:
     authorizations = payload.get("authorizations")
     if not isinstance(authorizations, list) or not authorizations:
@@ -1222,6 +1267,23 @@ def _chart_value(chart: dict[str, Any], *keys: str) -> str:
     return ""
 
 
+def _is_placeholder_chart_title(value: str) -> bool:
+    return bool(_PLACEHOLDER_CHART_TITLE_RE.fullmatch(value.strip()))
+
+
+def _chart_attachment_title(chart: dict[str, Any]) -> str | None:
+    for key in ("title", "caption", "altText", "alt_text"):
+        value = _chart_value(chart, key)
+        if value and not _is_placeholder_chart_title(value):
+            return value
+    return None
+
+
+def _is_placeholder_chart_filename(value: str) -> bool:
+    stem = Path(value).stem.replace("-", " ").replace("_", " ").strip()
+    return _is_placeholder_chart_title(stem)
+
+
 def _chart_filename_extension(content_type: str) -> str:
     normalized = content_type.lower().split(";", 1)[0].strip()
     if normalized == "image/jpeg":
@@ -1237,48 +1299,17 @@ def _chart_filename_extension(content_type: str) -> str:
 
 def _chart_filename(chart: dict[str, Any], index: int, content_type: str) -> str:
     explicit = _chart_value(chart, "fileName", "file_name")
-    if explicit:
+    if explicit and not _is_placeholder_chart_filename(explicit):
         return explicit
-    title = _chart_value(chart, "title") or f"chart-{index + 1}"
+    title = _chart_attachment_title(chart) or f"chart-{index + 1}"
     stem = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:80]
     return f"{stem or f'chart-{index + 1}'}.{_chart_filename_extension(content_type)}"
-
-
-def _slack_link(url: str, label: str) -> str:
-    return f"<{url.replace('>', '%3E')}|{label}>"
-
-
-def _to_slack_mrkdwn(text: str) -> str:
-    text = re.sub(r"\*\*([^*\n]+?)\*\*", r"*\1*", text)
-    text = re.sub(r"__([^_\n]+?)__", r"*\1*", text)
-    return re.sub(r"\[([^\]\n]+)\]\((https?://[^)\s]+)\)", r"<\2|\1>", text)
-
-
-def _final_slack_text(status: dict[str, Any], trail_url: str | None) -> str:
-    if status.get("status") != "Done" or status.get("error"):
-        return _failure_slack_text(str(status.get("error") or "SignalPilot analysis failed."), trail_url)
-
-    raw_answer = (
-        _string(status.get("slackMessage")).strip()
-        or _string(status.get("notionComment")).strip()
-        or _string(status.get("finalAnswer")).strip()
-        or _string(status.get("summary")).strip()
-        or "I finished the analysis, but there was no written answer in the result."
-    )
-    answer = _to_slack_mrkdwn(notebook_analysis._compact_bullet_answer(raw_answer) or raw_answer)
-    parts = ["*SignalPilot analysis complete*", answer]
-    confidence = status.get("confidenceScore", status.get("confidence_score"))
-    if confidence is not None:
-        parts.append(f"*Confidence:* {confidence}")
-    if trail_url:
-        parts.append(f"*Notebook trail:* {_slack_link(trail_url, 'Open authenticated notebook')}")
-    return _clip_text("\n\n".join(parts))
 
 
 def _failure_slack_text(error: str, trail_url: str | None) -> str:
     text = f"I could not complete the analysis.\n\n```{error[:3000]}```"
     if trail_url:
-        text += f"\n\nNotebook trail: {_slack_link(trail_url, 'Open notebook')}"
+        text += f"\n\nNotebook trail: <{trail_url.replace('>', '%3E')}|Open notebook>"
     return _clip_text(text)
 
 

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -25,14 +25,22 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from gateway.analysis_delivery import (
+    AnalysisPreflightKind,
+    SlackTraceProgressReporter,
+    classify_analysis_request,
+    delivery_result_to_status,
+    load_delivery_packet,
+    load_delivery_packet_from_events,
+    render_delivery,
+    render_slack_final_message,
+)
 from gateway.db.engine import close_db, get_session_factory, init_db
 from gateway.notebooks.session_service import NotebookRuntime, ensure_analysis_notebook_session
 from gateway.notion import analysis as notebook_analysis
 from gateway.slack_poc.progress import (
     COMPLETING_PROGRESS_TEXT,
     INITIAL_PROGRESS_TEXT,
-    SlackProgressReporter,
-    SlackProgressSummarizer,
 )
 from gateway.store import slack as slack_store
 
@@ -42,6 +50,7 @@ SLACK_TEXT_LIMIT = 35000
 SLACK_CHART_LIMIT = 3
 SLACK_ACK_REACTION = "eyes"
 SLACK_DONE_REACTION = "white_check_mark"
+SLACK_ERROR_REACTION = "x"
 
 
 class SlackApiError(RuntimeError):
@@ -265,6 +274,8 @@ class SlackPoCWorker:
             LOGGER.info("Ignoring duplicate Slack event_id=%s", request.event_id)
             return
         self._seen_event_ids.add(request.event_id)
+        if await self._handle_preflight(request):
+            return
         task = asyncio.create_task(self._process_request(request), name=f"slack-poc-{request.event_id}")
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
@@ -322,6 +333,17 @@ class SlackPoCWorker:
             thread_ts=thread_ts,
             source_url=source_url,
         )
+
+    async def _handle_preflight(self, request: SlackRequest) -> bool:
+        decision = classify_analysis_request(request.text)
+        if decision.kind == AnalysisPreflightKind.ANALYZE:
+            return False
+        await self.slack.post_message(
+            channel=request.channel_id,
+            thread_ts=request.thread_ts,
+            text=decision.response or "Send me a specific data question and I will run it through SignalPilot.",
+        )
+        return True
 
     async def _process_request(self, request: SlackRequest) -> None:
         trail_url: str | None = None
@@ -430,15 +452,37 @@ class SlackPoCWorker:
                     route=route,
                     status=status,
                 )
-            slack_status = notebook_analysis._with_public_chart_urls(status, runtime)
+            public_status = notebook_analysis._with_public_chart_urls(status, runtime)
+            try:
+                async with self.session_factory() as db:
+                    packet = await load_delivery_packet(
+                        db,
+                        org_id=self.config.org_id,
+                        user_id=analysis_user_id,
+                        thread_id=trace_thread_id,
+                        user_request=request.text,
+                        status_payload=public_status,
+                        trail_url=trail_url or "",
+                    )
+            except Exception as exc:
+                LOGGER.info("Could not load Slack delivery trace; using status fallback: %s", exc, exc_info=True)
+                packet = load_delivery_packet_from_events(
+                    [],
+                    user_request=request.text,
+                    status_payload=public_status,
+                    trail_url=trail_url or "",
+                    thread_status="done",
+                )
+            delivery = await render_delivery(packet)
+            slack_status = delivery_result_to_status(delivery, packet, base_status=public_status)
             await self._update_or_post_result_message(
                 channel=request.channel_id,
                 thread_ts=request.thread_ts,
                 message_ts=progress_ts,
-                text=_final_slack_text(slack_status, trail_url),
+                text=render_slack_final_message(packet, delivery, trail_url=trail_url),
             )
             await self._mark_request_done(request)
-            await self._post_chart_attachments(request, status, runtime)
+            await self._post_chart_attachments(request, slack_status, runtime)
         except Exception as exc:
             LOGGER.warning("Slack PoC request failed: event_id=%s error=%s", request.event_id, exc, exc_info=True)
             if route is not None:
@@ -462,6 +506,7 @@ class SlackPoCWorker:
                 message_ts=progress_ts,
                 text=_failure_slack_text(str(exc), trail_url),
             )
+            await self._mark_request_failed(request)
         finally:
             await self._stop_progress_reporter(progress_stop, progress_task)
             await self._remove_request_reaction(request, SLACK_ACK_REACTION)
@@ -485,6 +530,12 @@ class SlackPoCWorker:
     async def _mark_request_done(self, request: SlackRequest) -> None:
         await self._add_request_reaction(request, SLACK_DONE_REACTION)
         await self._remove_request_reaction(request, SLACK_ACK_REACTION)
+        await self._remove_request_reaction(request, SLACK_ERROR_REACTION)
+
+    async def _mark_request_failed(self, request: SlackRequest) -> None:
+        await self._add_request_reaction(request, SLACK_ERROR_REACTION)
+        await self._remove_request_reaction(request, SLACK_ACK_REACTION)
+        await self._remove_request_reaction(request, SLACK_DONE_REACTION)
 
     async def _update_or_post_result_message(
         self,
@@ -512,12 +563,7 @@ class SlackPoCWorker:
         message_ts: str,
         user_id: str,
     ) -> None:
-        summarizer = SlackProgressSummarizer(
-            provider=self.config.progress_model_provider,
-            model=self.config.progress_model,
-            timeout_seconds=self.config.progress_model_timeout_seconds,
-        )
-        reporter = SlackProgressReporter(
+        reporter = SlackTraceProgressReporter(
             slack=self.slack,
             session_factory=self.session_factory,
             org_id=self.config.org_id,
@@ -527,7 +573,6 @@ class SlackPoCWorker:
             channel_id=channel_id,
             message_ts=message_ts,
             interval_seconds=self.config.progress_interval_seconds,
-            summarizer=summarizer,
         )
         await reporter.run(stop_event)
 

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from gateway.db.engine import close_db, get_session_factory, init_db
 from gateway.notebooks.session_service import NotebookRuntime, ensure_analysis_notebook_session
 from gateway.notion import analysis as notebook_analysis
+from gateway.store import slack as slack_store
 
 LOGGER = logging.getLogger(__name__)
 SLACK_API_BASE = "https://slack.com/api"
@@ -58,8 +59,8 @@ class SlackAnalysisDefaults:
 
 @dataclass(frozen=True)
 class SlackPoCConfig:
-    bot_token: str
-    app_token: str
+    bot_token: str | None = None
+    app_token: str | None = None
     signing_secret: str | None = None
     bot_user_id: str | None = None
     org_id: str = "slack-poc"
@@ -85,7 +86,7 @@ class SlackRequest:
 
 
 class SlackApiClient:
-    def __init__(self, bot_token: str, app_token: str, *, http_client: httpx.AsyncClient | None = None) -> None:
+    def __init__(self, bot_token: str, app_token: str | None = None, *, http_client: httpx.AsyncClient | None = None) -> None:
         self.bot_token = bot_token
         self.app_token = app_token
         self._owned_client = http_client is None
@@ -129,6 +130,8 @@ class SlackApiClient:
         return await self._api("auth.test")
 
     async def socket_url(self) -> str:
+        if not self.app_token:
+            raise SlackApiError("Slack app-level token is required for Socket Mode")
         data = await self._api("apps.connections.open", token=self.app_token)
         url = data.get("url")
         if not isinstance(url, str) or not url:
@@ -339,6 +342,7 @@ class SlackPoCWorker:
                 runtime,
                 self.config.org_id,
                 analysis_user_id,
+                route,
             )
             async with self.session_factory() as db:
                 await notebook_analysis.update_analysis_trail_from_status(
@@ -399,7 +403,7 @@ class SlackPoCWorker:
         if not defaults.default_project_id:
             raise RuntimeError(
                 "SignalPilot needs a default dbt project before it can run Slack analysis. "
-                "Set SLACK_POC_DEFAULT_PROJECT_ID or configure a default for this channel."
+                "Configure a default project for this Slack workspace in integrations."
             )
         return defaults
 
@@ -513,6 +517,10 @@ class SlackPoCWorker:
 
 
 async def run_worker(config: SlackPoCConfig) -> None:
+    if not config.bot_token:
+        raise RuntimeError("SLACK_BOT_TOKEN is required for Slack Socket Mode")
+    if not config.app_token:
+        raise RuntimeError("SLACK_APP_TOKEN is required for Slack Socket Mode")
     _apply_local_runtime_defaults()
     await init_db()
     slack = SlackApiClient(config.bot_token, config.app_token)
@@ -574,17 +582,27 @@ def register_http_routes(
     if not config.signing_secret:
         raise RuntimeError("SLACK_SIGNING_SECRET is required for HTTP Events mode")
 
-    app.state.slack_poc_client = slack or SlackApiClient(config.bot_token, config.app_token)
+    if slack is not None:
+        app.state.slack_poc_client = slack
+    elif config.bot_token:
+        app.state.slack_poc_client = SlackApiClient(config.bot_token, config.app_token)
+    else:
+        app.state.slack_poc_client = None
     app.state.slack_poc_worker = None
     app.state.slack_poc_worker_lock = asyncio.Lock()
+    app.state.slack_poc_selfserve_event_ids = set()
 
     async def ensure_worker() -> SlackPoCWorker:
+        if not config.bot_token:
+            raise SlackApiError("SLACK_BOT_TOKEN is required for legacy Slack HTTP worker mode")
         if app.state.slack_poc_worker is not None:
             return app.state.slack_poc_worker
         async with app.state.slack_poc_worker_lock:
             if app.state.slack_poc_worker is None:
                 if initialize_db_on_first_request:
                     await init_db()
+                if app.state.slack_poc_client is None:
+                    app.state.slack_poc_client = SlackApiClient(config.bot_token, config.app_token)
                 auth = await app.state.slack_poc_client.auth_test()
                 bot_user_id = config.bot_user_id or _string(auth.get("user_id"))
                 if not bot_user_id:
@@ -612,8 +630,21 @@ def register_http_routes(
 
     async def dispatch(payload: dict[str, Any]) -> None:
         try:
-            worker = await ensure_worker()
-            await worker.handle_events_api_payload(payload)
+            if config.bot_token:
+                worker = await ensure_worker()
+                await worker.handle_events_api_payload(payload)
+                return
+
+            event_id = _string(payload.get("event_id"))
+            if event_id:
+                seen: set[str] = app.state.slack_poc_selfserve_event_ids
+                if event_id in seen:
+                    LOGGER.info("Ignoring duplicate Slack event_id=%s", event_id)
+                    return
+                seen.add(event_id)
+            if initialize_db_on_first_request:
+                await init_db()
+            await _dispatch_self_serve_payload(payload, config)
         except Exception as exc:
             LOGGER.warning("Slack HTTP event dispatch failed: %s", exc, exc_info=True)
 
@@ -651,7 +682,9 @@ def create_http_app(config: SlackPoCConfig, slack: SlackApiClient | None = None)
         worker = app.state.slack_poc_worker
         if worker is not None:
             await worker.drain()
-        await app.state.slack_poc_client.aclose()
+        client = app.state.slack_poc_client
+        if client is not None:
+            await client.aclose()
         await close_db()
 
     app = FastAPI(title="SignalPilot Slack PoC", lifespan=lifespan)
@@ -723,6 +756,50 @@ async def _handle_socket_message(raw: str | bytes, ws: Any, worker: SlackPoCWork
         await worker.handle_events_api_payload(payload)
 
 
+async def _dispatch_self_serve_payload(payload: dict[str, Any], base_config: SlackPoCConfig) -> None:
+    team_id = _payload_team_id(payload)
+    if not team_id:
+        LOGGER.info("Ignoring Slack event without team_id")
+        return
+
+    factory = get_session_factory()
+    async with factory() as db:
+        records = await slack_store.list_active_installation_records_for_team(db, team_id)
+
+    if not records:
+        LOGGER.info("Ignoring Slack event for team_id=%s without active Slack installation", team_id)
+        return
+    if len(records) > 1:
+        LOGGER.warning(
+            "Ignoring Slack event for ambiguous team_id=%s active_installations=%s",
+            team_id,
+            ",".join(record[0].id for record in records),
+        )
+        return
+
+    installation, install_config, bot_token = records[0]
+    slack = SlackApiClient(bot_token, base_config.app_token)
+    worker_config = SlackPoCConfig(
+        bot_token=bot_token,
+        app_token=base_config.app_token,
+        signing_secret=base_config.signing_secret,
+        bot_user_id=installation.bot_user_id,
+        org_id=installation.org_id,
+        user_id=installation.user_id,
+        default_project_id=install_config.default_project_id,
+        default_branch=install_config.default_branch or "main",
+        analysis_branch_mode=install_config.analysis_branch_mode or "per_request",
+        allowed_channel_ids=frozenset(install_config.allowed_channel_ids or []),
+        ack_text=base_config.ack_text,
+    )
+    worker = SlackPoCWorker(worker_config, slack, factory)
+    try:
+        await worker.handle_events_api_payload(payload)
+        await worker.drain()
+    finally:
+        await slack.aclose()
+
+
 async def _latest_notion_installation_user_id(db: AsyncSession, org_id: str) -> str | None:
     from sqlalchemy import select
 
@@ -750,6 +827,24 @@ def load_config_from_env() -> SlackPoCConfig:
         bot_token=bot_token,
         app_token=app_token,
         signing_secret=os.getenv("SLACK_SIGNING_SECRET") or None,
+        bot_user_id=os.getenv("SLACK_BOT_USER_ID") or None,
+        org_id=os.getenv("SLACK_POC_ORG_ID") or os.getenv("SIGNALPILOT_SLACK_ORG_ID") or "slack-poc",
+        user_id=os.getenv("SLACK_POC_USER_ID") or os.getenv("SIGNALPILOT_SLACK_USER_ID") or None,
+        default_project_id=os.getenv("SLACK_POC_DEFAULT_PROJECT_ID") or os.getenv("SIGNALPILOT_SLACK_DEFAULT_PROJECT_ID") or None,
+        default_branch=os.getenv("SLACK_POC_DEFAULT_BRANCH") or "main",
+        analysis_branch_mode=os.getenv("SLACK_POC_ANALYSIS_BRANCH_MODE") or "per_request",
+        channel_defaults=_channel_defaults_from_env(),
+        allowed_channel_ids=frozenset(_csv_env("SLACK_ALLOWED_CHANNEL_IDS") or _csv_env("SLACK_TEST_CHANNEL_ID")),
+        ack_text=os.getenv("SLACK_POC_ACK_TEXT") or "I'm on it and will post the answer back here soon.",
+    )
+
+
+def load_http_config_from_env() -> SlackPoCConfig:
+    _load_local_env()
+    return SlackPoCConfig(
+        bot_token=os.getenv("SLACK_BOT_TOKEN") or None,
+        app_token=os.getenv("SLACK_APP_TOKEN") or None,
+        signing_secret=_required_env("SLACK_SIGNING_SECRET"),
         bot_user_id=os.getenv("SLACK_BOT_USER_ID") or None,
         org_id=os.getenv("SLACK_POC_ORG_ID") or os.getenv("SIGNALPILOT_SLACK_ORG_ID") or "slack-poc",
         user_id=os.getenv("SLACK_POC_USER_ID") or os.getenv("SIGNALPILOT_SLACK_USER_ID") or None,
@@ -829,6 +924,12 @@ def _first_authorization_team_id(payload: dict[str, Any]) -> str:
     if not isinstance(first, dict):
         return ""
     return _string(first.get("team_id"))
+
+
+def _payload_team_id(payload: dict[str, Any]) -> str:
+    event = payload.get("event")
+    event_team = event.get("team") if isinstance(event, dict) else None
+    return _string(payload.get("team_id") or event_team or _first_authorization_team_id(payload))
 
 
 def _remove_bot_mention(text: str, bot_user_id: str | None) -> str:

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -54,6 +54,7 @@ SLACK_DONE_REACTION = "white_check_mark"
 SLACK_ERROR_REACTION = "x"
 SLACK_EVENT_DEDUPE_MAX_SIZE = 10_000
 SLACK_EVENT_DEDUPE_TTL_SECONDS = 6 * 60 * 60
+SLACK_POC_HTTP_DEFAULT_HOST = "127.0.0.1"
 _PLACEHOLDER_CHART_TITLE_RE = re.compile(
     r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?",
     flags=re.I,
@@ -833,7 +834,7 @@ async def run_http_server(config: SlackPoCConfig) -> None:
         raise RuntimeError("SLACK_SIGNING_SECRET is required for HTTP Events mode")
     _apply_local_runtime_defaults()
     app = create_http_app(config)
-    host = os.getenv("SLACK_POC_HTTP_HOST") or "0.0.0.0"
+    host = os.getenv("SLACK_POC_HTTP_HOST") or SLACK_POC_HTTP_DEFAULT_HOST
     port = int(os.getenv("SLACK_POC_HTTP_PORT") or "8787")
     server = uvicorn.Server(
         uvicorn.Config(

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -28,12 +28,20 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from gateway.db.engine import close_db, get_session_factory, init_db
 from gateway.notebooks.session_service import NotebookRuntime, ensure_analysis_notebook_session
 from gateway.notion import analysis as notebook_analysis
+from gateway.slack_poc.progress import (
+    COMPLETING_PROGRESS_TEXT,
+    INITIAL_PROGRESS_TEXT,
+    SlackProgressReporter,
+    SlackProgressSummarizer,
+)
 from gateway.store import slack as slack_store
 
 LOGGER = logging.getLogger(__name__)
 SLACK_API_BASE = "https://slack.com/api"
 SLACK_TEXT_LIMIT = 35000
 SLACK_CHART_LIMIT = 3
+SLACK_ACK_REACTION = "eyes"
+SLACK_DONE_REACTION = "white_check_mark"
 
 
 class SlackApiError(RuntimeError):
@@ -71,6 +79,11 @@ class SlackPoCConfig:
     channel_defaults: dict[str, SlackAnalysisDefaults] = field(default_factory=dict)
     allowed_channel_ids: frozenset[str] = frozenset()
     ack_text: str = "I'm on it and will post the answer back here soon."
+    progress_enabled: bool = True
+    progress_interval_seconds: float = 15.0
+    progress_model_provider: str = "anthropic"
+    progress_model: str | None = None
+    progress_model_timeout_seconds: float = 8.0
 
 
 @dataclass(frozen=True)
@@ -151,6 +164,35 @@ class SlackApiClient:
         data = await self._api("chat.postMessage", payload)
         ts = data.get("ts")
         return str(ts) if ts else ""
+
+    async def update_message(self, *, channel: str, ts: str, text: str) -> None:
+        await self._api(
+            "chat.update",
+            {
+                "channel": channel,
+                "ts": ts,
+                "text": _clip_text(text),
+                "mrkdwn": True,
+                "unfurl_links": False,
+                "unfurl_media": False,
+            },
+        )
+
+    async def add_reaction(self, *, channel: str, timestamp: str, name: str) -> None:
+        try:
+            await self._api("reactions.add", {"channel": channel, "timestamp": timestamp, "name": name})
+        except SlackApiError as exc:
+            if "already_reacted" in str(exc):
+                return
+            raise
+
+    async def remove_reaction(self, *, channel: str, timestamp: str, name: str) -> None:
+        try:
+            await self._api("reactions.remove", {"channel": channel, "timestamp": timestamp, "name": name})
+        except SlackApiError as exc:
+            if "no_reaction" in str(exc):
+                return
+            raise
 
     async def upload_file(
         self,
@@ -284,7 +326,18 @@ class SlackPoCWorker:
     async def _process_request(self, request: SlackRequest) -> None:
         trail_url: str | None = None
         route: notebook_analysis.AnalysisRoute | None = None
-        await self.slack.post_message(channel=request.channel_id, thread_ts=request.thread_ts, text=self.config.ack_text)
+        progress_ts = ""
+        progress_stop: asyncio.Event | None = None
+        progress_task: asyncio.Task[None] | None = None
+        await self._add_request_reaction(request, SLACK_ACK_REACTION)
+        try:
+            progress_ts = await self.slack.post_message(
+                channel=request.channel_id,
+                thread_ts=request.thread_ts,
+                text=INITIAL_PROGRESS_TEXT,
+            )
+        except Exception as exc:
+            LOGGER.info("Could not post Slack progress message: %s", exc, exc_info=True)
         try:
             previous_messages = await self._previous_thread_messages(request)
             async with self.session_factory() as db:
@@ -323,6 +376,7 @@ class SlackPoCWorker:
                     analysis_user_id=analysis_user_id,
                 )
 
+            trace_thread_id = f"session-{route.request_id}"
             start = await self._start_analysis(runtime, request, previous_messages, analysis_user_id, route)
             trail_url = notebook_analysis._public_signalpilot_url(_string(start.get("trailUrl")), runtime)
             async with self.session_factory() as db:
@@ -337,12 +391,37 @@ class SlackPoCWorker:
                     source_request_id=request.event_id,
                     analysis_user_id=analysis_user_id,
                 )
-            status = await notebook_analysis._poll_analysis(
-                _string(start["requestId"]),
-                runtime,
-                self.config.org_id,
-                analysis_user_id,
-                route,
+            if self.config.progress_enabled and progress_ts:
+                progress_stop = asyncio.Event()
+                progress_task = asyncio.create_task(
+                    self._run_progress_reporter(
+                        stop_event=progress_stop,
+                        thread_id=trace_thread_id,
+                        source_prompt=request.text,
+                        channel_id=request.channel_id,
+                        message_ts=progress_ts,
+                        user_id=analysis_user_id,
+                    ),
+                    name=f"slack-progress-{request.event_id}",
+                )
+            poll_task = asyncio.create_task(
+                notebook_analysis._poll_analysis(
+                    _string(start["requestId"]),
+                    runtime,
+                    self.config.org_id,
+                    analysis_user_id,
+                    route,
+                ),
+                name=f"slack-analysis-poll-{request.event_id}",
+            )
+            try:
+                status = await poll_task
+            finally:
+                await self._stop_progress_reporter(progress_stop, progress_task)
+            await self._update_progress_message(
+                channel_id=request.channel_id,
+                message_ts=progress_ts,
+                text=COMPLETING_PROGRESS_TEXT,
             )
             async with self.session_factory() as db:
                 await notebook_analysis.update_analysis_trail_from_status(
@@ -352,11 +431,13 @@ class SlackPoCWorker:
                     status=status,
                 )
             slack_status = notebook_analysis._with_public_chart_urls(status, runtime)
-            await self.slack.post_message(
+            await self._update_or_post_result_message(
                 channel=request.channel_id,
                 thread_ts=request.thread_ts,
+                message_ts=progress_ts,
                 text=_final_slack_text(slack_status, trail_url),
             )
+            await self._mark_request_done(request)
             await self._post_chart_attachments(request, status, runtime)
         except Exception as exc:
             LOGGER.warning("Slack PoC request failed: event_id=%s error=%s", request.event_id, exc, exc_info=True)
@@ -375,11 +456,104 @@ class SlackPoCWorker:
                         )
                 except Exception:
                     LOGGER.debug("Could not mark Slack analysis trail failed", exc_info=True)
-            await self.slack.post_message(
+            await self._update_or_post_result_message(
                 channel=request.channel_id,
                 thread_ts=request.thread_ts,
+                message_ts=progress_ts,
                 text=_failure_slack_text(str(exc), trail_url),
             )
+        finally:
+            await self._stop_progress_reporter(progress_stop, progress_task)
+            await self._remove_request_reaction(request, SLACK_ACK_REACTION)
+
+    async def _add_request_reaction(self, request: SlackRequest, name: str) -> None:
+        if not request.event_ts:
+            return
+        try:
+            await self.slack.add_reaction(channel=request.channel_id, timestamp=request.event_ts, name=name)
+        except Exception as exc:
+            LOGGER.info("Could not add Slack reaction=%s event_id=%s: %s", name, request.event_id, exc, exc_info=True)
+
+    async def _remove_request_reaction(self, request: SlackRequest, name: str) -> None:
+        if not request.event_ts:
+            return
+        try:
+            await self.slack.remove_reaction(channel=request.channel_id, timestamp=request.event_ts, name=name)
+        except Exception as exc:
+            LOGGER.info("Could not remove Slack reaction=%s event_id=%s: %s", name, request.event_id, exc, exc_info=True)
+
+    async def _mark_request_done(self, request: SlackRequest) -> None:
+        await self._add_request_reaction(request, SLACK_DONE_REACTION)
+        await self._remove_request_reaction(request, SLACK_ACK_REACTION)
+
+    async def _update_or_post_result_message(
+        self,
+        *,
+        channel: str,
+        thread_ts: str,
+        message_ts: str,
+        text: str,
+    ) -> None:
+        if message_ts:
+            try:
+                await self.slack.update_message(channel=channel, ts=message_ts, text=text)
+                return
+            except Exception as exc:
+                LOGGER.info("Could not update Slack result message: %s", exc, exc_info=True)
+        await self.slack.post_message(channel=channel, thread_ts=thread_ts, text=text)
+
+    async def _run_progress_reporter(
+        self,
+        *,
+        stop_event: asyncio.Event,
+        thread_id: str,
+        source_prompt: str,
+        channel_id: str,
+        message_ts: str,
+        user_id: str,
+    ) -> None:
+        summarizer = SlackProgressSummarizer(
+            provider=self.config.progress_model_provider,
+            model=self.config.progress_model,
+            timeout_seconds=self.config.progress_model_timeout_seconds,
+        )
+        reporter = SlackProgressReporter(
+            slack=self.slack,
+            session_factory=self.session_factory,
+            org_id=self.config.org_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            source_prompt=source_prompt,
+            channel_id=channel_id,
+            message_ts=message_ts,
+            interval_seconds=self.config.progress_interval_seconds,
+            summarizer=summarizer,
+        )
+        await reporter.run(stop_event)
+
+    async def _stop_progress_reporter(
+        self,
+        stop_event: asyncio.Event | None,
+        task: asyncio.Task[None] | None,
+    ) -> None:
+        if stop_event is None or task is None:
+            return
+        stop_event.set()
+        try:
+            await asyncio.wait_for(task, timeout=2)
+        except TimeoutError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        except Exception as exc:
+            LOGGER.info("Slack progress reporter stopped with error: %s", exc, exc_info=True)
+
+    async def _update_progress_message(self, *, channel_id: str, message_ts: str, text: str) -> None:
+        if not self.config.progress_enabled or not message_ts:
+            return
+        try:
+            await self.slack.update_message(channel=channel_id, ts=message_ts, text=text)
+        except Exception as exc:
+            LOGGER.info("Could not update Slack progress message: %s", exc, exc_info=True)
 
     async def _analysis_user_id(self, db: AsyncSession) -> str:
         if self.config.user_id:
@@ -542,6 +716,11 @@ async def run_worker(config: SlackPoCConfig) -> None:
             channel_defaults=config.channel_defaults,
             allowed_channel_ids=config.allowed_channel_ids,
             ack_text=config.ack_text,
+            progress_enabled=config.progress_enabled,
+            progress_interval_seconds=config.progress_interval_seconds,
+            progress_model_provider=config.progress_model_provider,
+            progress_model=config.progress_model,
+            progress_model_timeout_seconds=config.progress_model_timeout_seconds,
         )
         worker = SlackPoCWorker(config, slack, get_session_factory())
         stop_event = asyncio.Event()
@@ -620,6 +799,11 @@ def register_http_routes(
                     channel_defaults=config.channel_defaults,
                     allowed_channel_ids=config.allowed_channel_ids,
                     ack_text=config.ack_text,
+                    progress_enabled=config.progress_enabled,
+                    progress_interval_seconds=config.progress_interval_seconds,
+                    progress_model_provider=config.progress_model_provider,
+                    progress_model=config.progress_model,
+                    progress_model_timeout_seconds=config.progress_model_timeout_seconds,
                 )
                 app.state.slack_poc_worker = SlackPoCWorker(
                     resolved_config,
@@ -791,6 +975,11 @@ async def _dispatch_self_serve_payload(payload: dict[str, Any], base_config: Sla
         analysis_branch_mode=install_config.analysis_branch_mode or "per_request",
         allowed_channel_ids=frozenset(install_config.allowed_channel_ids or []),
         ack_text=base_config.ack_text,
+        progress_enabled=base_config.progress_enabled,
+        progress_interval_seconds=base_config.progress_interval_seconds,
+        progress_model_provider=base_config.progress_model_provider,
+        progress_model=base_config.progress_model,
+        progress_model_timeout_seconds=base_config.progress_model_timeout_seconds,
     )
     worker = SlackPoCWorker(worker_config, slack, factory)
     try:
@@ -836,6 +1025,11 @@ def load_config_from_env() -> SlackPoCConfig:
         channel_defaults=_channel_defaults_from_env(),
         allowed_channel_ids=frozenset(_csv_env("SLACK_ALLOWED_CHANNEL_IDS") or _csv_env("SLACK_TEST_CHANNEL_ID")),
         ack_text=os.getenv("SLACK_POC_ACK_TEXT") or "I'm on it and will post the answer back here soon.",
+        progress_enabled=_bool_env("SLACK_PROGRESS_ENABLED", True),
+        progress_interval_seconds=_float_env("SLACK_PROGRESS_INTERVAL_SECONDS", 15.0),
+        progress_model_provider=os.getenv("SLACK_PROGRESS_MODEL_PROVIDER") or "anthropic",
+        progress_model=os.getenv("SLACK_PROGRESS_MODEL") or None,
+        progress_model_timeout_seconds=_float_env("SLACK_PROGRESS_MODEL_TIMEOUT_SECONDS", 8.0),
     )
 
 
@@ -854,6 +1048,11 @@ def load_http_config_from_env() -> SlackPoCConfig:
         channel_defaults=_channel_defaults_from_env(),
         allowed_channel_ids=frozenset(_csv_env("SLACK_ALLOWED_CHANNEL_IDS") or _csv_env("SLACK_TEST_CHANNEL_ID")),
         ack_text=os.getenv("SLACK_POC_ACK_TEXT") or "I'm on it and will post the answer back here soon.",
+        progress_enabled=_bool_env("SLACK_PROGRESS_ENABLED", True),
+        progress_interval_seconds=_float_env("SLACK_PROGRESS_INTERVAL_SECONDS", 15.0),
+        progress_model_provider=os.getenv("SLACK_PROGRESS_MODEL_PROVIDER") or "anthropic",
+        progress_model=os.getenv("SLACK_PROGRESS_MODEL") or None,
+        progress_model_timeout_seconds=_float_env("SLACK_PROGRESS_MODEL_TIMEOUT_SECONDS", 8.0),
     )
 
 
@@ -887,6 +1086,23 @@ def _required_env(name: str) -> str:
 
 def _csv_env(name: str) -> list[str]:
     return [part.strip() for part in (os.getenv(name) or "").split(",") if part.strip()]
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be a number") from exc
 
 
 def _channel_defaults_from_env() -> dict[str, SlackAnalysisDefaults]:

--- a/signalpilot/gateway/gateway/store/chat_traces.py
+++ b/signalpilot/gateway/gateway/store/chat_traces.py
@@ -217,12 +217,14 @@ async def get_events(
     user_id: str,
     thread_id: str,
     after_index: int = -1,
+    require_thread: bool = True,
 ) -> list[ChatTraceEventInfo]:
-    thread = await get_thread(
-        session, org_id=org_id, user_id=user_id, thread_id=thread_id
-    )
-    if thread is None:
-        raise ValueError(f"Trace thread {thread_id} not found")
+    if require_thread:
+        thread = await get_thread(
+            session, org_id=org_id, user_id=user_id, thread_id=thread_id
+        )
+        if thread is None:
+            raise ValueError(f"Trace thread {thread_id} not found")
 
     result = await session.execute(
         select(GatewayChatTraceEvent)

--- a/signalpilot/gateway/gateway/store/chat_traces.py
+++ b/signalpilot/gateway/gateway/store/chat_traces.py
@@ -17,6 +17,7 @@ from ..models.workspace import (
     ChatTraceThreadInfo,
     ChatTraceThreadUpsert,
 )
+from ..trace_markers import redact_trace_control_markers
 
 
 def _thread_scope(org_id: str, thread_id: str):
@@ -145,6 +146,7 @@ async def append_event(
     ).scalar_one()
     idx = int(next_idx)
     now = time.time()
+    content, metadata = redact_trace_control_markers(event.content or "", event.metadata)
     row = GatewayChatTraceEvent(
         id=str(uuid.uuid4()),
         org_id=org_id,
@@ -153,14 +155,14 @@ async def append_event(
         idx=idx,
         event_type=event.type,
         role=event.role,
-        content=event.content or "",
+        content=content,
         tool_name=event.tool_name or "",
         tool_input_json=event.tool_input,
         tool_call_id=event.tool_call_id or "",
         is_error=bool(event.is_error),
         cost_usd=event.cost_usd,
         turn=int(event.turn or 0),
-        metadata_json=event.metadata,
+        metadata_json=metadata,
         created_at=now,
     )
     session.add(row)

--- a/signalpilot/gateway/gateway/store/slack.py
+++ b/signalpilot/gateway/gateway/store/slack.py
@@ -15,6 +15,7 @@ from gateway.models.slack import (
     SlackOAuthInstallationInfo,
 )
 from gateway.store.crypto import _decrypt_with_migration, _encrypt
+from gateway.string_utils import optional_string_value
 
 
 def _scope_list(value: object) -> list[str]:
@@ -23,10 +24,6 @@ def _scope_list(value: object) -> list[str]:
     if isinstance(value, list):
         return [str(scope).strip() for scope in value if str(scope).strip()]
     return []
-
-
-def _string(value: object) -> str | None:
-    return str(value) if value else None
 
 
 def _as_aware_utc(value: datetime) -> datetime:
@@ -125,13 +122,13 @@ async def upsert_oauth_installation(
     enterprise = token_response.get("enterprise") if isinstance(token_response.get("enterprise"), dict) else {}
     authed_user = token_response.get("authed_user") if isinstance(token_response.get("authed_user"), dict) else {}
 
-    team_id = _string(team.get("id"))
-    bot_user_id = _string(token_response.get("bot_user_id"))
-    bot_access_token = _string(token_response.get("access_token"))
+    team_id = optional_string_value(team.get("id"))
+    bot_user_id = optional_string_value(token_response.get("bot_user_id"))
+    bot_access_token = optional_string_value(token_response.get("access_token"))
     if not team_id or not bot_user_id or not bot_access_token:
         raise ValueError("Slack token response is missing team.id, bot_user_id, or access_token")
 
-    app_id = _string(token_response.get("app_id")) or ""
+    app_id = optional_string_value(token_response.get("app_id")) or ""
     result = await session.execute(
         select(SlackInstallation).where(
             SlackInstallation.org_id == org_id,
@@ -147,12 +144,12 @@ async def upsert_oauth_installation(
             org_id=org_id,
             user_id=user_id,
             team_id=team_id,
-            team_name=_string(team.get("name")),
-            enterprise_id=_string(enterprise.get("id")),
-            enterprise_name=_string(enterprise.get("name")),
+            team_name=optional_string_value(team.get("name")),
+            enterprise_id=optional_string_value(enterprise.get("id")),
+            enterprise_name=optional_string_value(enterprise.get("name")),
             app_id=app_id,
             bot_user_id=bot_user_id,
-            authed_user_id=_string(authed_user.get("id")),
+            authed_user_id=optional_string_value(authed_user.get("id")),
             bot_access_token_enc=_encrypt(bot_access_token),
             scopes=_scope_list(token_response.get("scope")),
             status="connected",
@@ -162,11 +159,11 @@ async def upsert_oauth_installation(
         session.add(row)
     else:
         row.user_id = user_id
-        row.team_name = _string(team.get("name"))
-        row.enterprise_id = _string(enterprise.get("id"))
-        row.enterprise_name = _string(enterprise.get("name"))
+        row.team_name = optional_string_value(team.get("name"))
+        row.enterprise_id = optional_string_value(enterprise.get("id"))
+        row.enterprise_name = optional_string_value(enterprise.get("name"))
         row.bot_user_id = bot_user_id
-        row.authed_user_id = _string(authed_user.get("id"))
+        row.authed_user_id = optional_string_value(authed_user.get("id"))
         row.bot_access_token_enc = _encrypt(bot_access_token)
         row.scopes = _scope_list(token_response.get("scope"))
         row.status = "connected"

--- a/signalpilot/gateway/gateway/store/slack.py
+++ b/signalpilot/gateway/gateway/store/slack.py
@@ -1,0 +1,289 @@
+"""Store operations for Slack integrations."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.db.models import SlackInstallation, SlackInstallationConfig, SlackOAuthState
+from gateway.models.slack import (
+    SlackInstallationConfigInfo,
+    SlackOAuthInstallationInfo,
+)
+from gateway.store.crypto import _decrypt_with_migration, _encrypt
+
+
+def _scope_list(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [scope.strip() for scope in value.split(",") if scope.strip()]
+    if isinstance(value, list):
+        return [str(scope).strip() for scope in value if str(scope).strip()]
+    return []
+
+
+def _string(value: object) -> str | None:
+    return str(value) if value else None
+
+
+def _as_aware_utc(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _config_info(config: SlackInstallationConfig | None) -> SlackInstallationConfigInfo | None:
+    if config is None:
+        return None
+    return SlackInstallationConfigInfo(
+        enabled=bool(config.enabled),
+        default_project_id=config.default_project_id,
+        default_branch=config.default_branch or "main",
+        analysis_branch_mode=config.analysis_branch_mode or "per_request",
+        allowed_channel_ids=list(config.allowed_channel_ids or []),
+    )
+
+
+async def _get_config(
+    session: AsyncSession,
+    installation_id: str,
+) -> SlackInstallationConfig | None:
+    result = await session.execute(
+        select(SlackInstallationConfig).where(SlackInstallationConfig.installation_id == installation_id)
+    )
+    return result.scalar_one_or_none()
+
+
+def _installation_info(
+    row: SlackInstallation,
+    config: SlackInstallationConfig | None = None,
+) -> SlackOAuthInstallationInfo:
+    return SlackOAuthInstallationInfo(
+        id=row.id,
+        team_id=row.team_id,
+        team_name=row.team_name,
+        enterprise_id=row.enterprise_id,
+        enterprise_name=row.enterprise_name,
+        app_id=row.app_id or None,
+        bot_user_id=row.bot_user_id,
+        authed_user_id=row.authed_user_id,
+        scopes=list(row.scopes or []),
+        status=row.status,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        org_id=row.org_id,
+        config=_config_info(config),
+    )
+
+
+async def create_oauth_state(
+    session: AsyncSession,
+    org_id: str,
+    user_id: str | None,
+    redirect_after: str | None,
+    ttl_seconds: int = 600,
+) -> str:
+    """Create a short-lived Slack OAuth state value."""
+    state = secrets.token_urlsafe(32)
+    row = SlackOAuthState(
+        state=state,
+        org_id=org_id,
+        user_id=user_id,
+        redirect_after=redirect_after,
+        expires_at=datetime.now(UTC) + timedelta(seconds=ttl_seconds),
+    )
+    session.add(row)
+    await session.commit()
+    return state
+
+
+async def consume_oauth_state(
+    session: AsyncSession,
+    state: str,
+) -> SlackOAuthState | None:
+    """Return and delete a valid OAuth state, or None when missing/expired."""
+    result = await session.execute(select(SlackOAuthState).where(SlackOAuthState.state == state))
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    await session.delete(row)
+    await session.commit()
+    if _as_aware_utc(row.expires_at) < datetime.now(UTC):
+        return None
+    return row
+
+
+async def upsert_oauth_installation(
+    session: AsyncSession,
+    org_id: str,
+    user_id: str | None,
+    token_response: dict,
+) -> SlackOAuthInstallationInfo:
+    """Create or update a Slack OAuth installation from Slack's token response."""
+    team = token_response.get("team") if isinstance(token_response.get("team"), dict) else {}
+    enterprise = token_response.get("enterprise") if isinstance(token_response.get("enterprise"), dict) else {}
+    authed_user = token_response.get("authed_user") if isinstance(token_response.get("authed_user"), dict) else {}
+
+    team_id = _string(team.get("id"))
+    bot_user_id = _string(token_response.get("bot_user_id"))
+    bot_access_token = _string(token_response.get("access_token"))
+    if not team_id or not bot_user_id or not bot_access_token:
+        raise ValueError("Slack token response is missing team.id, bot_user_id, or access_token")
+
+    app_id = _string(token_response.get("app_id")) or ""
+    result = await session.execute(
+        select(SlackInstallation).where(
+            SlackInstallation.org_id == org_id,
+            SlackInstallation.team_id == team_id,
+            SlackInstallation.app_id == app_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    now = datetime.now(UTC)
+    if row is None:
+        row = SlackInstallation(
+            id=str(uuid.uuid4()),
+            org_id=org_id,
+            user_id=user_id,
+            team_id=team_id,
+            team_name=_string(team.get("name")),
+            enterprise_id=_string(enterprise.get("id")),
+            enterprise_name=_string(enterprise.get("name")),
+            app_id=app_id,
+            bot_user_id=bot_user_id,
+            authed_user_id=_string(authed_user.get("id")),
+            bot_access_token_enc=_encrypt(bot_access_token),
+            scopes=_scope_list(token_response.get("scope")),
+            status="connected",
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(row)
+    else:
+        row.user_id = user_id
+        row.team_name = _string(team.get("name"))
+        row.enterprise_id = _string(enterprise.get("id"))
+        row.enterprise_name = _string(enterprise.get("name"))
+        row.bot_user_id = bot_user_id
+        row.authed_user_id = _string(authed_user.get("id"))
+        row.bot_access_token_enc = _encrypt(bot_access_token)
+        row.scopes = _scope_list(token_response.get("scope"))
+        row.status = "connected"
+        row.updated_at = now
+
+    await session.commit()
+    await session.refresh(row)
+    return _installation_info(row, await _get_config(session, row.id))
+
+
+async def list_oauth_installations(
+    session: AsyncSession,
+    org_id: str,
+) -> list[SlackOAuthInstallationInfo]:
+    result = await session.execute(
+        select(SlackInstallation)
+        .where(SlackInstallation.org_id == org_id)
+        .order_by(SlackInstallation.updated_at.desc())
+    )
+    rows = list(result.scalars())
+    configs = {row.id: await _get_config(session, row.id) for row in rows}
+    return [_installation_info(row, configs.get(row.id)) for row in rows]
+
+
+async def get_oauth_installation(
+    session: AsyncSession,
+    org_id: str,
+    installation_id: str,
+) -> SlackOAuthInstallationInfo | None:
+    result = await session.execute(
+        select(SlackInstallation).where(
+            SlackInstallation.org_id == org_id,
+            SlackInstallation.id == installation_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    return _installation_info(row, await _get_config(session, row.id))
+
+
+async def save_oauth_installation_config(
+    session: AsyncSession,
+    org_id: str,
+    installation_id: str,
+    enabled: bool = True,
+    default_project_id: str | None = None,
+    default_branch: str = "main",
+    analysis_branch_mode: str = "per_request",
+    allowed_channel_ids: list[str] | None = None,
+) -> SlackOAuthInstallationInfo | None:
+    result = await session.execute(
+        select(SlackInstallation).where(
+            SlackInstallation.org_id == org_id,
+            SlackInstallation.id == installation_id,
+        )
+    )
+    install = result.scalar_one_or_none()
+    if install is None:
+        return None
+
+    config = await _get_config(session, installation_id)
+    if config is None:
+        config = SlackInstallationConfig(installation_id=installation_id)
+        session.add(config)
+    config.enabled = enabled
+    config.default_project_id = default_project_id
+    config.default_branch = default_branch or "main"
+    config.analysis_branch_mode = analysis_branch_mode or "per_request"
+    config.allowed_channel_ids = allowed_channel_ids or []
+    install.status = "active" if enabled else "needs_setup"
+    install.updated_at = datetime.now(UTC)
+    await session.commit()
+    await session.refresh(install)
+    return _installation_info(install, config)
+
+
+async def disable_oauth_installation(
+    session: AsyncSession,
+    org_id: str,
+    installation_id: str,
+) -> bool:
+    result = await session.execute(
+        select(SlackInstallation).where(
+            SlackInstallation.org_id == org_id,
+            SlackInstallation.id == installation_id,
+        )
+    )
+    install = result.scalar_one_or_none()
+    if install is None:
+        return False
+    config = await _get_config(session, installation_id)
+    if config is not None:
+        config.enabled = False
+    install.status = "disconnected"
+    install.updated_at = datetime.now(UTC)
+    await session.commit()
+    return True
+
+
+async def list_active_installation_records_for_team(
+    session: AsyncSession,
+    team_id: str,
+) -> list[tuple[SlackInstallation, SlackInstallationConfig, str]]:
+    """Return active Slack install rows, setup config, and decrypted bot token."""
+    result = await session.execute(
+        select(SlackInstallation).where(
+            SlackInstallation.team_id == team_id,
+            SlackInstallation.status.in_(["connected", "needs_setup", "active"]),
+        )
+    )
+    rows = list(result.scalars())
+    records: list[tuple[SlackInstallation, SlackInstallationConfig, str]] = []
+    for row in rows:
+        config = await _get_config(session, row.id)
+        if config is None or not config.enabled or not config.default_project_id:
+            continue
+        token, _ = _decrypt_with_migration(row.bot_access_token_enc)
+        records.append((row, config, token))
+    return records

--- a/signalpilot/gateway/gateway/store/store.py
+++ b/signalpilot/gateway/gateway/store/store.py
@@ -20,6 +20,7 @@ import gateway.store.notion as notion_mod
 import gateway.store.paths as paths
 import gateway.store.projects as projects
 import gateway.store.settings as settings_mod
+import gateway.store.slack as slack_mod
 from gateway.byok import decrypt_envelope, encrypt_fields_envelope
 from gateway.db.models import (
     GatewayConnection,
@@ -782,6 +783,62 @@ class Store:
         """Disable a Notion OAuth installation for this org."""
         oid = self._require_org_id()
         return await notion_mod.disable_oauth_installation(
+            self.session,
+            org_id=oid,
+            installation_id=installation_id,
+        )
+
+    # ─── Slack Integrations ─────────────────────────────────────────────
+
+    async def create_slack_oauth_state(self, redirect_after: str | None, ttl_seconds: int = 600) -> str:
+        """Create a short-lived Slack OAuth state value."""
+        oid = self._require_org_id()
+        return await slack_mod.create_oauth_state(
+            self.session,
+            org_id=oid,
+            user_id=self.user_id,
+            redirect_after=redirect_after,
+            ttl_seconds=ttl_seconds,
+        )
+
+    async def list_slack_oauth_installations(self) -> list[slack_mod.SlackOAuthInstallationInfo]:
+        """List Slack OAuth installations for this org."""
+        oid = self._require_org_id()
+        return await slack_mod.list_oauth_installations(self.session, org_id=oid)
+
+    async def get_slack_oauth_installation(
+        self, installation_id: str,
+    ) -> slack_mod.SlackOAuthInstallationInfo | None:
+        """Get a Slack OAuth installation for this org."""
+        oid = self._require_org_id()
+        return await slack_mod.get_oauth_installation(self.session, org_id=oid, installation_id=installation_id)
+
+    async def save_slack_oauth_installation_config(
+        self,
+        installation_id: str,
+        enabled: bool = True,
+        default_project_id: str | None = None,
+        default_branch: str = "main",
+        analysis_branch_mode: str = "per_request",
+        allowed_channel_ids: list[str] | None = None,
+    ) -> slack_mod.SlackOAuthInstallationInfo | None:
+        """Save setup defaults for a Slack OAuth installation."""
+        oid = self._require_org_id()
+        return await slack_mod.save_oauth_installation_config(
+            self.session,
+            org_id=oid,
+            installation_id=installation_id,
+            enabled=enabled,
+            default_project_id=default_project_id,
+            default_branch=default_branch,
+            analysis_branch_mode=analysis_branch_mode,
+            allowed_channel_ids=allowed_channel_ids,
+        )
+
+    async def disable_slack_oauth_installation(self, installation_id: str) -> bool:
+        """Disable a Slack OAuth installation for this org."""
+        oid = self._require_org_id()
+        return await slack_mod.disable_oauth_installation(
             self.session,
             org_id=oid,
             installation_id=installation_id,

--- a/signalpilot/gateway/gateway/string_utils.py
+++ b/signalpilot/gateway/gateway/string_utils.py
@@ -1,0 +1,13 @@
+"""Small string coercion helpers shared by gateway modules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def string_value(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def optional_string_value(value: Any) -> str | None:
+    return str(value) if value else None

--- a/signalpilot/gateway/gateway/trace_markers.py
+++ b/signalpilot/gateway/gateway/trace_markers.py
@@ -1,0 +1,131 @@
+"""Helpers for parseable worker control markers in chat traces."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+CONTROL_MARKERS_METADATA_KEY = "control_markers"
+TRACE_CONTROL_MARKERS = ("PLAN", "PROGRESS", "FINAL_STATEMENT")
+
+
+@dataclass(frozen=True)
+class TraceMarker:
+    marker: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _MarkerMatch:
+    marker: str
+    payload: dict[str, Any]
+    start: int
+    end: int
+
+
+def redact_trace_control_markers(
+    content: str,
+    metadata: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any] | None]:
+    """Move parseable control markers from visible content into metadata."""
+    matches = _find_marker_matches(content)
+    if not matches:
+        return content, metadata
+
+    redacted = _redact_matches(content, matches)
+    next_metadata = dict(metadata or {})
+    existing = next_metadata.get(CONTROL_MARKERS_METADATA_KEY)
+    markers = list(existing) if isinstance(existing, list) else []
+    markers.extend(
+        {"marker": match.marker, "payload": match.payload}
+        for match in matches
+    )
+    next_metadata[CONTROL_MARKERS_METADATA_KEY] = markers
+    return redacted, next_metadata
+
+
+def iter_trace_marker_payloads(
+    content: str,
+    metadata: dict[str, Any] | None = None,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Return marker payloads from metadata first, then legacy inline content."""
+    payloads: list[tuple[str, dict[str, Any]]] = []
+    if isinstance(metadata, dict):
+        raw_markers = metadata.get(CONTROL_MARKERS_METADATA_KEY)
+        if isinstance(raw_markers, list):
+            for item in raw_markers:
+                if not isinstance(item, dict):
+                    continue
+                marker = _normalize_marker(item.get("marker"))
+                payload = item.get("payload")
+                if marker and isinstance(payload, dict):
+                    payloads.append((marker, payload))
+
+    payloads.extend((match.marker, match.payload) for match in _find_marker_matches(content))
+    return payloads
+
+
+def _find_marker_matches(content: str) -> list[_MarkerMatch]:
+    if not content:
+        return []
+    decoder = json.JSONDecoder()
+    matches: list[_MarkerMatch] = []
+    marker_pattern = "|".join(re.escape(marker) for marker in TRACE_CONTROL_MARKERS)
+    for match in re.finditer(rf"(?m)^[ \t]*({marker_pattern})[ \t]*:[ \t]*", content):
+        marker = _normalize_marker(match.group(1))
+        if marker is None:
+            continue
+        remainder = content[match.end() :]
+        stripped = remainder.lstrip()
+        offset = len(remainder) - len(stripped)
+        try:
+            parsed, json_end = decoder.raw_decode(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        end = _extend_to_marker_line_end(content, match.end() + offset + json_end)
+        matches.append(_MarkerMatch(marker=marker, payload=parsed, start=match.start(), end=end))
+    matches.sort(key=lambda item: item.start)
+    return _drop_overlapping(matches)
+
+
+def _redact_matches(content: str, matches: list[_MarkerMatch]) -> str:
+    pieces: list[str] = []
+    cursor = 0
+    for match in matches:
+        pieces.append(content[cursor : match.start])
+        cursor = match.end
+    pieces.append(content[cursor:])
+    return re.sub(r"\n{3,}", "\n\n", "".join(pieces)).strip()
+
+
+def _extend_to_marker_line_end(content: str, end: int) -> int:
+    cursor = end
+    while cursor < len(content) and content[cursor] in " \t":
+        cursor += 1
+    if cursor < len(content) and content[cursor] == "\r":
+        cursor += 1
+        if cursor < len(content) and content[cursor] == "\n":
+            cursor += 1
+    elif cursor < len(content) and content[cursor] == "\n":
+        cursor += 1
+    return cursor
+
+
+def _drop_overlapping(matches: list[_MarkerMatch]) -> list[_MarkerMatch]:
+    result: list[_MarkerMatch] = []
+    last_end = -1
+    for match in matches:
+        if match.start < last_end:
+            continue
+        result.append(match)
+        last_end = match.end
+    return result
+
+
+def _normalize_marker(value: Any) -> str | None:
+    marker = str(value or "").strip().upper()
+    return marker if marker in TRACE_CONTROL_MARKERS else None

--- a/signalpilot/gateway/tests/test_analysis_delivery.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gateway.analysis_delivery import (
+    AnalysisPreflightKind,
+    DeliveryRenderer,
+    classify_analysis_request,
+    delivery_result_to_status,
+    load_delivery_packet_from_events,
+    render_slack_final_message,
+    render_slack_progress_message,
+)
+from gateway.trace_markers import redact_trace_control_markers
+
+
+def test_preflight_gates_greetings_and_ambiguous_data_prompts() -> None:
+    assert classify_analysis_request("hi").kind == AnalysisPreflightKind.DIRECT
+    assert classify_analysis_request("hello").kind == AnalysisPreflightKind.DIRECT
+    assert classify_analysis_request("thanks").kind == AnalysisPreflightKind.DIRECT
+
+    ambiguous = classify_analysis_request("revenue")
+
+    assert ambiguous.kind == AnalysisPreflightKind.AMBIGUOUS
+    assert "fresh, specific analysis request" in (ambiguous.response or "")
+    assert classify_analysis_request("Analyze revenue by product for Q2").kind == AnalysisPreflightKind.ANALYZE
+
+
+def test_trace_loader_extracts_latest_worker_plan_progress_and_final_statement() -> None:
+    packet = load_delivery_packet_from_events(
+        [
+            {"idx": 0, "type": "user", "content": "Analyze revenue"},
+            {"idx": 1, "type": "text", "content": 'PLAN: {"steps":["Inspect schema","Run revenue query"]}'},
+            {
+                "idx": 2,
+                "type": "text",
+                "content": 'PROGRESS: {"currentStep":"Inspect schema","completedSteps":[],"status":"checking tables"}',
+            },
+            {
+                "idx": 3,
+                "type": "text",
+                "content": 'PLAN: {"steps":["Inspect schema","Run revenue query","Validate totals"]}',
+            },
+            {
+                "idx": 4,
+                "type": "text",
+                "content": (
+                    'FINAL_STATEMENT: {"statement":"Revenue increased.","confidenceScore":0.8,'
+                    '"caveats":["Excludes refunds"],"handoffNotes":["Used notebook SDK."]}'
+                ),
+            },
+            {
+                "idx": 5,
+                "type": "done",
+                "metadata": {
+                    "result": {
+                        "notion_charts": [
+                            {
+                                "title": "Revenue trend",
+                                "url": "/api/notion-analysis/chart/req/revenue.png",
+                            }
+                        ]
+                    }
+                },
+            },
+        ],
+        status_payload={"status": "Done"},
+    )
+
+    assert packet.user_request == "Analyze revenue"
+    assert packet.plan is not None
+    assert packet.plan.steps == ["Inspect schema", "Run revenue query", "Validate totals"]
+    assert packet.latest_progress is not None
+    assert packet.latest_progress.current_step == "Inspect schema"
+    assert packet.final_statement is not None
+    assert packet.final_statement.statement == "Revenue increased."
+    assert packet.final_statement.confidence_score == 0.8
+    assert packet.charts[0]["title"] == "Revenue trend"
+    assert packet.status == "done"
+
+
+def test_trace_control_markers_are_redacted_into_metadata_for_delivery() -> None:
+    content, metadata = redact_trace_control_markers(
+        "- Revenue increased.\n"
+        "- Costs stayed flat.\n\n"
+        'FINAL_STATEMENT: {"statement":"Revenue increased. Costs stayed flat.",'
+        '"confidenceScore":0.8,"caveats":["Excludes refunds"],'
+        '"handoffNotes":["Used notebook SDK."]}'
+    )
+
+    assert "FINAL_STATEMENT" not in content
+    assert content == "- Revenue increased.\n- Costs stayed flat."
+
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": content,
+                "metadata": metadata,
+            }
+        ],
+        status_payload={"status": "Done"},
+    )
+
+    assert packet.final_statement is not None
+    assert packet.final_statement.statement == "Revenue increased. Costs stayed flat."
+    assert packet.final_statement.confidence_score == 0.8
+    assert packet.final_statement.caveats == ["Excludes refunds"]
+    assert packet.final_statement.handoff_notes == ["Used notebook SDK."]
+
+
+def test_slack_progress_waits_for_worker_plan_then_uses_exact_steps() -> None:
+    no_plan = load_delivery_packet_from_events([], user_request="Analyze revenue")
+
+    assert render_slack_progress_message(no_plan) == "Analyzing your request..."
+
+    packet = load_delivery_packet_from_events(
+        [
+            {"idx": 1, "type": "text", "content": 'PLAN: {"steps":["Inspect schema","Run revenue query"]}'},
+            {
+                "idx": 2,
+                "type": "text",
+                "content": (
+                    'PROGRESS: {"currentStep":"Run revenue query",'
+                    '"completedSteps":["Inspect schema"],"status":"querying fin-db"}'
+                ),
+            },
+        ],
+    )
+
+    rendered = render_slack_progress_message(packet)
+
+    assert "- [x] Inspect schema" in rendered
+    assert "- [ ] Run revenue query (current)" in rendered
+    assert "querying fin-db" in rendered
+
+
+@pytest.mark.asyncio
+async def test_delivery_renderer_falls_back_to_final_statement_without_model() -> None:
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    'FINAL_STATEMENT: {"statement":"Revenue increased.","confidenceScore":0.8,'
+                    '"caveats":["Excludes refunds"],"handoffNotes":["Used notebook SDK."]}'
+                ),
+            }
+        ],
+        status_payload={"status": "Done"},
+        trail_url="https://app.test/projects?file=analysis.py",
+    )
+
+    delivery = await DeliveryRenderer(model="", api_key="").render(packet)
+    status = delivery_result_to_status(delivery, packet)
+    slack_text = render_slack_final_message(packet, delivery)
+
+    assert delivery.slack_message == "- Revenue increased."
+    assert status["finalAnswer"] == "- Revenue increased."
+    assert status["confidenceScore"] == 0.8
+    assert "*Analysis complete*" in slack_text
+    assert "- Revenue increased." in slack_text
+    assert "*Confidence:* 0.8" in slack_text
+    assert "<https://app.test/projects?file=analysis.py|Open authenticated notebook>" in slack_text
+
+
+@pytest.mark.asyncio
+async def test_delivery_renderer_defaults_to_sonnet_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SIGNALPILOT_DELIVERY_MODEL", raising=False)
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    'FINAL_STATEMENT: {"statement":"Revenue increased.",'
+                    '"confidenceScore":0.8,"caveats":[],"handoffNotes":[]}'
+                ),
+            }
+        ],
+        status_payload={"status": "Done"},
+    )
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "summary": "Revenue increased.",
+                                "slackMessage": "- Revenue increased.",
+                                "notionComment": "- Revenue increased.",
+                                "finalAnswer": "- Revenue increased.",
+                                "gotchas": [],
+                                "analysisMethod": "Notebook SDK.",
+                                "notionCharts": [],
+                            }
+                        ),
+                    }
+                ]
+            }
+
+    class FakeClient:
+        async def post(self, _url: str, *, headers: dict[str, str], json: dict[str, object]) -> FakeResponse:
+            del headers
+            captured["json"] = json
+            return FakeResponse()
+
+    await DeliveryRenderer(api_key="test-key", http_client=FakeClient()).render(packet)  # type: ignore[arg-type]
+
+    request_json = captured["json"]
+    assert isinstance(request_json, dict)
+    assert request_json["model"] == "claude-sonnet-4-5-20250929"
+
+
+@pytest.mark.asyncio
+async def test_delivery_renderer_prompt_requires_separate_bullet_lines() -> None:
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    'FINAL_STATEMENT: {"statement":"Revenue increased. Costs stayed flat.",'
+                    '"confidenceScore":0.8,"caveats":[],"handoffNotes":[]}'
+                ),
+            }
+        ],
+        status_payload={"status": "Done"},
+    )
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "summary": "Revenue increased.",
+                                "slackMessage": "- Revenue increased.\n- Costs stayed flat.",
+                                "notionComment": "- Revenue increased.\n- Costs stayed flat.",
+                                "finalAnswer": "- Revenue increased.\n- Costs stayed flat.",
+                                "gotchas": [],
+                                "analysisMethod": "Notebook SDK.",
+                                "notionCharts": [],
+                            }
+                        ),
+                    }
+                ]
+            }
+
+    class FakeClient:
+        async def post(self, _url: str, *, headers: dict[str, str], json: dict[str, object]) -> FakeResponse:
+            captured["headers"] = headers
+            captured["json"] = json
+            return FakeResponse()
+
+    await DeliveryRenderer(model="claude-haiku-test", api_key="test-key", http_client=FakeClient()).render(packet)  # type: ignore[arg-type]
+
+    request_json = captured["json"]
+    assert isinstance(request_json, dict)
+    system_prompt = request_json["system"]
+    assert isinstance(system_prompt, str)
+    assert "Each bullet must be on its own line and must start with '- '" in system_prompt
+    assert "do not keep them inside one bullet" in system_prompt

--- a/signalpilot/gateway/tests/test_analysis_delivery.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery.py
@@ -224,6 +224,55 @@ async def test_delivery_renderer_defaults_to_sonnet_model(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_delivery_renderer_preserves_packet_charts_when_model_returns_empty_chart_list() -> None:
+    packet = load_delivery_packet_from_events(
+        [],
+        status_payload={
+            "status": "Done",
+            "notionCharts": [
+                {"title": "Revenue trend", "url": "/api/notion-analysis/chart/req/revenue.png"},
+                {"title": "Margin ranking", "url": "/api/notion-analysis/chart/req/margin.png"},
+            ],
+        },
+    )
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "summary": "Revenue increased.",
+                                "slackMessage": "- Revenue increased.",
+                                "notionComment": "- Revenue increased.",
+                                "finalAnswer": "- Revenue increased.",
+                                "gotchas": [],
+                                "analysisMethod": "Notebook SDK.",
+                                "notionCharts": [],
+                            }
+                        ),
+                    }
+                ]
+            }
+
+    class FakeClient:
+        async def post(self, _url: str, *, headers: dict[str, str], json: dict[str, object]) -> FakeResponse:
+            del headers, json
+            return FakeResponse()
+
+    delivery = await DeliveryRenderer(model="claude-haiku-test", api_key="test-key", http_client=FakeClient()).render(packet)  # type: ignore[arg-type]
+    status = delivery_result_to_status(delivery, packet)
+
+    assert [chart["title"] for chart in delivery.notion_charts] == ["Revenue trend", "Margin ranking"]
+    assert [chart["title"] for chart in status["notionCharts"]] == ["Revenue trend", "Margin ranking"]
+
+
+@pytest.mark.asyncio
 async def test_delivery_renderer_prompt_requires_separate_bullet_lines() -> None:
     packet = load_delivery_packet_from_events(
         [

--- a/signalpilot/gateway/tests/test_analysis_delivery.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -9,10 +11,13 @@ from gateway.analysis_delivery import (
     DeliveryRenderer,
     classify_analysis_request,
     delivery_result_to_status,
+    load_delivery_packet,
     load_delivery_packet_from_events,
     render_slack_final_message,
     render_slack_progress_message,
 )
+from gateway.analysis_delivery import trace_loader as trace_loader_module
+from gateway.analysis_delivery.renderer import fallback_delivery
 from gateway.trace_markers import redact_trace_control_markers
 
 
@@ -79,6 +84,72 @@ def test_trace_loader_extracts_latest_worker_plan_progress_and_final_statement()
     assert packet.final_statement.confidence_score == 0.8
     assert packet.charts[0]["title"] == "Revenue trend"
     assert packet.status == "done"
+
+
+@pytest.mark.asyncio
+async def test_load_delivery_packet_reuses_loaded_trace_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    async def get_thread(*args, **kwargs):
+        calls.append(("get_thread", kwargs))
+        return SimpleNamespace(status="done")
+
+    async def get_events(*args, **kwargs):
+        calls.append(("get_events", kwargs))
+        return []
+
+    monkeypatch.setattr(trace_loader_module.chat_traces, "get_thread", get_thread)
+    monkeypatch.setattr(trace_loader_module.chat_traces, "get_events", get_events)
+
+    packet = await load_delivery_packet(
+        AsyncMock(),
+        org_id="org-1",
+        user_id="user-1",
+        thread_id="thread-1",
+    )
+
+    assert packet.status == "done"
+    assert calls == [
+        (
+            "get_thread",
+            {"org_id": "org-1", "user_id": "user-1", "thread_id": "thread-1"},
+        ),
+        (
+            "get_events",
+            {
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "thread_id": "thread-1",
+                "require_thread": False,
+            },
+        ),
+    ]
+
+
+def test_fallback_delivery_strips_placeholder_chart_labels() -> None:
+    packet = load_delivery_packet_from_events(
+        [],
+        status_payload={
+            "status": "Done",
+            "notionCharts": [
+                {
+                    "title": "Chart 1",
+                    "caption": "Notebook image 1",
+                    "url": "/api/notion-analysis/chart/req/image-1.png",
+                }
+            ],
+        },
+    )
+
+    result = fallback_delivery(packet)
+
+    assert result.notion_charts == [
+        {
+            "title": "",
+            "caption": "",
+            "url": "/api/notion-analysis/chart/req/image-1.png",
+        }
+    ]
 
 
 def test_trace_control_markers_are_redacted_into_metadata_for_delivery() -> None:

--- a/signalpilot/gateway/tests/test_chat_traces.py
+++ b/signalpilot/gateway/tests/test_chat_traces.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock
+
+import httpx
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from gateway.db.models import GatewayBase
 from gateway.models.workspace import ChatTraceEventCreate, ChatTraceThreadUpsert
+from gateway.slack_poc.progress import (
+    INITIAL_PROGRESS_TEXT,
+    ProgressSummary,
+    SlackProgressReporter,
+    SlackProgressSummarizer,
+    build_status_hints,
+    extract_progress_objects,
+    extract_progress_signals,
+    sanitize_trace_events,
+)
 from gateway.store.chat_traces import (
     append_event,
     clear_events,
@@ -215,3 +229,481 @@ async def test_trace_thread_listing_is_org_scoped(db_session) -> None:
             user_id="user-a",
             thread_id="thread-1",
         )
+
+
+def test_slack_progress_sanitizer_extracts_signals_without_findings() -> None:
+    events = [
+        {
+            "idx": 201,
+            "type": "text",
+            "content": "All 9 cells were added successfully. Now let me run all cells.",
+            "created_at": 100.0,
+        },
+        {
+            "idx": 202,
+            "type": "tool_use",
+            "tool_name": "mcp__signalpilot-notebook__edit_notebook",
+            "tool_input": {
+                "edits": [
+                    {
+                        "code": (
+                            "import signalpilot as sp\n"
+                            "db = sp.connect('fin-db')\n"
+                            "result = db.query(\"SELECT SUM(total_revenue) FROM analytics_marts.fct_transfers\")"
+                        )
+                    }
+                ]
+            },
+            "created_at": 101.0,
+        },
+        {
+            "idx": 203,
+            "type": "tool_use",
+            "tool_name": "mcp__signalpilot-notebook__run_cells",
+            "tool_input": {"session_id": "session-slack-99cf7447b23c57f7"},
+            "created_at": 102.0,
+        },
+        {
+            "idx": 204,
+            "type": "text",
+            "content": (
+                '{"finalAnswer":"Revenue was 2,628.88 across 220 completed transfers",'
+                '"confidenceScore":0.82}'
+            ),
+            "created_at": 103.0,
+        },
+        {
+            "idx": 205,
+            "type": "tool_result",
+            "content": "Traceback (most recent call last): SELECT * FROM analytics_marts.fct_transfers",
+            "created_at": 104.0,
+        },
+    ]
+
+    signals = extract_progress_signals(events)
+    sanitized = sanitize_trace_events(events, started_at=100.0)
+    serialized = str(sanitized)
+
+    assert "connects_to_fin-db" in signals
+    assert "contains_db_query" in signals
+    assert "uses_dbt_marts" in signals
+    assert "runs_notebook_cells" in signals
+    assert "fin-db" in serialized
+    assert "analytics_marts.fct_transfers" in serialized
+    assert "All 9 cells were added successfully" in serialized
+    assert "2,628.88" not in serialized
+    assert "220 completed" not in serialized
+    assert "finalAnswer" not in serialized
+    assert "SELECT SUM" not in serialized
+    assert "Traceback" not in serialized
+
+
+def test_slack_progress_extracts_safe_objects_for_ai_status() -> None:
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "mcp__signalpilot-notebook__edit_notebook",
+            "tool_input": {
+                "code": (
+                    "db = sp.connect('private-equity-db')\n"
+                    "db.query('select * from staging.fct_revenue')\n"
+                    "open('models/marts/fct_revenue.sql')"
+                )
+            },
+        }
+    ]
+
+    assert extract_progress_objects(events) == [
+        "private-equity-db",
+        "staging.fct_revenue",
+        "models/marts/fct_revenue.sql",
+    ]
+    assert extract_progress_objects(
+        [
+            {
+                "type": "tool_use",
+                "tool_name": "mcp__signalpilot-notebook__edit_notebook",
+                "tool_input": {"code": 'db = sp.connect(\\"private-equity-db\\")'},
+            }
+        ]
+    ) == ["private-equity-db"]
+
+
+def test_slack_progress_extracts_chart_labels_and_status_hints() -> None:
+    events = [
+        {
+            "idx": 164,
+            "type": "tool_use",
+            "tool_name": "mcp__signalpilot-notebook__edit_notebook",
+            "tool_input": {
+                "edits": [
+                    {
+                        "code": (
+                            "def build_ebitda_chart(fin_df):\n"
+                            "    ax_eb.set_title('Monthly EBITDA by Portfolio Company')\n"
+                            "    fig_eb.savefig('/tmp/ebitda_trends.png')\n"
+                            "ebitda_chart = build_ebitda_chart(financials_df)"
+                        )
+                    }
+                ]
+            },
+        }
+    ]
+    sanitized = sanitize_trace_events(events)
+
+    assert sanitized[0]["objects"] == [
+        "ebitda chart",
+        "Monthly EBITDA by Portfolio Company",
+        "ebitda trends chart",
+    ]
+    assert build_status_hints(
+        {
+            "recentEvents": sanitized,
+            "observedObjects": ["portfolio.monthly_financials", "ebitda chart"],
+        }
+    ) == ["Building Monthly EBITDA by Portfolio Company chart..."]
+
+
+def test_slack_progress_sanitizes_notebook_error_results() -> None:
+    sanitized = sanitize_trace_events(
+        [
+            {
+                "idx": 88,
+                "type": "tool_result",
+                "content": (
+                    "[{'type': 'text', 'text': '{\"error\": "
+                    "\"MultipleDefinitionError(name=\\'sp\\', cells=(\\'MJUe\\', \\'vblA\\'))\"}'}]"
+                ),
+            }
+        ]
+    )
+
+    assert sanitized == [
+        {
+            "idx": 88,
+            "type": "tool_result",
+            "safeText": "Notebook error: MultipleDefinitionError for sp",
+            "signals": ["notebook_error"],
+        }
+    ]
+    assert build_status_hints({"recentEvents": sanitized}) == ["Fixing duplicate sp definitions..."]
+
+
+def test_slack_progress_run_cells_uses_recent_objects_for_status_hints() -> None:
+    sanitized = sanitize_trace_events(
+        [
+            {
+                "idx": 176,
+                "type": "tool_use",
+                "tool_name": "mcp__signalpilot-notebook__run_cells",
+                "tool_input": {"session_id": "session-slack-1", "timeout": 120},
+            }
+        ]
+    )
+
+    assert build_status_hints(
+        {
+            "recentEvents": sanitized,
+            "observedObjects": ["private-equity-db", "portfolio.customer_metrics"],
+        }
+    ) == [
+        "Running portfolio.customer_metrics query...",
+        "Running private-equity-db notebook cells...",
+    ]
+
+
+def test_slack_progress_status_hints_prefer_current_event_objects() -> None:
+    assert build_status_hints(
+        {
+            "recentEvents": [
+                {
+                    "idx": 155,
+                    "type": "tool_use",
+                    "signals": ["contains_db_query"],
+                    "objects": ["portfolio.customer_metrics", "portfolio.operating_initiatives"],
+                }
+            ],
+            "observedObjects": ["portfolio.monthly_financials"],
+        }
+    ) == ["Querying portfolio.operating_initiatives..."]
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_summarizer_uses_ai_for_concrete_status() -> None:
+    seen_payloads: list[dict] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        seen_payloads.append(json.loads(body["messages"][0]["content"]))
+        return httpx.Response(
+            200,
+            json={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": '{"statusText":"Querying staging.fct_revenue...","shouldUpdate":true}',
+                    }
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        summary = await SlackProgressSummarizer(
+            model="claude-haiku-4-5-20251001",
+            api_key="sk-ant-test",
+            http_client=client,
+        ).summarize(
+            {
+                "previousStatus": INITIAL_PROGRESS_TEXT,
+                "observedSignals": ["contains_db_query"],
+                "recentEvents": [
+                    {
+                        "idx": 1,
+                        "type": "tool_use",
+                        "toolName": "mcp__signalpilot-notebook__edit_notebook",
+                        "signals": ["contains_db_query"],
+                        "objects": ["private-equity-db", "staging.fct_revenue"],
+                    }
+                ],
+            }
+        )
+    finally:
+        await client.aclose()
+
+    assert summary.status_text == "Querying staging.fct_revenue..."
+    assert summary.should_update is True
+    assert seen_payloads[0]["recentEvents"][0]["objects"] == ["private-equity-db", "staging.fct_revenue"]
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_summarizer_accepts_fenced_json() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "```json\n"
+                            '{"statusText":"Fixing MultipleDefinitionError in notebook structure...",'
+                            '"shouldUpdate":true}'
+                            "\n```"
+                        ),
+                    }
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        summary = await SlackProgressSummarizer(
+            model="claude-haiku-4-5-20251001",
+            api_key="sk-ant-test",
+            http_client=client,
+        ).summarize(
+            {
+                "previousStatus": INITIAL_PROGRESS_TEXT,
+                "recentEvents": [
+                    {
+                        "idx": 88,
+                        "type": "tool_result",
+                        "safeText": "Notebook error: MultipleDefinitionError for sp",
+                        "signals": ["notebook_error"],
+                    }
+                ],
+            }
+        )
+    finally:
+        await client.aclose()
+
+    assert summary.status_text == "Fixing MultipleDefinitionError in notebook structure..."
+    assert summary.should_update is True
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_summarizer_retries_generic_ai_status() -> None:
+    calls: list[dict] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        payload = json.loads(body["messages"][0]["content"])
+        calls.append(payload)
+        text = (
+            '{"statusText":"Building charts...","shouldUpdate":true}'
+            if len(calls) == 1
+            else '{"statusText":"Building EBITDA chart...","shouldUpdate":true}'
+        )
+        return httpx.Response(200, json={"content": [{"type": "text", "text": text}]})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        summary = await SlackProgressSummarizer(
+            model="claude-haiku-4-5-20251001",
+            api_key="sk-ant-test",
+            http_client=client,
+        ).summarize(
+            {
+                "previousStatus": INITIAL_PROGRESS_TEXT,
+                "observedSignals": ["builds_charts"],
+                "observedObjects": ["portfolio.monthly_financials", "EBITDA chart"],
+                "statusHints": ["Building EBITDA chart..."],
+                "recentEvents": [
+                    {
+                        "idx": 164,
+                        "type": "tool_use",
+                        "toolName": "mcp__signalpilot-notebook__edit_notebook",
+                        "signals": ["builds_charts"],
+                        "objects": ["EBITDA chart"],
+                    }
+                ],
+            }
+        )
+    finally:
+        await client.aclose()
+
+    assert summary.status_text == "Building EBITDA chart..."
+    assert len(calls) == 2
+    assert calls[1]["rejectedStatusText"] == "Building charts..."
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_summarizer_skips_update_when_ai_stays_generic() -> None:
+    calls: list[dict] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        calls.append(json.loads(body["messages"][0]["content"]))
+        return httpx.Response(
+            200,
+            json={"content": [{"type": "text", "text": '{"statusText":"Running notebook cells...","shouldUpdate":true}'}]},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        summary = await SlackProgressSummarizer(
+            model="claude-haiku-4-5-20251001",
+            api_key="sk-ant-test",
+            http_client=client,
+        ).summarize(
+            {
+                "previousStatus": INITIAL_PROGRESS_TEXT,
+                "statusHints": ["Running portfolio.customer_metrics query..."],
+                "recentEvents": [
+                    {
+                        "idx": 176,
+                        "type": "tool_use",
+                        "toolName": "mcp__signalpilot-notebook__run_cells",
+                        "signals": ["runs_notebook_cells"],
+                    }
+                ],
+            }
+        )
+    finally:
+        await client.aclose()
+
+    assert summary.status_text == INITIAL_PROGRESS_TEXT
+    assert summary.should_update is False
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_summarizer_skips_update_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    summarizer = SlackProgressSummarizer(model="claude-small-test")
+
+    summary = await summarizer.summarize(
+        {
+            "previousStatus": INITIAL_PROGRESS_TEXT,
+            "observedSignals": ["contains_db_query"],
+            "recentEvents": [],
+        }
+    )
+
+    assert summary.status_text == INITIAL_PROGRESS_TEXT
+    assert summary.should_update is False
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_summarizer_skips_update_on_invalid_json_and_timeout() -> None:
+    async def invalid_json_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"content": [{"type": "text", "text": "not json"}]})
+
+    invalid_client = httpx.AsyncClient(transport=httpx.MockTransport(invalid_json_handler))
+    try:
+        invalid_summary = await SlackProgressSummarizer(
+            model="claude-small-test",
+            api_key="sk-ant-test",
+            http_client=invalid_client,
+        ).summarize(
+            {
+                "previousStatus": INITIAL_PROGRESS_TEXT,
+                "observedSignals": ["notebook_edited"],
+                "recentEvents": [],
+            }
+        )
+    finally:
+        await invalid_client.aclose()
+
+    async def timeout_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("timeout")
+
+    timeout_client = httpx.AsyncClient(transport=httpx.MockTransport(timeout_handler))
+    try:
+        timeout_summary = await SlackProgressSummarizer(
+            model="claude-small-test",
+            api_key="sk-ant-test",
+            http_client=timeout_client,
+        ).summarize(
+            {
+                "previousStatus": INITIAL_PROGRESS_TEXT,
+                "observedSignals": ["runs_notebook_cells"],
+                "recentEvents": [],
+            }
+        )
+    finally:
+        await timeout_client.aclose()
+
+    assert invalid_summary.status_text == INITIAL_PROGRESS_TEXT
+    assert invalid_summary.should_update is False
+    assert timeout_summary.status_text == INITIAL_PROGRESS_TEXT
+    assert timeout_summary.should_update is False
+
+
+@pytest.mark.asyncio
+async def test_slack_progress_reporter_ignores_slack_update_failure() -> None:
+    slack = AsyncMock()
+    slack.update_message.side_effect = RuntimeError("slack update failed")
+    reporter = SlackProgressReporter(
+        slack=slack,
+        session_factory=AsyncMock(),
+        org_id="org-a",
+        user_id="user-a",
+        thread_id="session-slack-1",
+        source_prompt="Use my fin db and dbt project",
+        channel_id="C1",
+        message_ts="2.0",
+        interval_seconds=0.1,
+        summarizer=AsyncMock(
+            summarize=AsyncMock(return_value=ProgressSummary("Querying portfolio.customer_metrics...", True))
+        ),
+    )
+
+    async def fetch_events():
+        return [
+            {
+                "idx": 1,
+                "type": "tool_use",
+                "tool_name": "mcp__signalpilot-notebook__run_cells",
+                "tool_input": {},
+                "created_at": 100.0,
+            }
+        ]
+
+    reporter._fetch_events = fetch_events
+
+    await reporter._tick()
+
+    slack.update_message.assert_awaited_once()
+    assert reporter.previous_status == INITIAL_PROGRESS_TEXT

--- a/signalpilot/gateway/tests/test_git_repos.py
+++ b/signalpilot/gateway/tests/test_git_repos.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def test_init_bare_repo_creates_branchable_default(monkeypatch, tmp_path) -> None:
+    from gateway.git import repos
+
+    project_id = "00000000-0000-0000-0000-000000000001"
+    monkeypatch.setattr(repos, "REPOS_ROOT", tmp_path)
+
+    repos.init_bare_repo(project_id)
+
+    main_sha = repos.branch_head_sha(project_id, "main")
+    assert main_sha
+    assert repos.ensure_branch_from(project_id, "analysis/slack/test", "main") == main_sha
+    assert repos.branch_head_sha(project_id, "analysis/slack/test") == main_sha
+
+
+def test_init_bare_repo_repairs_existing_empty_repo(monkeypatch, tmp_path) -> None:
+    from gateway.git import repos
+
+    project_id = "00000000-0000-0000-0000-000000000002"
+    monkeypatch.setattr(repos, "REPOS_ROOT", tmp_path)
+    path = tmp_path / f"{project_id}.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch", "main", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    repos.init_bare_repo(project_id)
+
+    main_sha = repos.branch_head_sha(project_id, "main")
+    assert main_sha
+    assert repos.ensure_branch_from(project_id, "analysis/slack/test", "main") == main_sha

--- a/signalpilot/gateway/tests/test_middleware.py
+++ b/signalpilot/gateway/tests/test_middleware.py
@@ -44,6 +44,11 @@ class TestMiddlewarePublicPaths:
 
         assert "/slack/events" in PUBLIC_PATHS
 
+    def test_slack_oauth_callback_is_public(self):
+        from gateway.http import PUBLIC_PATHS
+
+        assert "/api/integrations/slack/oauth/callback" in PUBLIC_PATHS
+
     def test_api_endpoints_not_public(self):
         from gateway.http import PUBLIC_PATHS
 

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -28,6 +28,52 @@ def _block_rich_text(block: dict) -> list[dict]:
 
 
 @pytest.mark.asyncio
+async def test_poll_analysis_uses_project_route_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict] = []
+    runtime = NotebookRuntime(
+        session_id="session-1",
+        internal_base_url="http://notebook.internal",
+        public_base_url="https://app.test/notebook/session-1",
+    )
+    route = notion_analysis.AnalysisRoute(
+        source="slack",
+        request_id="slack-req-1",
+        project_id="project-1",
+        branch="analysis/slack/slack-req-1-hi",
+        default_branch="main",
+        analysis_user_id="analysis:slack:slack-req-1",
+    )
+
+    async def call_notebook(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return {"status": "Done"}
+
+    monkeypatch.setattr(notion_analysis, "_call_notebook", call_notebook)
+
+    result = await notion_analysis._poll_analysis(
+        "slack-req-1",
+        runtime,
+        "org-1",
+        "user-1",
+        route,
+    )
+
+    assert result == {"status": "Done"}
+    assert calls[0]["args"][:4] == (
+        runtime,
+        "/api/notion-analysis/status/slack-req-1",
+        "org-1",
+        "user-1",
+    )
+    assert calls[0]["args"][4] == {
+        "headers": {
+            "X-Gateway-Project-Id": "project-1",
+            "X-Gateway-Branch-Id": "analysis/slack/slack-req-1-hi",
+        }
+    }
+
+
+@pytest.mark.asyncio
 async def test_start_comment_is_posted_before_notebook_call_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from gateway.analysis_delivery import DeliveryPacket, WorkerPlan, WorkerProgress
 from gateway.db.models import NotionInstallation, NotionInstallationConfig
 from gateway.notebooks.session_service import NotebookRuntime
 from gateway.notion import analysis as notion_analysis
@@ -298,6 +299,54 @@ def test_start_comment_links_request_details_without_raw_url() -> None:
     assert any(part.get("text", {}).get("link", {}).get("url") == url for part in rich_text)
 
 
+@pytest.mark.asyncio
+async def test_notion_trace_progress_updates_comment_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    packet = DeliveryPacket(
+        user_request="Analyze revenue",
+        plan=WorkerPlan(steps=["Explore schema", "Analyze financials", "Write answer"]),
+        latest_progress=WorkerProgress(
+            current_step="Analyze financials",
+            completed_steps=["Explore schema"],
+            status="running governed queries",
+        ),
+    )
+    calls: dict[str, str | dict] = {}
+
+    async def load_delivery_packet(*args, **kwargs):
+        return packet
+
+    async def update_page_properties(*_args, **_kwargs):
+        calls["properties"] = "unexpected"
+
+    async def update_comment(_token, _comment_id, *, rich_text):
+        calls["comment"] = _rich_text_content(rich_text)
+
+    monkeypatch.setattr(notion_analysis, "load_delivery_packet", load_delivery_packet)
+    monkeypatch.setattr(notion_client, "update_page_properties", update_page_properties)
+    monkeypatch.setattr(notion_client, "update_comment", update_comment)
+
+    reporter = notion_analysis._NotionTraceProgressReporter(
+        token="token-1",
+        request_page_url="https://notion.test/request-page-1",
+        progress_comment_id="comment-1",
+        db=MagicMock(),
+        org_id="org-1",
+        user_id="user-1",
+        thread_id="session-notion-1",
+        user_request="Analyze revenue",
+    )
+
+    await reporter.tick({})
+
+    assert "properties" not in calls
+    comment_text = str(calls["comment"])
+    assert comment_text.startswith("I'm on it and will post the answer back soon.")
+    assert "- [x] Explore schema" in comment_text
+    assert "- [ ] Analyze financials (current)" in comment_text
+    assert "Working on: Analyze financials." in comment_text
+    assert "Loading:" not in comment_text
+
+
 def test_public_signalpilot_url_preserves_durable_notebooks_trail_url() -> None:
     runtime = NotebookRuntime(
         session_id="runtime-session-1",
@@ -479,6 +528,38 @@ def test_final_comment_rich_text_mentions_attached_charts() -> None:
     assert "Momentum ranking" in content
 
 
+def test_final_comment_rich_text_omits_placeholder_chart_titles() -> None:
+    status = {
+        "notionComment": "- MapleCloud leads.",
+        "notionCharts": [
+            {
+                "title": "Notebook image 1",
+                "url": "/api/notion-analysis/chart/req/image-1.png",
+                "fileUploadId": "upload-1",
+                "includeInComment": True,
+                "includeOnPage": True,
+            },
+            {
+                "title": "Notebook image 1",
+                "url": "/api/notion-analysis/chart/req/image-2.png",
+                "fileUploadId": "upload-2",
+                "includeInComment": True,
+                "includeOnPage": True,
+            },
+        ],
+    }
+
+    rich_text = notion_analysis._final_comment_rich_text(status, "https://notion.test/request-page-1")
+    content = _rich_text_content(rich_text)
+
+    assert "Charts attached:" not in content
+    assert "Notebook image" not in content
+    assert notion_analysis._comment_attachments(status) == [
+        {"type": "file_upload", "file_upload_id": "upload-1"},
+        {"type": "file_upload", "file_upload_id": "upload-2"},
+    ]
+
+
 def test_analysis_detail_blocks_prepend_uploaded_chart_images() -> None:
     blocks = notion_analysis._analysis_detail_blocks(
         {
@@ -546,10 +627,15 @@ async def test_upload_chart_images_to_notion_uploads_unique_chart_urls(monkeypat
 
 @pytest.mark.asyncio
 async def test_create_final_comment_retries_without_chart_attachments(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[list[dict] | None] = []
+    calls: list[dict[str, object]] = []
 
     async def create_comment(*args, **kwargs):
-        calls.append(kwargs.get("attachments"))
+        calls.append(
+            {
+                "attachments": kwargs.get("attachments"),
+                "text": _rich_text_content(kwargs["rich_text"]),
+            }
+        )
         if kwargs.get("attachments"):
             raise RuntimeError("attachments rejected")
 
@@ -573,7 +659,74 @@ async def test_create_final_comment_retries_without_chart_attachments(monkeypatc
         "https://notion.test/request-page-1",
     )
 
-    assert calls == [[{"type": "file_upload", "file_upload_id": "upload-1"}], None]
+    assert calls[0]["attachments"] == [{"type": "file_upload", "file_upload_id": "upload-1"}]
+    assert calls[1]["attachments"] is None
+    assert "Charts attached:" in str(calls[0]["text"])
+    assert "Charts attached:" not in str(calls[1]["text"])
+
+
+@pytest.mark.asyncio
+async def test_create_final_comment_deletes_progress_comment_then_posts_attached_final(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def delete_comment(_token, comment_id):
+        calls.append(("delete", comment_id))
+
+    async def create_comment(*args, **kwargs):
+        calls.append(
+            (
+                "create",
+                {
+                    "text": _rich_text_content(kwargs["rich_text"]),
+                    "attachments": kwargs.get("attachments"),
+                },
+            )
+        )
+
+    monkeypatch.setattr(notion_client, "delete_comment", delete_comment)
+    monkeypatch.setattr(notion_client, "create_comment", create_comment)
+
+    await notion_analysis._create_final_comment(
+        "token-1",
+        "discussion-1",
+        {
+            "notionComment": "- MapleCloud leads.",
+            "notionCharts": [
+                {
+                    "title": "Momentum ranking",
+                    "url": "/api/notion-analysis/chart/req/ranking.png",
+                    "fileUploadId": "upload-1",
+                    "includeInComment": True,
+                    "includeOnPage": True,
+                }
+            ],
+        },
+        "https://notion.test/request-page-1",
+        comment_id="comment-1",
+    )
+
+    assert calls == [
+        ("delete", "comment-1"),
+        (
+            "create",
+            {
+                "text": (
+                    "• MapleCloud leads.\n\n"
+                    "Request page: request details\n\n"
+                    "Charts attached:\n"
+                    "• Momentum ranking"
+                ),
+                "attachments": [
+                    {
+                        "type": "file_upload",
+                        "file_upload_id": "upload-1",
+                    }
+                ],
+            },
+        ),
+    ]
 
 
 def test_failure_comment_rich_text_links_page_and_marks_error_as_code() -> None:

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -560,6 +560,29 @@ def test_final_comment_rich_text_omits_placeholder_chart_titles() -> None:
     ]
 
 
+def test_analysis_detail_blocks_omit_placeholder_chart_captions() -> None:
+    blocks = notion_analysis._analysis_detail_blocks(
+        {
+            "summary": "MapleCloud leads.",
+            "notionCharts": [
+                {
+                    "title": "Notebook image 1",
+                    "caption": "Chart 1",
+                    "url": "/api/notion-analysis/chart/req/image-1.png",
+                    "fileUploadId": "upload-1",
+                    "includeInComment": True,
+                    "includeOnPage": True,
+                }
+            ],
+        }
+    )
+
+    image = next(block["image"] for block in blocks if block.get("type") == "image")
+
+    assert image["caption"] == []
+    assert image["file_upload"] == {"id": "upload-1"}
+
+
 def test_analysis_detail_blocks_prepend_uploaded_chart_images() -> None:
     blocks = notion_analysis._analysis_detail_blocks(
         {

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -154,7 +154,7 @@ async def test_start_comment_is_posted_before_notebook_call_failure(monkeypatch:
     monkeypatch.setattr(notion_client, "create_comment", create_comment)
     monkeypatch.setattr(notion_client, "is_bot_comment", lambda _comment: False)
     monkeypatch.setattr(notion_client, "comment_has_page_mention", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "Hello")
+    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "Analyze revenue by month")
     monkeypatch.setattr(notion_analysis, "resolve_configured_analysis_route", resolve_route)
     monkeypatch.setattr(notion_analysis, "ensure_analysis_notebook_session", ensure_runtime)
     monkeypatch.setattr(notion_analysis, "upsert_analysis_trail_seed", seed_trail)
@@ -228,7 +228,7 @@ async def test_missing_default_project_posts_setup_required_failure(monkeypatch:
     monkeypatch.setattr(notion_client, "create_comment", create_comment)
     monkeypatch.setattr(notion_client, "is_bot_comment", lambda _comment: False)
     monkeypatch.setattr(notion_client, "comment_has_page_mention", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "Hello")
+    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "Analyze revenue by month")
     monkeypatch.setattr(notion_analysis, "_call_notebook", call_notebook)
 
     result = await notion_analysis.process_routed_comment_event(routed, payload, db=MagicMock())
@@ -236,6 +236,56 @@ async def test_missing_default_project_posts_setup_required_failure(monkeypatch:
     assert result.status == "processed"
     assert "call_notebook" not in calls
     assert any("default dbt project" in call for call in calls if call.startswith("comment:"))
+
+
+@pytest.mark.asyncio
+async def test_notion_preflight_greeting_posts_direct_reply_without_request_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    install = NotionInstallation(
+        id="install-1",
+        org_id="org-1",
+        user_id="user-1",
+        workspace_id="workspace-1",
+        bot_id="bot-1",
+        access_token_enc=b"encrypted",
+        status="active",
+    )
+    config = NotionInstallationConfig(
+        installation_id="install-1",
+        parent_page_id=None,
+        trigger_page_id="trigger-1",
+        requests_data_source_id="ds-1",
+        requests_database_page_id="db-1",
+        enabled=True,
+    )
+    routed = RoutedNotionInstallation(installation=install, config=config, access_token="token-1")
+    payload = {"entity": {"id": "comment-1"}, "data": {"page_id": "page-1"}}
+    comment = {"id": "comment-1", "discussion_id": "discussion-1", "rich_text": []}
+
+    async def list_comments(*args, **kwargs):
+        return [comment]
+
+    async def create_comment(*args, **kwargs):
+        calls.append(f"comment:{_rich_text_content(kwargs['rich_text'])}")
+
+    async def fail_create_request_page(*args, **kwargs):
+        raise AssertionError("greeting should not create a request page")
+
+    async def fail_call_notebook(*args, **kwargs):
+        raise AssertionError("greeting should not call notebook")
+
+    monkeypatch.setattr(notion_client, "list_comments", list_comments)
+    monkeypatch.setattr(notion_client, "create_comment", create_comment)
+    monkeypatch.setattr(notion_client, "create_request_page", fail_create_request_page)
+    monkeypatch.setattr(notion_client, "is_bot_comment", lambda _comment: False)
+    monkeypatch.setattr(notion_client, "comment_has_page_mention", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "hi")
+    monkeypatch.setattr(notion_analysis, "_call_notebook", fail_call_notebook)
+
+    result = await notion_analysis.process_routed_comment_event(routed, payload, db=MagicMock())
+
+    assert result.status == "processed"
+    assert calls == ["comment:Hi. Send me a specific data question and I will run it through SignalPilot."]
 
 
 def test_start_comment_links_request_details_without_raw_url() -> None:

--- a/signalpilot/gateway/tests/test_notion_notebook_session_service.py
+++ b/signalpilot/gateway/tests/test_notion_notebook_session_service.py
@@ -71,6 +71,8 @@ async def test_pod_extra_env_includes_gateway_oauth_user_anthropic_key_and_web_u
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "global-ant-key")
     monkeypatch.delenv("SP_WEB_URL", raising=False)
+    monkeypatch.delenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL", raising=False)
+    monkeypatch.delenv("SIGNALPILOT_WORKER_AGENT_MODEL", raising=False)
     monkeypatch.setenv("SIGNALPILOT_WEB_URL", "https://app.signalpilot.ai")
     monkeypatch.setattr(
         session_service.user_secrets_store,
@@ -97,6 +99,8 @@ async def test_pod_extra_env_includes_gateway_oauth_user_anthropic_key_and_web_u
 async def test_pod_extra_env_defaults_web_url_in_cloud_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SP_WEB_URL", raising=False)
     monkeypatch.delenv("SIGNALPILOT_WEB_URL", raising=False)
+    monkeypatch.delenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL", raising=False)
+    monkeypatch.delenv("SIGNALPILOT_WORKER_AGENT_MODEL", raising=False)
     monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
     monkeypatch.setattr(
         session_service.user_secrets_store,
@@ -112,6 +116,28 @@ async def test_pod_extra_env_defaults_web_url_in_cloud_mode(monkeypatch: pytest.
     )
 
     assert env == {"SP_WEB_URL": "https://app.signalpilot.ai"}
+
+
+@pytest.mark.asyncio
+async def test_pod_extra_env_includes_analysis_agent_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("CLAUDE_CODE_OAUTH_TOKEN", "OAUTH_TOKEN", "ANTHROPIC_API_KEY", "SP_WEB_URL", "SIGNALPILOT_WEB_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+    monkeypatch.setenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL", "claude-sonnet-4-5-20250929")
+    monkeypatch.setattr(
+        session_service.user_secrets_store,
+        "get_user_anthropic_key",
+        AsyncMock(return_value=None),
+    )
+
+    env = await session_service._pod_extra_env(
+        AsyncMock(),
+        org_id="org-1",
+        user_id="user-1",
+        extra_env=None,
+    )
+
+    assert env == {"SIGNALPILOT_ANALYSIS_AGENT_MODEL": "claude-sonnet-4-5-20250929"}
 
 
 @pytest.mark.asyncio

--- a/signalpilot/gateway/tests/test_notion_oauth.py
+++ b/signalpilot/gateway/tests/test_notion_oauth.py
@@ -414,8 +414,41 @@ async def test_create_request_page_does_not_write_prompt_or_source_body(monkeypa
     body = calls[0]["json_body"]
     assert body["parent"] == {"type": "data_source_id", "data_source_id": "data-source-123"}
     assert body["properties"]["Summary"]["rich_text"][0]["text"]["content"].startswith("## Question")
+    assert body["properties"]["Created at"] == {"date": {"start": "2026-06-01T12:00:00+00:00"}}
 
     assert "children" not in body
+
+
+@pytest.mark.asyncio
+async def test_create_request_page_falls_back_to_readable_created_at_for_legacy_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def fake_notion_json(api_key: str, method: str, path: str, *, json_body=None, params=None):
+        del api_key, method, path, params
+        calls.append(json.loads(json.dumps(json_body)))
+        if len(calls) == 1:
+            request = httpx.Request("POST", "https://api.notion.com/v1/pages")
+            response = httpx.Response(400, json={"message": "Created at should be rich_text"}, request=request)
+            raise httpx.HTTPStatusError("bad request", request=request, response=response)
+        return {"id": "request-page-123", "url": "https://notion.test/request-page-123"}
+
+    monkeypatch.setattr(notion_client, "notion_json", fake_notion_json)
+
+    page = await notion_client.create_request_page(
+        "token",
+        "data-source-123",
+        headline="Revenue question",
+        source_url="https://notion.test/source-page",
+        requester_id="user-123",
+        prompt="Analyze revenue",
+        created_at="2026-06-26T14:38:44.790255+00:00",
+    )
+
+    assert page == {"id": "request-page-123", "url": "https://notion.test/request-page-123"}
+    assert calls[0]["properties"]["Created at"] == {"date": {"start": "2026-06-26T14:38:44.790255+00:00"}}
+    assert calls[1]["properties"]["Created at"]["rich_text"][0]["text"]["content"] == "Jun 26, 2026 14:38 UTC"
 
 
 @pytest.mark.asyncio

--- a/signalpilot/gateway/tests/test_slack_oauth.py
+++ b/signalpilot/gateway/tests/test_slack_oauth.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import HTTPException
+
+from gateway.api import slack as slack_api
+from gateway.models.slack import SlackProvisionRequest
+
+
+def test_authorize_url_includes_state_and_required_oauth_fields() -> None:
+    url = slack_api.build_slack_authorize_url(
+        "client-123",
+        "https://app.test/slack/callback",
+        "state-123",
+        "app_mentions:read,chat:write",
+    )
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://slack.com/oauth/v2/authorize"
+    assert params["client_id"] == ["client-123"]
+    assert params["redirect_uri"] == ["https://app.test/slack/callback"]
+    assert params["scope"] == ["app_mentions:read,chat:write"]
+    assert params["state"] == ["state-123"]
+
+
+def test_oauth_redirect_rejects_external_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SIGNALPILOT_WEB_URL", "https://app.signalpilot.ai")
+
+    redirect_url = slack_api._safe_redirect_url(
+        "https://evil.test/integrations",
+        installation_id="install-1",
+    )
+    parsed = urlparse(redirect_url)
+    params = parse_qs(parsed.query)
+
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://app.signalpilot.ai/integrations"
+    assert params["slack"] == ["connected"]
+    assert params["slack_installation_id"] == ["install-1"]
+
+
+@pytest.mark.asyncio
+async def test_provisioning_requires_existing_default_project() -> None:
+    class Store:
+        async def get_workspace_project(self, project_id: str):
+            assert project_id == "project-1"
+
+    with pytest.raises(HTTPException) as exc:
+        await slack_api.provision_slack_oauth_installation(
+            "install-1",
+            SlackProvisionRequest(default_project_id="project-1"),
+            Store(),
+            object(),
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Default project not found"
+
+
+@pytest.mark.asyncio
+async def test_provisioning_saves_default_project() -> None:
+    calls: list[dict] = []
+
+    class Store:
+        async def get_workspace_project(self, project_id: str):
+            assert project_id == "project-1"
+            return object()
+
+        async def save_slack_oauth_installation_config(self, installation_id: str, **kwargs):
+            calls.append({"installation_id": installation_id, **kwargs})
+            return {
+                "id": installation_id,
+                "team_id": "T1",
+                "team_name": "Demo",
+                "bot_user_id": "UBOT",
+                "status": "active",
+                "config": {
+                    "enabled": True,
+                    "default_project_id": kwargs["default_project_id"],
+                    "default_branch": kwargs["default_branch"],
+                    "analysis_branch_mode": kwargs["analysis_branch_mode"],
+                    "allowed_channel_ids": kwargs["allowed_channel_ids"],
+                },
+            }
+
+    response = await slack_api.provision_slack_oauth_installation(
+        "install-1",
+        SlackProvisionRequest(default_project_id="project-1", allowed_channel_ids=["C1"]),
+        Store(),
+        object(),
+    )
+
+    assert response.installation.id == "install-1"
+    assert calls == [
+        {
+            "installation_id": "install-1",
+            "enabled": True,
+            "default_project_id": "project-1",
+            "default_branch": "main",
+            "analysis_branch_mode": "per_request",
+            "allowed_channel_ids": ["C1"],
+        }
+    ]

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -23,7 +23,7 @@ from gateway.slack_poc.worker import (
     SlackPoCWorker,
     SlackRequest,
     _apply_local_runtime_defaults,
-    _final_slack_text,
+    _EventDeduper,
     _remove_bot_mention,
     create_http_app,
 )
@@ -33,25 +33,19 @@ def test_remove_bot_mention_removes_configured_mention_and_fallback_mentions() -
     assert _remove_bot_mention("<@U123> analyze revenue <@U999>", "U123") == "analyze revenue"
 
 
-def test_final_slack_text_includes_answer_trail_confidence_without_chart_links() -> None:
-    text = _final_slack_text(
-        {
-            "status": "Done",
-            "notionComment": "**Revenue grew** in Q2.\nCosts stayed flat.",
-            "confidenceScore": 0.83,
-            "notionCharts": [{"title": "Revenue trend", "url": "https://app.test/chart.png"}],
-        },
-        "https://app.test/projects?file=analysis.py",
-    )
+def test_event_deduper_bounds_size_and_expires_old_events() -> None:
+    deduper = _EventDeduper(max_size=2, ttl_seconds=10)
 
-    assert "*SignalPilot analysis complete*" in text
-    assert "*Revenue grew* in Q2" in text
-    assert "**Revenue grew**" not in text
-    assert "*Confidence:* 0.83" in text
-    assert "<https://app.test/projects?file=analysis.py|Open authenticated notebook>" in text
-    assert "*Notebook trail:* https://" not in text
-    assert "https://app.test/chart.png" not in text
-    assert "*Charts:*" not in text
+    assert deduper.add("event-1", now=100)
+    assert not deduper.add("event-1", now=101)
+    assert deduper.add("event-2", now=102)
+    assert deduper.add("event-3", now=103)
+    assert len(deduper) == 2
+    assert deduper.add("event-1", now=104)
+
+    expiring = _EventDeduper(max_size=10, ttl_seconds=5)
+    assert expiring.add("event-1", now=100)
+    assert expiring.add("event-1", now=106)
 
 
 @pytest.mark.asyncio
@@ -473,6 +467,50 @@ async def test_worker_uploads_chart_images_as_slack_thread_files(monkeypatch: py
         content=b"png-bytes",
         content_type="image/png",
     )
+
+
+@pytest.mark.asyncio
+async def test_worker_omits_placeholder_chart_file_titles(monkeypatch: pytest.MonkeyPatch) -> None:
+    slack = AsyncMock(spec=SlackApiClient)
+    slack.fetch_bytes.return_value = (b"png-bytes", "image/png")
+    worker = SlackPoCWorker(
+        SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", bot_user_id="UBOT"),
+        slack,
+        AsyncMock(),
+    )
+
+    monkeypatch.setattr(
+        "gateway.slack_poc.worker.notebook_analysis._internal_signalpilot_url",
+        lambda url, runtime: f"http://notebook.test{url}",
+    )
+
+    await worker._post_chart_attachments(
+        SlackRequest(
+            event_id="Ev1",
+            team_id="T1",
+            channel_id="C1",
+            user_id="U1",
+            text="analyze revenue",
+            event_ts="1.0",
+            thread_ts="1.0",
+            source_url="slack://channel/C1/p10",
+        ),
+        {
+            "notionCharts": [
+                {
+                    "title": "Notebook image 1",
+                    "fileName": "notebook-image-1.png",
+                    "url": "/api/notion-analysis/chart/notion-1/image-1.png",
+                }
+            ]
+        },
+        AsyncMock(),
+    )
+
+    slack.upload_file.assert_awaited_once()
+    kwargs = slack.upload_file.await_args.kwargs
+    assert kwargs["title"] is None
+    assert kwargs["filename"] == "chart-1.png"
     slack.post_message.assert_not_called()
 
 

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -369,16 +369,60 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
         "db_enter",
         "update",
         "db_exit",
+        "db_enter",
+        "db_exit",
     ]
     assert slack_events[0] == ("post", INITIAL_PROGRESS_TEXT)
     assert ("update", "Querying database...") in slack_events[1:]
     assert ("update", COMPLETING_PROGRESS_TEXT) in slack_events[1:]
     assert slack_events[-1][0] == "update"
-    assert "*SignalPilot analysis complete*" in slack_events[-1][1]
+    assert "*Analysis complete*" in slack_events[-1][1]
     assert slack.post_message.await_count == 1
     slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
     slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="white_check_mark")
     slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
+    slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="x")
+
+
+@pytest.mark.asyncio
+async def test_worker_adds_error_reaction_when_analysis_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    slack = AsyncMock(spec=SlackApiClient)
+    slack.post_message.return_value = "progress-ts"
+    slack.add_reaction.return_value = None
+    slack.remove_reaction.return_value = None
+
+    worker = SlackPoCWorker(
+        SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", org_id="org-1", user_id="user-1"),
+        slack,
+        AsyncMock(),
+    )
+
+    async def fail_previous_messages(_request):
+        raise RuntimeError("notebook auth missing")
+
+    monkeypatch.setattr(worker, "_previous_thread_messages", fail_previous_messages)
+
+    await worker._process_request(
+        SlackRequest(
+            event_id="Ev1",
+            team_id="T1",
+            channel_id="C1",
+            user_id="U1",
+            text="analyze revenue",
+            event_ts="1.0",
+            thread_ts="1.0",
+            source_url="https://slack.test/archives/C1/p10",
+        )
+    )
+
+    slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
+    slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="x")
+    added_reactions = [call.kwargs["name"] for call in slack.add_reaction.await_args_list]
+    assert "white_check_mark" not in added_reactions
+    slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
+    slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="white_check_mark")
+    slack.update_message.assert_awaited_once()
+    assert "could not complete the analysis" in slack.update_message.call_args.kwargs["text"]
 
 
 @pytest.mark.asyncio
@@ -693,6 +737,74 @@ async def test_worker_posts_empty_prompt_guidance_for_bare_mention() -> None:
 
     slack.post_message.assert_called_once()
     assert "Ask me a data question" in slack.post_message.call_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_worker_preflight_direct_greeting_does_not_spawn_analysis(monkeypatch: pytest.MonkeyPatch) -> None:
+    slack = AsyncMock(spec=SlackApiClient)
+    slack.permalink.return_value = "https://slack.test/archives/C1/p1000"
+    worker = SlackPoCWorker(
+        SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", bot_user_id="UBOT"),
+        slack,
+        AsyncMock(),
+    )
+
+    async def fail_process_request(_request):
+        raise AssertionError("greeting should not spawn analysis")
+
+    monkeypatch.setattr(worker, "_process_request", fail_process_request)
+
+    await worker.handle_events_api_payload(
+        {
+            "event_id": "Ev1",
+            "team_id": "T1",
+            "event": {
+                "type": "app_mention",
+                "channel": "C1",
+                "user": "U1",
+                "text": "<@UBOT> hi",
+                "ts": "1.0",
+            },
+        }
+    )
+    await worker.drain()
+
+    slack.post_message.assert_awaited_once()
+    assert "specific data question" in slack.post_message.call_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_worker_preflight_ambiguous_data_prompt_does_not_spawn_analysis(monkeypatch: pytest.MonkeyPatch) -> None:
+    slack = AsyncMock(spec=SlackApiClient)
+    slack.permalink.return_value = "https://slack.test/archives/C1/p1000"
+    worker = SlackPoCWorker(
+        SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", bot_user_id="UBOT"),
+        slack,
+        AsyncMock(),
+    )
+
+    async def fail_process_request(_request):
+        raise AssertionError("ambiguous prompt should not spawn analysis")
+
+    monkeypatch.setattr(worker, "_process_request", fail_process_request)
+
+    await worker.handle_events_api_payload(
+        {
+            "event_id": "Ev1",
+            "team_id": "T1",
+            "event": {
+                "type": "app_mention",
+                "channel": "C1",
+                "user": "U1",
+                "text": "<@UBOT> revenue",
+                "ts": "1.0",
+            },
+        }
+    )
+    await worker.drain()
+
+    slack.post_message.assert_awaited_once()
+    assert "fresh, specific analysis request" in slack.post_message.call_args.kwargs["text"]
 
 
 @pytest.mark.asyncio

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -49,6 +49,32 @@ def test_event_deduper_bounds_size_and_expires_old_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_http_server_defaults_to_loopback_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeServer:
+        def __init__(self, config):
+            captured["host"] = config.host
+
+        async def serve(self) -> None:
+            captured["served"] = True
+
+    monkeypatch.delenv("SLACK_POC_HTTP_HOST", raising=False)
+    monkeypatch.setattr(worker_module.uvicorn, "Server", FakeServer)
+
+    await worker_module.run_http_server(
+        SlackPoCConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            signing_secret="test-secret",
+            bot_user_id="UBOT",
+        )
+    )
+
+    assert captured == {"host": worker_module.SLACK_POC_HTTP_DEFAULT_HOST, "served": True}
+
+
+@pytest.mark.asyncio
 async def test_slack_upload_file_uses_form_encoded_external_upload_flow() -> None:
     calls: list[httpx.Request] = []
 

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -15,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from gateway.db.models import SlackInstallation, SlackInstallationConfig
 from gateway.slack_poc import worker as worker_module
+from gateway.slack_poc.progress import COMPLETING_PROGRESS_TEXT, INITIAL_PROGRESS_TEXT
 from gateway.slack_poc.worker import (
     SlackApiClient,
     SlackPoCConfig,
@@ -127,6 +129,57 @@ async def test_slack_read_methods_use_form_encoded_payloads() -> None:
         await slack.aclose()
 
 
+@pytest.mark.asyncio
+async def test_slack_update_message_uses_chat_update() -> None:
+    calls: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path.endswith("/chat.update"):
+            body = json.loads(request.content.decode("utf-8"))
+            assert body["channel"] == "C1"
+            assert body["ts"] == "2.0"
+            assert body["text"] == "Querying database..."
+            assert body["mrkdwn"] is True
+            return httpx.Response(200, json={"ok": True})
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    slack = SlackApiClient("xoxb-test", "xapp-test", http_client=client)
+    try:
+        await slack.update_message(channel="C1", ts="2.0", text="Querying database...")
+    finally:
+        await slack.aclose()
+
+    assert [call.url.path for call in calls] == ["/api/chat.update"]
+
+
+@pytest.mark.asyncio
+async def test_slack_reactions_use_reactions_api_and_ignore_duplicate_remove_absence() -> None:
+    calls: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        body = json.loads(request.content.decode("utf-8"))
+        if request.url.path.endswith("/reactions.add"):
+            assert body == {"channel": "C1", "timestamp": "1.0", "name": "eyes"}
+            return httpx.Response(200, json={"ok": False, "error": "already_reacted"})
+        if request.url.path.endswith("/reactions.remove"):
+            assert body == {"channel": "C1", "timestamp": "1.0", "name": "eyes"}
+            return httpx.Response(200, json={"ok": False, "error": "no_reaction"})
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    slack = SlackApiClient("xoxb-test", "xapp-test", http_client=client)
+    try:
+        await slack.add_reaction(channel="C1", timestamp="1.0", name="eyes")
+        await slack.remove_reaction(channel="C1", timestamp="1.0", name="eyes")
+    finally:
+        await slack.aclose()
+
+    assert [call.url.path for call in calls] == ["/api/reactions.add", "/api/reactions.remove"]
+
+
 def test_cloud_mode_does_not_apply_local_notebook_direct_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
     monkeypatch.delenv("SP_NOTEBOOK_DIRECT_URL", raising=False)
@@ -167,6 +220,8 @@ async def test_worker_uses_notion_installation_user_when_user_id_unset(monkeypat
 @pytest.mark.asyncio
 async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypatch: pytest.MonkeyPatch) -> None:
     events: list[str] = []
+    progress_seen = asyncio.Event()
+    slack_events: list[tuple[str, str]] = []
 
     class SessionContext:
         async def __aenter__(self):
@@ -227,6 +282,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     async def poll_analysis(*args, **kwargs):
         events.append("poll")
         assert events.index("db_exit") < events.index("start")
+        await asyncio.wait_for(progress_seen.wait(), timeout=1)
         return {"status": "Done", "notionComment": "Done", "confidenceScore": 1.0}
 
     monkeypatch.setattr(worker_module.notebook_analysis, "resolve_analysis_route_for_defaults", resolve_route)
@@ -240,6 +296,21 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
 
     slack = AsyncMock(spec=SlackApiClient)
     slack.thread_messages.return_value = []
+    slack.add_reaction.return_value = None
+    slack.remove_reaction.return_value = None
+
+    async def post_message(**kwargs):
+        text = kwargs["text"]
+        slack_events.append(("post", text))
+        if text == INITIAL_PROGRESS_TEXT:
+            return "progress-ts"
+        return f"ts-{len(slack_events)}"
+
+    async def update_message(**kwargs):
+        slack_events.append(("update", kwargs["text"]))
+
+    slack.post_message.side_effect = post_message
+    slack.update_message.side_effect = update_message
     worker = SlackPoCWorker(
         SlackPoCConfig(
             bot_token="xoxb-test",
@@ -258,6 +329,18 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
         return {"requestId": "req-1", "trailUrl": "https://app.test/notebook/session-1"}
 
     monkeypatch.setattr(worker, "_start_analysis", start_analysis)
+
+    async def run_progress_reporter(*, stop_event, thread_id, source_prompt, channel_id, message_ts, user_id):
+        assert thread_id == "session-slack-req-1"
+        assert source_prompt == "analyze revenue"
+        assert channel_id == "C1"
+        assert message_ts == "progress-ts"
+        assert user_id == "user-1"
+        await slack.update_message(channel=channel_id, ts=message_ts, text="Querying database...")
+        progress_seen.set()
+        await stop_event.wait()
+
+    monkeypatch.setattr(worker, "_run_progress_reporter", run_progress_reporter)
 
     await worker._process_request(
         SlackRequest(
@@ -287,7 +370,15 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
         "update",
         "db_exit",
     ]
-    assert slack.post_message.await_count == 2
+    assert slack_events[0] == ("post", INITIAL_PROGRESS_TEXT)
+    assert ("update", "Querying database...") in slack_events[1:]
+    assert ("update", COMPLETING_PROGRESS_TEXT) in slack_events[1:]
+    assert slack_events[-1][0] == "update"
+    assert "*SignalPilot analysis complete*" in slack_events[-1][1]
+    assert slack.post_message.await_count == 1
+    slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
+    slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="white_check_mark")
+    slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
 
 
 @pytest.mark.asyncio

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -5,6 +5,7 @@ import hmac
 import json
 import os
 import time
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 from urllib.parse import parse_qs
 
@@ -12,6 +13,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from gateway.db.models import SlackInstallation, SlackInstallationConfig
 from gateway.slack_poc import worker as worker_module
 from gateway.slack_poc.worker import (
     SlackApiClient,
@@ -392,6 +394,160 @@ def test_http_events_rejects_invalid_signature() -> None:
         )
 
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_self_serve_dispatch_uses_stored_installation(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(UTC)
+    install = SlackInstallation(
+        id="slack-install-1",
+        org_id="org-1",
+        user_id="user-1",
+        team_id="T1",
+        team_name="Demo",
+        app_id="A1",
+        bot_user_id="UBOT",
+        bot_access_token_enc=b"encrypted",
+        scopes=["app_mentions:read", "chat:write"],
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+    config = SlackInstallationConfig(
+        installation_id="slack-install-1",
+        enabled=True,
+        default_project_id="project-1",
+        default_branch="main",
+        analysis_branch_mode="per_request",
+        allowed_channel_ids=["C1"],
+    )
+    captured: list[SlackPoCConfig] = []
+
+    class Factory:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def records(_db, team_id: str):
+        assert team_id == "T1"
+        return [(install, config, "installed-bot-token")]
+
+    async def handle(self, payload):
+        captured.append(self.config)
+        assert payload["event"]["text"] == "<@UBOT> analyze revenue"
+
+    async def drain(self):
+        return None
+
+    monkeypatch.setattr(worker_module, "get_session_factory", lambda: Factory())
+    monkeypatch.setattr(worker_module.slack_store, "list_active_installation_records_for_team", records)
+    monkeypatch.setattr(SlackPoCWorker, "handle_events_api_payload", handle)
+    monkeypatch.setattr(SlackPoCWorker, "drain", drain)
+
+    await worker_module._dispatch_self_serve_payload(
+        {
+            "event_id": "Ev1",
+            "team_id": "T1",
+            "event": {
+                "type": "app_mention",
+                "team": "T1",
+                "channel": "C1",
+                "user": "U1",
+                "text": "<@UBOT> analyze revenue",
+                "ts": "1.0",
+            },
+        },
+        SlackPoCConfig(signing_secret="secret", ack_text="I'm on it."),
+    )
+
+    assert len(captured) == 1
+    assert captured[0].bot_token == "installed-bot-token"
+    assert captured[0].org_id == "org-1"
+    assert captured[0].user_id == "user-1"
+    assert captured[0].bot_user_id == "UBOT"
+    assert captured[0].default_project_id == "project-1"
+    assert captured[0].allowed_channel_ids == frozenset({"C1"})
+
+
+@pytest.mark.asyncio
+async def test_self_serve_dispatch_rejects_ambiguous_installations(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(UTC)
+    install_1 = SlackInstallation(
+        id="slack-install-1",
+        org_id="org-1",
+        user_id="user-1",
+        team_id="T1",
+        app_id="A1",
+        bot_user_id="UBOT1",
+        bot_access_token_enc=b"encrypted",
+        scopes=[],
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+    install_2 = SlackInstallation(
+        id="slack-install-2",
+        org_id="org-2",
+        user_id="user-2",
+        team_id="T1",
+        app_id="A1",
+        bot_user_id="UBOT2",
+        bot_access_token_enc=b"encrypted",
+        scopes=[],
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+    config = SlackInstallationConfig(
+        installation_id="slack-install-1",
+        enabled=True,
+        default_project_id="project-1",
+        default_branch="main",
+        analysis_branch_mode="per_request",
+        allowed_channel_ids=[],
+    )
+
+    class Factory:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def records(_db, team_id: str):
+        assert team_id == "T1"
+        return [(install_1, config, "bot-token-1"), (install_2, config, "bot-token-2")]
+
+    async def fail_handle(self, payload):
+        raise AssertionError("ambiguous install should not dispatch")
+
+    monkeypatch.setattr(worker_module, "get_session_factory", lambda: Factory())
+    monkeypatch.setattr(worker_module.slack_store, "list_active_installation_records_for_team", records)
+    monkeypatch.setattr(SlackPoCWorker, "handle_events_api_payload", fail_handle)
+
+    await worker_module._dispatch_self_serve_payload(
+        {
+            "event_id": "Ev1",
+            "team_id": "T1",
+            "event": {
+                "type": "app_mention",
+                "team": "T1",
+                "channel": "C1",
+                "user": "U1",
+                "text": "<@UBOT> analyze revenue",
+                "ts": "1.0",
+            },
+        },
+        SlackPoCConfig(signing_secret="secret"),
+    )
 
 
 @pytest.mark.asyncio

--- a/signalpilot/notebook-server/signalpilot/_client/agent.py
+++ b/signalpilot/notebook-server/signalpilot/_client/agent.py
@@ -3,7 +3,7 @@
 Usage:
     import signalpilot as sp
 
-    agent = sp.agent(model="claude-sonnet-4-20250514")
+    agent = sp.agent(model="claude-sonnet-4-5-20250929")
 
     # Synchronous — blocks until the agent finishes
     response = agent.run("Analyze the sales data")
@@ -62,7 +62,7 @@ class AgentClient:
     def __init__(
         self,
         server_url: str = "http://localhost:2718",
-        model: str = "claude-sonnet-4-20250514",
+        model: str = "claude-sonnet-4-5-20250929",
         system_prompt: str | None = None,
     ) -> None:
         self._server_url = server_url.rstrip("/")
@@ -277,7 +277,7 @@ class AgentClient:
 
 
 def agent(
-    model: str = "claude-sonnet-4-20250514",
+    model: str = "claude-sonnet-4-5-20250929",
     server_url: str = "http://localhost:2718",
     system_prompt: str | None = None,
 ) -> AgentClient:

--- a/signalpilot/notebook-server/signalpilot/_server/ai/agent_manager.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/agent_manager.py
@@ -39,7 +39,7 @@ class AgentInstance:
     status: str = "idle"  # idle, running, stopped, error
     created_at: float = 0.0
     message_count: int = 0
-    model: str = "claude-sonnet-4-20250514"
+    model: str = "claude-sonnet-4-5-20250929"
     system_prompt: str = ""
     event_buffer: list[dict[str, Any]] = field(default_factory=list)
     last_error: str | None = None
@@ -55,7 +55,7 @@ class AgentManager:
         self,
         *,
         session_id: str | None = None,
-        model: str = "claude-sonnet-4-20250514",
+        model: str = "claude-sonnet-4-5-20250929",
         system_prompt: str | None = None,
     ) -> AgentInstance:
         """Create a new agent instance."""

--- a/signalpilot/notebook-server/signalpilot/_server/ai/analysis_prompts.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/analysis_prompts.py
@@ -90,10 +90,15 @@ Required workflow:
 2. Do the actual analysis in notebook cells with the SignalPilot notebook SDK:
    initialize the SDK, select the governed connection, discover the data, run
    queries, perform calculations, and record evidence/results in the notebook.
-   Every SDK setup cell that uses governed data access must initialize first,
-   in this order: `import signalpilot as sp`, `sp.init()`, `sp.connections()`,
-   then `sp.connect("connection_name")`. Markdown-only `sp.md(...)` cells do
-   not require `sp.init()`.
+   Define `sp` in exactly one notebook cell. The seeded notebook defines `sp` in
+   the first hidden request-context cell; later cells must receive `sp` through
+   marimo dependencies and must not repeat `import signalpilot as sp`.
+   In marimo, imported aliases are notebook definitions, so repeating that import
+   across cells causes `MultipleDefinitionError`. If no existing cell defines
+   `sp`, import it once, then initialize governed data access in this order:
+   `sp.init()`, `sp.connections()`, then `sp.connect("connection_name")`.
+   Markdown-only `sp.md(...)` cells do not require `sp.init()` and must not
+   re-import `sp`.
    Use the public notebook SDK helpers that exist in the runtime, especially
    `sp.init()`, `sp.connections()`, `sp.connect("connection_name")`, and
    `db.query("SELECT ...")` (or `sp.query("SELECT ...", connection_name=...)`).
@@ -195,10 +200,13 @@ Required workflow:
    instead of duplicating it all in the summary.
 
 Completion checklist before final JSON:
-- The live notebook contains an SDK setup cell for governed data access with
-  this exact order: `import signalpilot as sp`, `sp.init()`, `sp.connections()`,
-  then `sp.connect("...")`. Markdown-only `sp.md(...)` cells may appear before
-  this and do not require SDK initialization.
+- The live notebook defines `sp` in exactly one notebook cell. It must not repeat
+  `import signalpilot as sp`; later cells should receive `sp` through marimo
+  dependencies.
+- The live notebook contains an SDK setup cell for governed data access using
+  `sp.init()`, `sp.connections()`, then `sp.connect("...")`. Markdown-only
+  `sp.md(...)` cells may appear before this and do not require SDK
+  initialization.
 - The live notebook contains governed query cells that call `db.query(...)` or
   `sp.query(...)` for the actual source data used in the answer.
 - Every material finding in the summary has a nearby "Analysis steps" branch

--- a/signalpilot/notebook-server/signalpilot/_server/ai/analysis_prompts.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/analysis_prompts.py
@@ -179,22 +179,26 @@ Required workflow:
      `print("rows", len(q1_gbp_revenue_df)); print("date range",
      q1_gbp_revenue_df["created_at"].min(),
      q1_gbp_revenue_df["created_at"].max())`
-4. Add charts when the question involves comparison, ranking, trend,
-   distribution, or contribution analysis. Build charts from notebook-computed
-   DataFrames only, never from hand-entered MCP output. Prefer 1-3 focused
-   charts that make the answer easier to audit, such as a ranked bar chart,
-   trend line, scatter/bubble comparison, or contribution waterfall. Give each
-   chart a clear title, axis labels, and one-sentence interpretation in the
-   notebook. If a chart is useful outside the notebook, save or expose it as a
-   shareable PNG/SVG/HTML artifact. For matplotlib charts, save the figure and
-   render it in the notebook by leaving the chart object or `sp.image(src=...)`
-   as the cell's final expression. Do not end chart cells with `plt.show()` or
-   `print(...)`; printed "Chart saved" messages are feedback only and should
-   not replace the visible chart output. The gateway will harvest useful
-   notebook chart outputs for Slack and Notion; do not return channel chart
-   JSON.
-5. Keep chart selection in the notebook itself. If no chart adds value, state
-   why briefly in the notebook caveats or FINAL_STATEMENT handoffNotes.
+4. Produce charts for every completed Slack/Notion data-analysis request when
+   governed source data can be queried. Build charts from notebook-computed
+   DataFrames only, never from hand-entered MCP output. The notebook must expose
+   at least two visible chart outputs for Notion page content whenever the data
+   supports two different useful views; the first chart must also be suitable
+   for the Slack/Notion comment thread. Good defaults are a ranked bar chart
+   plus a trend, distribution, contribution, or dimension-breakdown chart. Give
+   each chart a clear title, axis labels, and one-sentence interpretation in the
+   notebook. If only one chart is defensible, create that one and state why a
+   second would be misleading in the notebook caveats and FINAL_STATEMENT
+   handoffNotes. If no chart can be generated because the request is genuinely
+   non-visual or the data is unavailable, state that as a caveat. For matplotlib
+   charts, save the figure and render it in the notebook by leaving the chart
+   object or `sp.image(src=...)` as the cell's final expression. Do not end chart
+   cells with `plt.show()` or `print(...)`; printed "Chart saved" messages are
+   feedback only and should not replace the visible chart output. The gateway
+   will harvest useful notebook chart outputs for Slack and Notion; do not
+   return channel chart JSON.
+5. Keep chart selection in the notebook itself. Do not finish a completed
+   tabular-data analysis with only prose or tables when charts can be made.
 6. Run the relevant notebook cells in the live session before answering. If a
    cell cannot be run, state that and explain the residual risk in the notebook
    and in FINAL_STATEMENT caveats/handoffNotes.
@@ -231,11 +235,14 @@ Completion checklist before FINAL_STATEMENT:
   In marimo, loop variables such as `row`, `i`, `fig`, or `ax` are notebook
   globals and can trigger MultipleDefinitionError if reused. Use unique names
   per cell or wrap chart-building logic in uniquely named functions.
-- The notebook contains chart cells for comparison/ranking/trend-style
-  requests, unless the request is genuinely non-visual or charting would be
-  misleading. Charts are generated from notebook-computed DataFrames, saved as
-  artifacts when useful for Notion, and rendered as visible notebook outputs
-  instead of ending with `print(...)` feedback.
+- The notebook contains chart cells for completed Slack/Notion data-analysis
+  requests when governed source data can be queried. Aim for two visible,
+  harvestable chart outputs so Notion can render two page charts; include at
+  least one chart unless the request is genuinely non-visual, data is
+  unavailable, or charting would be misleading. Charts are generated from
+  notebook-computed DataFrames, saved as artifacts when useful for Notion, and
+  rendered as visible notebook outputs instead of ending with `print(...)`
+  feedback.
 - FINAL_STATEMENT handoffNotes state that the result came from
   notebook-executed SDK cells, not MCP query outputs.
 - The top of the notebook remains readable: request context, executive summary

--- a/signalpilot/notebook-server/signalpilot/_server/ai/analysis_prompts.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/analysis_prompts.py
@@ -37,31 +37,41 @@ Notebook context:
 - Trail URL: {record.trail_url}
 
 Open and edit the live notebook session above. The notebook must contain the
-real analysis trail before you return the final JSON.
+real analysis trail before you return FINAL_STATEMENT.
 
 Live-session rule:
 - You MUST edit the notebook through the live notebook MCP tools
   (`mcp__signalpilot-notebook__edit_notebook` / `edit_notebook`) using
   Session ID `{record.session_id}`. Confirm the edit tool reports
-  `"persisted": true`; if not, stop and return JSON describing that failure.
+  `"persisted": true`; if not, stop and emit FINAL_STATEMENT describing that
+  failure.
 - You MUST run the changed cells through the live notebook MCP run tool
   (`mcp__signalpilot-notebook__run_cells` / `run_cells`) before
   answering. Confirm the run tool reports `"status": "success"` and an empty
-  `errorCellIds` list; if not, stop and return JSON describing the notebook run
-  failure.
+  `errorCellIds` list; if not, stop and emit FINAL_STATEMENT describing the
+  notebook run failure.
 - You MUST NOT use Claude Code file-writing tools such as Write, Edit,
   MultiEdit, or Bash to modify `{record.notebook_path}`. Direct file writes
   create a stale browser/kernel session and are considered a failed analysis
   workflow.
-- If live notebook edit or run tools are unavailable, stop and return JSON with
-  status details in gotchas/analysisMethod instead of writing the notebook file
-  directly.
+- If live notebook edit or run tools are unavailable, stop and emit
+  FINAL_STATEMENT with status details in caveats/handoffNotes instead of
+  writing the notebook file directly.
 
 Progress update rule:
 - Before the first tool batch and before each major phase, emit one short
   user-visible text update explaining what you are checking and why. Cover
   scouting, notebook editing, cell execution, error fixes, and final
   verification.
+- Once you have enough context to choose the work sequence, emit exactly one
+  parseable plan line:
+  `PLAN: {{ "steps": ["..."] }}`
+- As work advances, emit parseable progress lines tied to that plan:
+  `PROGRESS: {{ "currentStep": "...", "completedSteps": ["..."], "status": "..." }}`
+  Use the exact step strings from PLAN in currentStep and completedSteps.
+  The `status` value must be a short user-readable phrase such as
+  `"querying portfolio tables"` or `"building charts"`. Never use raw machine
+  status enums such as `"in_progress"`, `"running"`, `"done"`, or `"failed"`.
 - After a tool result changes the plan or finds an error, briefly state what
   changed and what you will do next.
 - Keep updates concise and practical. Do not expose private reasoning or list
@@ -104,8 +114,8 @@ Required workflow:
    `db.query("SELECT ...")` (or `sp.query("SELECT ...", connection_name=...)`).
    Do not pass unsupported keyword arguments such as `connection=` to
    `sp.sql(...)`. If a live governed connection cannot be established in the
-   kernel, stop and return JSON describing the notebook run failure instead of
-   silently replacing the analysis with chat-only MCP results.
+   kernel, stop and emit FINAL_STATEMENT describing the notebook run failure
+   instead of silently replacing the analysis with chat-only MCP results.
    Never paste MCP query results or hand-entered sample rows into
    `pd.DataFrame({{...}})` as the source of truth. DataFrames are fine only when
    they are built from notebook-executed SDK calls, for example
@@ -176,30 +186,28 @@ Required workflow:
    trend line, scatter/bubble comparison, or contribution waterfall. Give each
    chart a clear title, axis labels, and one-sentence interpretation in the
    notebook. If a chart is useful outside the notebook, save or expose it as a
-   shareable PNG/SVG/HTML artifact and include its absolute or trail-relative
-   URL in `notionCharts`. For matplotlib charts, save the figure and render it
-   in the notebook by leaving the chart object or `sp.image(src=...)` as the
-   cell's final expression. Do not end chart cells with `plt.show()` or
+   shareable PNG/SVG/HTML artifact. For matplotlib charts, save the figure and
+   render it in the notebook by leaving the chart object or `sp.image(src=...)`
+   as the cell's final expression. Do not end chart cells with `plt.show()` or
    `print(...)`; printed "Chart saved" messages are feedback only and should
-   not replace the visible chart output.
-5. Select at most two charts for Notion when they materially clarify the
-   answer. Use `includeInComment: true` only for charts that fit the concise
-   thread answer, and `includeOnPage: true` for charts that should be embedded
-   on the request page. If no chart adds value, return `notionCharts: []` and
-   explain why briefly in analysisMethod or gotchas.
+   not replace the visible chart output. The gateway will harvest useful
+   notebook chart outputs for Slack and Notion; do not return channel chart
+   JSON.
+5. Keep chart selection in the notebook itself. If no chart adds value, state
+   why briefly in the notebook caveats or FINAL_STATEMENT handoffNotes.
 6. Run the relevant notebook cells in the live session before answering. If a
    cell cannot be run, state that and explain the residual risk in the notebook
-   and in the JSON gotchas/analysisMethod fields.
+   and in FINAL_STATEMENT caveats/handoffNotes.
 7. Do not base the final answer only on chat-only MCP calls. MCP findings may
    guide where to look, but durable queries, calculations, evidence, and the
    answer must live in the notebook.
-8. Before returning JSON, update the notebook's "Executive Summary and
-   Explorations" cell with the finalAnswer content, the gotchas/caveats
+8. Before emitting FINAL_STATEMENT, update the notebook's "Executive Summary
+   and Explorations" cell with the final answer summary, the gotchas/caveats
    bullets, and the confidence score/methodology rationale. Keep the exact
    heading text. Keep detailed query trace in the "Analysis steps" branch cells
    instead of duplicating it all in the summary.
 
-Completion checklist before final JSON:
+Completion checklist before FINAL_STATEMENT:
 - The live notebook defines `sp` in exactly one notebook cell. It must not repeat
   `import signalpilot as sp`; later cells should receive `sp` through marimo
   dependencies.
@@ -228,7 +236,7 @@ Completion checklist before final JSON:
   misleading. Charts are generated from notebook-computed DataFrames, saved as
   artifacts when useful for Notion, and rendered as visible notebook outputs
   instead of ending with `print(...)` feedback.
-- The final JSON's analysisMethod states that the result came from
+- FINAL_STATEMENT handoffNotes state that the result came from
   notebook-executed SDK cells, not MCP query outputs.
 - The top of the notebook remains readable: request context, executive summary
   with caveats, then analysis branches. Queries must not be buried after a long
@@ -246,94 +254,25 @@ Source URL:
 Previous discussion messages:
 {previous or "- None"}
 
-When the analysis is complete, your final assistant message must be only valid
-JSON with this exact shape. Treat notionComment and finalAnswer as different
-audiences:
-- If you cannot complete the analysis, still return this JSON shape. Put the
-  failure details, attempted steps, and next debugging action in finalAnswer,
-  notionComment, gotchas, and analysisMethod. Do not return plain text.
-- notionComment is the level-1 answer for the original Notion comment thread.
-  It should directly answer the user's question in 3-6 concise bullets. Do not
-  explain the full methodology there. Do not use Markdown headings or tables in
-  notionComment. If one or two chart links are useful, mention them naturally
-  or rely on `notionCharts` instead of pasting large chart data into the
-  comment.
-- finalAnswer is the more detailed answer persisted to the Notion request row
-  page. It must use this Markdown hierarchy exactly:
+When the analysis is complete, your final assistant message must be
+user-friendly and audit-ready for the notebook chat thread:
+- Start with a concise bullet-point answer in normal user language.
+- Include confidence and the most important caveats as readable bullets.
+- Emit exactly one parseable FINAL_STATEMENT control-only line for the gateway
+  orchestrator after the user-facing bullets. This line is extracted and
+  removed from stored/displayed trace content; do not introduce it, describe it,
+  or treat it as part of the user-visible answer:
+`FINAL_STATEMENT: {{ "statement": "...", "confidenceScore": 0.0, "caveats": ["..."], "handoffNotes": ["..."] }}`
 
-  ## Executive Summary and Explorations
-
-  - Short executive answer bullets.
-  - Include gotchas/caveats as explicit bullets that name assumptions,
-    exclusions/not-included items, known gaps, and sensitivity risks.
-  - Include a short list of analysis steps actually run, but do not repeat
-    metadata already stored in request row properties such as notebook path,
-    session id, trail URL, request URL, or connection name unless it is essential
-    evidence.
-
-  ## Detailed Research
-
-  Full detailed research, calculations, evidence, comparisons, and reasoning.
-
-  ## Confidence Score: X
-
-  Confidence methodology/rationale as bullets, including source data, filters,
-  validation checks that passed, residual assumptions, and what could lower or
-  raise the score.
-
-  The Notion worker will render Detailed Research and Confidence Score as
-  accordions, so do not write "accordion" or implementation notes in the text.
-- notionCharts is optional, but include it whenever the notebook produced
-  shareable chart artifacts that should appear in Notion. Provide at most two
-  charts. URLs must be absolute or trail-relative and should point to durable
-  artifacts produced by notebook cells, not temporary local-only paths.
-- analysisMethod explains how you reached the answer and why the confidence is
-  justified. Keep it brief and avoid repeating notebook path, session id, trail
-  URL, request URL, or connection metadata already present on the row.
-{{
-  "summary": "short Notion-table summary",
-  "confidenceScore": 0.0,
-  "finalAnswer": "Markdown using the exact requested hierarchy",
-  "gotchas": ["hidden assumptions, gaps, or caveats"],
-  "analysisMethod": "brief non-redundant method and confidence rationale",
-  "notionComment": "3-6 concise bullets for the original Notion thread, under 1200 characters",
-  "notionCharts": [
-    {{
-      "title": "short chart title",
-      "url": "https://... or /files/...",
-      "caption": "one-sentence interpretation",
-      "altText": "accessible description",
-      "includeInComment": true,
-      "includeOnPage": true
-    }}
-  ]
-}}
-"""
-
-
-def json_repair_prompt(user_prompt: str, transcript: str) -> str:
-    transcript_excerpt = transcript.strip()[-12000:]
-    return f"""
-Your previous Notion analysis response did not end with valid JSON.
-
-Do not call tools. Do not continue the analysis. Convert the completed work and
-visible transcript below into one valid JSON object only. If the analysis was
-blocked or incomplete, still return the JSON shape and describe the failure.
-
-Original user request:
-{user_prompt}
-
-Previous transcript excerpt:
-{transcript_excerpt}
-
-Return only this JSON shape:
-{{
-  "summary": "short Notion-table summary",
-  "confidenceScore": 0.0,
-  "finalAnswer": "Markdown using Executive Summary and Explorations, Detailed Research, and Confidence Score sections",
-  "gotchas": ["hidden assumptions, gaps, or caveats"],
-  "analysisMethod": "brief method and confidence rationale",
-  "notionComment": "3-6 concise bullets for the original Notion thread, under 1200 characters",
-  "notionCharts": []
-}}
+- statement is the same compact answer to the user's request, grounded in the
+  notebook-executed evidence. Keep it user-facing: short sentences or bullet-like
+  clauses, not a dense paragraph.
+- confidenceScore is a number from 0.0 to 1.0.
+- caveats name assumptions, exclusions/not-included items, known gaps, and
+  sensitivity risks.
+- handoffNotes summarize the method, source data, filters, validation checks,
+  and any next debugging action if the analysis was incomplete.
+- Do not include slackMessage, notionComment, finalAnswer, notionCharts, or any
+  other channel delivery fields. The gateway orchestrator owns Slack and Notion
+  rendering.
 """

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py
@@ -25,7 +25,7 @@ router = APIRouter()
 
 
 class CreateAgentRequest(msgspec.Struct, rename="camel"):
-    model: str = "claude-sonnet-4-20250514"
+    model: str = "claude-sonnet-4-5-20250929"
     system_prompt: str | None = None
     session_id: str | None = None
 

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/chat.py
@@ -153,6 +153,8 @@ def _assistant_trace_message(
     content = payload.get("content")
     final_json: str | None = None
     if isinstance(content, str):
+        content = _friendly_trace_control_content(content)
+        payload = {**payload, "content": content}
         final_json = _extract_final_json_content(content)
         if final_json is not None:
             payload = {**payload, "content": final_json}
@@ -175,6 +177,149 @@ def _assistant_trace_message(
         "metadata_json": None,
         "created_at": created_at,
     }
+
+
+def _friendly_trace_control_content(content: str) -> str:
+    final_statement = _extract_marker_payload(content, "FINAL_STATEMENT")
+    if final_statement is not None:
+        return _format_final_statement_for_chat(final_statement)
+    return _replace_plan_progress_markers(content)
+
+
+def _extract_marker_payload(content: str, marker: str) -> dict[str, Any] | None:
+    decoder = json.JSONDecoder()
+    for match in re.finditer(rf"(?m)^\s*{marker}\s*:\s*", content):
+        remainder = content[match.end() :]
+        stripped = remainder.lstrip()
+        try:
+            parsed, _ = decoder.raw_decode(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _replace_plan_progress_markers(content: str) -> str:
+    decoder = json.JSONDecoder()
+    replacements: list[tuple[int, int, str]] = []
+    for match in re.finditer(r"(?m)^\s*(PLAN|PROGRESS)\s*:\s*", content):
+        marker = match.group(1)
+        remainder = content[match.end() :]
+        stripped = remainder.lstrip()
+        offset = len(remainder) - len(stripped)
+        try:
+            parsed, end = decoder.raw_decode(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        replacement = (
+            _format_plan_for_chat(parsed)
+            if marker == "PLAN"
+            else _format_progress_for_chat(parsed)
+        )
+        replacements.append((match.start(), match.end() + offset + end, replacement))
+    for start, end, replacement in reversed(replacements):
+        content = f"{content[:start]}{replacement}{content[end:]}"
+    return re.sub(r"\n{3,}", "\n\n", content).strip()
+
+
+def _format_plan_for_chat(payload: dict[str, Any]) -> str:
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        return "Plan updated."
+    bullets = [_clean_bullet_text(step) for step in steps]
+    bullets = [step for step in bullets if step]
+    if not bullets:
+        return "Plan updated."
+    return "Plan:\n" + "\n".join(f"- {step}" for step in bullets)
+
+
+def _format_progress_for_chat(payload: dict[str, Any]) -> str:
+    current = _clean_bullet_text(
+        payload.get("currentStep") or payload.get("current_step") or ""
+    )
+    status = _clean_bullet_text(payload.get("status") or "")
+    completed_raw = payload.get("completedSteps", payload.get("completed_steps", []))
+    completed = (
+        [_clean_bullet_text(step) for step in completed_raw]
+        if isinstance(completed_raw, list)
+        else []
+    )
+    completed = [step for step in completed if step]
+    lines = ["Progress:"]
+    if current:
+        lines.append(f"- Current: {current}")
+    if status:
+        lines.append(f"- Status: {status}")
+    if completed:
+        lines.append("- Completed: " + ", ".join(completed))
+    return "\n".join(lines)
+
+
+def _format_final_statement_for_chat(payload: dict[str, Any]) -> str:
+    statement = _clean_bullet_text(payload.get("statement") or "")
+    caveats_raw = payload.get("caveats", [])
+    notes_raw = payload.get("handoffNotes", payload.get("handoff_notes", []))
+    caveats = (
+        [_clean_bullet_text(item) for item in caveats_raw]
+        if isinstance(caveats_raw, list)
+        else []
+    )
+    notes = (
+        [_clean_bullet_text(item) for item in notes_raw]
+        if isinstance(notes_raw, list)
+        else []
+    )
+    caveats = [item for item in caveats if item]
+    notes = [item for item in notes if item]
+
+    lines = ["Analysis complete."]
+    answer_bullets = _bulletize_text(statement)
+    if answer_bullets:
+        lines.extend(["", "Findings:", *[f"- {item}" for item in answer_bullets]])
+    confidence = _format_confidence(payload.get("confidenceScore", payload.get("confidence_score")))
+    if confidence:
+        lines.extend(["", f"Confidence: {confidence}"])
+    if caveats:
+        lines.extend(["", "Gotchas / caveats:", *[f"- {item}" for item in caveats[:8]]])
+    if notes:
+        lines.extend(["", "Method:", *[f"- {item}" for item in notes[:6]]])
+    return "\n".join(lines)
+
+
+def _bulletize_text(content: str, max_bullets: int = 6) -> list[str]:
+    stripped = content.strip()
+    if not stripped:
+        return []
+    bullets: list[str] = []
+    for line in stripped.splitlines():
+        cleaned = _clean_bullet_text(line)
+        if cleaned:
+            bullets.append(cleaned)
+    if len(bullets) <= 1:
+        bullets = [_clean_bullet_text(part) for part in re.split(r"(?<=[.!?])\s+", stripped)]
+    unique = [bullet for index, bullet in enumerate(bullets) if bullet and bullets.index(bullet) == index]
+    return unique[:max_bullets]
+
+
+def _clean_bullet_text(value: Any) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"^#{1,6}\s+", "", text)
+    text = re.sub(r"^[-*]\s+", "", text)
+    text = re.sub(r"^\d+[.)]\s+", "", text)
+    return text.strip()
+
+
+def _format_confidence(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return str(value).strip()
+    return f"{numeric:.2f}".rstrip("0").rstrip(".")
 
 
 def _extract_final_json_content(content: str) -> str | None:

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
@@ -15,12 +15,11 @@ from dataclasses import asdict, dataclass
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
-from urllib.error import HTTPError, URLError
 from urllib.parse import quote, unquote, unquote_to_bytes, urlencode, urlparse
-from urllib.request import Request as UrlRequest, urlopen
 from uuid import NAMESPACE_URL, uuid5
 
 import msgspec
+import requests
 from starlette.exceptions import HTTPException
 from starlette.responses import FileResponse, JSONResponse
 
@@ -192,7 +191,6 @@ def _gateway_json_get(
 ) -> Any:
     from signalpilot._server.gateway_client import gateway_headers, gateway_url
 
-    headers = {"Accept": "application/json", **gateway_headers()}
     url = f"{gateway_url()}{path}"
     if params:
         query = urlencode(
@@ -200,18 +198,27 @@ def _gateway_json_get(
         )
         if query:
             url = f"{url}?{query}"
-    request = UrlRequest(url, headers=headers, method="GET")
+    _validate_gateway_json_url(url)
+    headers = {"Accept": "application/json", **gateway_headers()}
     try:
-        with urlopen(request, timeout=timeout_seconds) as response:
-            body = response.read().decode("utf-8", errors="replace")
-    except HTTPError as e:
-        body = e.read().decode("utf-8", errors="replace")[:500]
-        raise RuntimeError(f"Gateway HTTP {e.code}: {body}") from e
-    except URLError as e:
-        raise RuntimeError(f"Gateway unavailable: {e.reason}") from e
+        response = requests.get(url, headers=headers, timeout=timeout_seconds)
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        body = e.response.text[:500] if e.response is not None else ""
+        status_code = e.response.status_code if e.response is not None else "error"
+        raise RuntimeError(f"Gateway HTTP {status_code}: {body}") from e
+    except requests.RequestException as e:
+        raise RuntimeError(f"Gateway unavailable: {e}") from e
+    body = response.text
     if not body:
         return None
     return json.loads(body)
+
+
+def _validate_gateway_json_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RuntimeError("Gateway URL must be an absolute http or https URL")
 
 
 def _connection_label(connection: dict[str, Any]) -> str:

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
@@ -621,20 +621,43 @@ def _analysis_source(value: str | None) -> str:
     return source or "notion"
 
 
-def _project_root(app_state: AppState) -> Path:
+def _analysis_project_context(
+    app_state: AppState,
+) -> tuple[str, str] | None:
     request = getattr(app_state, "request", None)
     headers = getattr(request, "headers", {}) or {}
-    project_id = headers.get("x-gateway-project-id")
-    if project_id:
-        branch = headers.get("x-gateway-branch-id", "main").strip() or "main"
+    query_params = getattr(app_state, "query_params", lambda _key: None)
+    project_id = (
+        headers.get("x-gateway-project-id", "")
+        or query_params("project")
+        or ""
+    ).strip()
+    if not project_id:
+        return None
+    branch = (
+        headers.get("x-gateway-branch-id", "")
+        or query_params("branch")
+        or "main"
+    ).strip() or "main"
+    return project_id, branch
+
+
+def _project_root(app_state: AppState) -> Path:
+    context = _analysis_project_context(app_state)
+    if context is not None:
+        project_id, branch = context
         try:
             from signalpilot._server.files.project_sync import (
+                _current_git_branch,
                 local_project_dir,
                 sync_down,
             )
 
             local_dir = local_project_dir(project_id, branch)
-            if (local_dir / ".git").exists():
+            if (
+                (local_dir / ".git").exists()
+                and _current_git_branch(local_dir) == branch
+            ):
                 return local_dir
 
             result = sync_down(project_id, branch)
@@ -862,19 +885,6 @@ def _(sp):
     else:
         text += followup_cell
     path.write_text(text, encoding="utf-8")
-
-
-def _analysis_project_context(app_state: AppState) -> tuple[str, str] | None:
-    project_id = app_state.request.headers.get(
-        "x-gateway-project-id", ""
-    ).strip()
-    if not project_id:
-        return None
-    branch = (
-        app_state.request.headers.get("x-gateway-branch-id", "main").strip()
-        or "main"
-    )
-    return project_id, branch
 
 
 def _checkpoint_analysis_files(
@@ -1244,8 +1254,58 @@ def _chart_dir(app_state: AppState, record: AnalysisRecord) -> Path:
     return chart_dir
 
 
-def _chart_url(record: AnalysisRecord, filename: str) -> str:
-    return f"/api/notion-analysis/chart/{record.request_id}/{filename}"
+def _chart_url(
+    app_state: AppState, record: AnalysisRecord, filename: str
+) -> str:
+    url = f"/api/notion-analysis/chart/{record.request_id}/{filename}"
+    context = _analysis_project_context(app_state)
+    if context is None:
+        return url
+    project_id, branch = context
+    return f"{url}?{urlencode({'project': project_id, 'branch': branch})}"
+
+
+def _chart_file_from_project_registries(
+    request_id: str, filename: str
+) -> Path | None:
+    try:
+        from signalpilot._server.files.project_sync import PROJECTS_ROOT
+    except Exception:
+        return None
+
+    for registry_path in PROJECTS_ROOT.glob(
+        "*/**/notebooks/.signalpilot-analysis-registry.json"
+    ):
+        try:
+            raw = json.loads(registry_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        records = raw.get("records", [])
+        if not isinstance(records, list):
+            continue
+        for item in records:
+            if (
+                not isinstance(item, dict)
+                or item.get("request_id") != request_id
+            ):
+                continue
+            notebook_path = item.get("notebook_path")
+            if not isinstance(notebook_path, str) or not notebook_path:
+                continue
+            repo = registry_path.parent.parent
+            chart_dir = (
+                repo
+                / notebook_path
+            ).parent / "public" / "signalpilot-notion-charts"
+            try:
+                resolved_dir = chart_dir.resolve(strict=True)
+                chart_path = (resolved_dir / filename).resolve(strict=True)
+                chart_path.relative_to(resolved_dir)
+            except (OSError, ValueError):
+                continue
+            if chart_path.is_file():
+                return chart_path
+    return None
 
 
 def _chart_filename_extension(content_type: str) -> str:
@@ -1356,7 +1416,7 @@ def _materialize_existing_chart_artifacts(
         materialized.append(
             AnalysisChart(
                 title=chart.title,
-                url=_chart_url(record, filename),
+                url=_chart_url(app_state, record, filename),
                 caption=chart.caption,
                 alt_text=chart.alt_text,
                 include_in_comment=chart.include_in_comment,
@@ -1505,6 +1565,21 @@ def _image_candidates_from_output_data(
     for mimetype, value in data.items():
         if not isinstance(mimetype, str):
             continue
+        if mimetype == "application/vnd.sp+mimebundle":
+            mimebundle = _load_sp_mimebundle(value)
+            if mimebundle is not None:
+                candidates.extend(
+                    _image_candidates_from_output_data(
+                        app_state,
+                        cell_id,
+                        {
+                            key: item
+                            for key, item in mimebundle.items()
+                            if key != "__metadata__"
+                        },
+                    )
+                )
+            continue
         if mimetype.startswith("image/"):
             if isinstance(value, bytes):
                 candidates.append(
@@ -1553,6 +1628,18 @@ def _image_candidates_from_output_data(
     return candidates
 
 
+def _load_sp_mimebundle(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _safe_chart_cell_id(cell_id: str) -> str:
     cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", cell_id).strip("-")
     return cleaned[:64] or "cell"
@@ -1579,7 +1666,7 @@ def _write_image_chart_artifacts(
             charts.append(
                 AnalysisChart(
                     title=title,
-                    url=_chart_url(record, filename),
+                    url=_chart_url(app_state, record, filename),
                     caption=title,
                     alt_text=title,
                     include_in_comment=True,
@@ -1589,6 +1676,28 @@ def _write_image_chart_artifacts(
             if len(charts) >= 2:
                 return charts
     return charts
+
+
+def _chart_identity(chart: AnalysisChart) -> str:
+    return chart.url.strip() or chart.title.strip()
+
+
+def _merge_chart_lists(
+    *chart_lists: list[AnalysisChart],
+    limit: int = 2,
+) -> list[AnalysisChart]:
+    merged: list[AnalysisChart] = []
+    seen: set[str] = set()
+    for charts in chart_lists:
+        for chart in charts:
+            key = _chart_identity(chart)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            merged.append(chart)
+            if len(merged) >= limit:
+                return merged
+    return merged
 
 
 _PLOTLY_FIGURE_ATTR_RE = re.compile(
@@ -2273,7 +2382,7 @@ def _write_plotly_chart_artifacts(
             charts.append(
                 AnalysisChart(
                     title=title,
-                    url=_chart_url(record, filename),
+                    url=_chart_url(app_state, record, filename),
                     caption=title,
                     alt_text=f"Chart from notebook cell {cell_id}: {title}",
                     include_in_comment=True,
@@ -2436,7 +2545,7 @@ def _write_result_fallback_chart_artifacts(
         charts.append(
             AnalysisChart(
                 title="Operating momentum composite ranking",
-                url=_chart_url(record, filename),
+                url=_chart_url(app_state, record, filename),
                 caption=f"{winner} has the highest composite momentum score.",
                 alt_text=(
                     "Horizontal bar chart ranking companies by composite "
@@ -2489,7 +2598,7 @@ def _write_result_fallback_chart_artifacts(
             charts.append(
                 AnalysisChart(
                     title="Operating momentum dimension breakdown",
-                    url=_chart_url(record, filename),
+                    url=_chart_url(app_state, record, filename),
                     caption=(
                         "Normalized comparison of the component momentum "
                         "dimensions from the final ranking table."
@@ -2512,6 +2621,12 @@ def _html_outputs_from_output_data(
     html_outputs: list[tuple[str, str]] = []
     for cell_id, data in output_data:
         raw_html = data.get("text/html")
+        if isinstance(raw_html, str):
+            html_outputs.append((cell_id, raw_html))
+        mimebundle = _load_sp_mimebundle(data.get("application/vnd.sp+mimebundle"))
+        if mimebundle is None:
+            continue
+        raw_html = mimebundle.get("text/html")
         if isinstance(raw_html, str):
             html_outputs.append((cell_id, raw_html))
     return html_outputs
@@ -2548,12 +2663,11 @@ def _fallback_chart_artifacts_from_session_cache(
             if not isinstance(data, dict):
                 continue
             output_data.append((cell_id, data))
-    charts = _write_plotly_chart_artifacts(
+    plotly_charts = _write_plotly_chart_artifacts(
         app_state, record, _html_outputs_from_output_data(output_data)
     )
-    if charts:
-        return charts
-    return _write_image_chart_artifacts(app_state, record, output_data)
+    image_charts = _write_image_chart_artifacts(app_state, record, output_data)
+    return _merge_chart_lists(plotly_charts, image_charts)
 
 
 def _fallback_chart_artifacts_from_session(
@@ -2572,15 +2686,15 @@ def _fallback_chart_artifacts_from_session(
         if not isinstance(output, CellOutput):
             continue
         output_data.append((str(cell_id), {output.mimetype: output.data}))
-    charts = _write_plotly_chart_artifacts(
+    plotly_charts = _write_plotly_chart_artifacts(
         app_state, record, _html_outputs_from_output_data(output_data)
     )
-    if charts:
+    image_charts = _write_image_chart_artifacts(app_state, record, output_data)
+    charts = _merge_chart_lists(plotly_charts, image_charts)
+    if len(charts) >= 2:
         return charts
-    charts = _write_image_chart_artifacts(app_state, record, output_data)
-    if charts:
-        return charts
-    return _fallback_chart_artifacts_from_session_cache(app_state, record)
+    cache_charts = _fallback_chart_artifacts_from_session_cache(app_state, record)
+    return _merge_chart_lists(charts, cache_charts)
 
 
 def _ensure_notion_chart_artifacts(
@@ -2593,31 +2707,20 @@ def _ensure_notion_chart_artifacts(
         for chart in (record.result.notion_charts or [])
         if chart.url.strip()
     ]
-    materialized = _materialize_existing_chart_artifacts(
-        app_state, record, existing_charts
-    )
-    if materialized:
-        record.result.notion_charts = materialized
-        return
-    generated = _fallback_chart_artifacts_from_session(app_state, record)
-    if generated:
-        record.result.notion_charts = generated
-    else:
-        generated = _write_result_fallback_chart_artifacts(app_state, record)
-        if generated:
-            record.result.notion_charts = generated
-            return
-    if generated:
-        return
-    elif existing_charts:
+    materialized = _materialize_existing_chart_artifacts(app_state, record, existing_charts)
+    session_charts = _fallback_chart_artifacts_from_session(app_state, record)
+    charts = _merge_chart_lists(materialized, session_charts)
+    if len(charts) < 2:
+        result_charts = _write_result_fallback_chart_artifacts(app_state, record)
+        charts = _merge_chart_lists(charts, result_charts)
+    if len(charts) < 2:
         external_charts = [
             chart
             for chart in existing_charts
             if urlparse(chart.url).scheme in {"http", "https"}
         ]
-        record.result.notion_charts = external_charts[:2]
-    else:
-        record.result.notion_charts = []
+        charts = _merge_chart_lists(charts, external_charts)
+    record.result.notion_charts = charts
 
 
 def _persist_record_completion_artifacts(
@@ -3035,18 +3138,22 @@ async def notion_analysis_chart(*, request: Request) -> FileResponse:
     filename = request.path_params["filename"]
     record = _records_by_request_id.get(request_id)
     if record is None:
-        raise HTTPException(
-            status_code=404, detail="Analysis request not found"
+        chart_path = _chart_file_from_project_registries(
+            request_id, filename
         )
-
-    chart_dir = _chart_dir(app_state, record).resolve(strict=True)
-    try:
-        chart_path = (chart_dir / filename).resolve(strict=True)
-        chart_path.relative_to(chart_dir)
-    except (OSError, ValueError):
-        raise HTTPException(
-            status_code=404, detail="Chart not found"
-        ) from None
+        if chart_path is None:
+            raise HTTPException(
+                status_code=404, detail="Analysis request not found"
+            )
+    else:
+        chart_dir = _chart_dir(app_state, record).resolve(strict=True)
+        try:
+            chart_path = (chart_dir / filename).resolve(strict=True)
+            chart_path.relative_to(chart_dir)
+        except (OSError, ValueError):
+            raise HTTPException(
+                status_code=404, detail="Chart not found"
+            ) from None
 
     media_type = mimetypes.guess_type(chart_path.name)[0] or "image/svg+xml"
     return FileResponse(

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
@@ -788,11 +788,11 @@ app = sp.App()
 def _():
     import signalpilot as sp
     sp.md({request_context_json})
+    return (sp,)
 
 
 @app.cell(hide_code=True)
-def _():
-    import signalpilot as sp
+def _(sp):
     sp.md("""
     ## Executive Summary and Explorations
 
@@ -801,8 +801,7 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _():
-    import signalpilot as sp
+def _(sp):
     sp.md("""
     ## Analysis steps
 

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
@@ -30,7 +30,6 @@ from signalpilot._runtime.commands import SerializedQueryParams
 from signalpilot._runtime.virtual_file import read_virtual_file
 from signalpilot._server.ai.analysis_prompts import (
     analysis_prompt as _analysis_prompt,
-    json_repair_prompt as _json_repair_prompt,
 )
 from signalpilot._server.api.deps import AppState
 from signalpilot._server.api.endpoints.notion_urls import (
@@ -56,6 +55,19 @@ LOGGER = _loggers.sp_logger()
 router = APIRouter()
 
 AnalysisStatus = Literal["New", "Analyzing", "Done", "Failed"]
+DEFAULT_ANALYSIS_AGENT_MODEL = "claude-sonnet-4-5-20250929"
+_ANALYSIS_AGENT_MODEL_ENV_NAMES = (
+    "SIGNALPILOT_ANALYSIS_AGENT_MODEL",
+    "SIGNALPILOT_WORKER_AGENT_MODEL",
+)
+
+
+def _analysis_agent_model() -> str:
+    for name in _ANALYSIS_AGENT_MODEL_ENV_NAMES:
+        value = (os.getenv(name) or "").strip()
+        if value:
+            return value
+    return DEFAULT_ANALYSIS_AGENT_MODEL
 
 
 class StartNotionAnalysisRequest(msgspec.Struct, rename="camel"):
@@ -1096,6 +1108,47 @@ def _parse_result(text: str) -> AnalysisResult:
     )
 
 
+def _parse_final_statement_result(text: str) -> AnalysisResult:
+    data = _extract_marker_json(text, "FINAL_STATEMENT")
+    statement = str(data.get("statement", "")).strip()
+    if not statement:
+        raise ValueError("Agent did not emit FINAL_STATEMENT.statement")
+    confidence = data.get("confidenceScore", data.get("confidence_score"))
+    if confidence is not None:
+        confidence = float(confidence)
+        confidence = max(0.0, min(1.0, confidence))
+    caveats = data.get("caveats") or []
+    if not isinstance(caveats, list):
+        caveats = [str(caveats)]
+    handoff_notes = data.get("handoffNotes", data.get("handoff_notes", [])) or []
+    if not isinstance(handoff_notes, list):
+        handoff_notes = [str(handoff_notes)]
+    return AnalysisResult(
+        summary=statement[:500],
+        confidence_score=confidence,
+        final_answer=statement,
+        gotchas=[str(item) for item in caveats],
+        analysis_method="; ".join(str(item) for item in handoff_notes),
+        notion_comment=statement[:1200],
+        notion_charts=[],
+    )
+
+
+def _extract_marker_json(text: str, marker: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    latest: dict[str, Any] | None = None
+    for match in re.finditer(rf"(?m)^\s*{re.escape(marker)}\s*:\s*", text):
+        try:
+            parsed, _ = decoder.raw_decode(text[match.end() :].lstrip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            latest = parsed
+    if latest is None:
+        raise ValueError(f"Agent did not emit {marker}")
+    return latest
+
+
 def _truncate_comment(text: str, limit: int = 1200) -> str:
     text = text.strip()
     if len(text) <= limit:
@@ -1111,21 +1164,20 @@ def _plain_text_failure_result(text: str, error: Exception) -> AnalysisResult:
         final_answer=(
             "## Executive Summary and Explorations\n\n"
             "- I could not complete the requested analysis.\n"
-            "- The agent returned plain text instead of the required JSON "
-            "response, so SignalPilot preserved the available failure details "
-            "below.\n\n"
+            "- The agent did not emit the required FINAL_STATEMENT marker, so "
+            "SignalPilot preserved the available failure details below.\n\n"
             "## Detailed Research\n\n"
             f"{detail}\n\n"
             "## Confidence Score: 0\n\n"
             "- No completed analysis result was produced."
         ),
         gotchas=[
-            "The agent did not return the required JSON response.",
+            "The agent did not emit the required FINAL_STATEMENT marker.",
             "The analysis should be rerun after inspecting the notebook trail.",
         ],
         analysis_method=(
-            "The agent returned plain text instead of the required JSON object; "
-            "SignalPilot preserved that text as failure detail."
+            "The agent did not emit the required FINAL_STATEMENT marker; "
+            "SignalPilot preserved the available text as failure detail."
         ),
         notion_comment=_truncate_comment(
             f"I could not complete the requested analysis.\n\n{detail}"
@@ -2697,6 +2749,7 @@ async def _run_analysis(
                 async for event in run_notebook_agent(
                     message=prompt,
                     session_id=SessionId(record.session_id),
+                    model=_analysis_agent_model(),
                     new_chat=new_chat,
                     thread_id=record.session_id,
                     notebook_mcp_app=app_state.request.app,
@@ -2776,63 +2829,7 @@ async def _run_analysis(
             )
             return
 
-        try:
-            record.result = _parse_result("".join(text_parts))
-        except Exception as parse_error:
-            repair_parts: list[str] = []
-            await append_trace_event(
-                {
-                    "type": "text",
-                    "content": (
-                        "Formatting the completed analysis into the required "
-                        "Notion JSON response."
-                    ),
-                    "tool_name": "",
-                    "tool_input": None,
-                    "tool_call_id": "",
-                    "is_error": False,
-                    "cost_usd": None,
-                    "turn": 0,
-                },
-            )
-            try:
-                async with asyncio.timeout(
-                    min(120.0, _agent_timeout_seconds())
-                ):
-                    async for event in run_notebook_agent(
-                        message=_json_repair_prompt(
-                            body.prompt, "".join(text_parts)
-                        ),
-                        session_id=SessionId(record.session_id),
-                        new_chat=False,
-                        max_turns=3,
-                        thread_id=record.session_id,
-                        notebook_mcp_app=app_state.request.app,
-                        cwd=agent_cwd,
-                        disallow_file_edits=True,
-                        additional_disallowed_tools=["Agent"],
-                    ):
-                        event_data = {
-                            "type": event.type,
-                            "content": event.content,
-                            "tool_name": event.tool_name,
-                            "tool_input": event.tool_input,
-                            "tool_call_id": event.tool_call_id,
-                            "is_error": event.is_error,
-                            "cost_usd": event.cost_usd,
-                            "turn": event.turn,
-                        }
-                        await append_trace_event(event_data)
-                        if event.type == "text" and event.content:
-                            repair_parts.append(event.content)
-                        if event.type == "error":
-                            raise RuntimeError(
-                                event.content or "Agent JSON repair failed"
-                            )
-                text_parts.extend(repair_parts)
-                record.result = _parse_result("".join(repair_parts))
-            except Exception as repair_error:
-                raise parse_error from repair_error
+        record.result = _parse_final_statement_result("".join(text_parts))
         record.status = "Done"
         record.error = None
         _persist_record_completion_artifacts(app_state, record)
@@ -2869,7 +2866,7 @@ async def _run_analysis(
         LOGGER.exception("Notion analysis %s failed", record.request_id)
         failed = False
         try:
-            record.result = _parse_result("".join(text_parts))
+            record.result = _parse_final_statement_result("".join(text_parts))
             record.status = "Done"
             record.error = None
         except Exception:

--- a/signalpilot/notebook-server/tests/_server/api/test_chat_trace_conversations.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_chat_trace_conversations.py
@@ -99,3 +99,76 @@ def test_slack_trace_source_gets_source_specific_default_title(
     body = json.loads(response.body)
 
     assert body["conversations"][0]["title"] == "Slack analysis"
+
+
+def test_trace_messages_render_final_statement_as_user_friendly_bullets(
+    monkeypatch,
+) -> None:
+    chat_endpoint = _load_chat_endpoint(monkeypatch)
+    trace_event_messages = chat_endpoint["_trace_event_messages"]
+
+    messages = trace_event_messages(
+        [
+            {"idx": 0, "type": "user", "role": "user", "content": "Analyze revenue"},
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    'FINAL_STATEMENT: {"statement":"Revenue increased. Costs stayed flat.",'
+                    '"confidenceScore":0.8,"caveats":["Excludes refunds"],'
+                    '"handoffNotes":["Used notebook SDK cells."]}'
+                ),
+                "created_at": 1_800_000_000,
+            },
+        ]
+    )
+
+    payload = json.loads(messages[-1]["content"])
+    content = payload["content"]
+
+    assert "FINAL_STATEMENT" not in content
+    assert '{"statement"' not in content
+    assert "Analysis complete." in content
+    assert "Findings:" in content
+    assert "- Revenue increased." in content
+    assert "- Costs stayed flat." in content
+    assert "Confidence: 0.8" in content
+    assert "Gotchas / caveats:" in content
+    assert "- Excludes refunds" in content
+    assert "Method:" in content
+    assert "- Used notebook SDK cells." in content
+
+
+def test_trace_messages_render_plan_and_progress_markers_readably(
+    monkeypatch,
+) -> None:
+    chat_endpoint = _load_chat_endpoint(monkeypatch)
+    trace_event_messages = chat_endpoint["_trace_event_messages"]
+
+    messages = trace_event_messages(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    "I have enough context to plan the run.\n\n"
+                    'PLAN: {"steps":["Inspect schema","Run revenue query"]}\n\n'
+                    'PROGRESS: {"currentStep":"Inspect schema","completedSteps":[],'
+                    '"status":"Checking tables"}'
+                ),
+                "created_at": 1_800_000_000,
+            },
+        ]
+    )
+
+    payload = json.loads(messages[-1]["content"])
+    content = payload["content"]
+
+    assert "PLAN:" not in content
+    assert "PROGRESS:" not in content
+    assert "Plan:" in content
+    assert "- Inspect schema" in content
+    assert "- Run revenue query" in content
+    assert "Progress:" in content
+    assert "- Current: Inspect schema" in content
+    assert "- Status: Checking tables" in content

--- a/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_charts.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_charts.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import base64
 import importlib
+import json
 import sys
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 
 _stubbed_signalpilot = sys.modules.get("signalpilot")
 if getattr(_stubbed_signalpilot, "__spec__", None) is None:
@@ -17,7 +19,8 @@ notion_analysis = importlib.import_module(
 def _app_state(tmp_path):
     return SimpleNamespace(
         session_manager=SimpleNamespace(
-            workspace=SimpleNamespace(directory=str(tmp_path))
+            workspace=SimpleNamespace(directory=str(tmp_path)),
+            get_session=lambda _session_id: None,
         )
     )
 
@@ -33,6 +36,69 @@ def _record() -> notion_analysis.AnalysisRecord:
         headline="Analysis",
         source_url="slack://message",
         created_at="2026-06-18T00:00:00Z",
+    )
+
+
+def test_chart_url_carries_project_branch_context(tmp_path) -> None:
+    project = "1dbf5492-81e6-4683-835f-f1785c9cfe78"
+    branch = "analysis/notion/notion-req-analyze"
+    app_state = SimpleNamespace(
+        request=SimpleNamespace(headers={}),
+        query_params=lambda key: {"project": project, "branch": branch}.get(key),
+        session_manager=SimpleNamespace(
+            workspace=SimpleNamespace(directory=str(tmp_path)),
+            get_session=lambda _session_id: None,
+        ),
+    )
+
+    url = notion_analysis._chart_url(app_state, _record(), "chart.png")
+    parsed = urlparse(url)
+
+    assert parsed.path == "/api/notion-analysis/chart/notion-test/chart.png"
+    assert parse_qs(parsed.query) == {
+        "project": [project],
+        "branch": [branch],
+    }
+
+
+def test_finds_existing_chart_file_from_project_registry(
+    tmp_path, monkeypatch
+) -> None:
+    from signalpilot._server.files import project_sync
+
+    project_root = tmp_path / "projects" / "project-1" / "repo"
+    notebook_path = "notebooks/notion/analysis.py"
+    chart_dir = (
+        project_root
+        / "notebooks"
+        / "notion"
+        / "public"
+        / "signalpilot-notion-charts"
+    )
+    chart_dir.mkdir(parents=True)
+    chart_file = chart_dir / "chart.png"
+    chart_file.write_bytes(b"png")
+    registry = project_root / "notebooks" / ".signalpilot-analysis-registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {
+                        "request_id": "notion-test",
+                        "notebook_path": notebook_path,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(project_sync, "PROJECTS_ROOT", tmp_path / "projects")
+
+    assert (
+        notion_analysis._chart_file_from_project_registries(
+            "notion-test", "chart.png"
+        )
+        == chart_file
     )
 
 
@@ -110,3 +176,81 @@ def test_writes_image_mime_data_url_outputs_as_chart_artifacts(tmp_path) -> None
         / "notion-test-cell-2-image-1.png"
     )
     assert chart_path.read_bytes() == image_bytes
+
+
+def test_writes_sp_mimebundle_image_outputs_as_chart_artifacts(tmp_path) -> None:
+    app_state = _app_state(tmp_path)
+    record = _record()
+    image_bytes = b"mimebundle-png"
+    data_url = (
+        "data:image/png;base64,"
+        + base64.b64encode(image_bytes).decode("ascii")
+    )
+
+    charts = notion_analysis._write_image_chart_artifacts(
+        app_state,
+        record,
+        [
+            (
+                "matplotlib-cell",
+                {
+                    "application/vnd.sp+mimebundle": json.dumps(
+                        {
+                            "image/png": data_url,
+                            "__metadata__": {"image/png": {"width": 900}},
+                        }
+                    )
+                },
+            )
+        ],
+    )
+
+    assert len(charts) == 1
+    assert charts[0].url == (
+        "/api/notion-analysis/chart/notion-test/"
+        "notion-test-matplotlib-cell-image-1.png"
+    )
+    chart_path = (
+        tmp_path
+        / "public"
+        / "signalpilot-notion-charts"
+        / "notion-test-matplotlib-cell-image-1.png"
+    )
+    assert chart_path.read_bytes() == image_bytes
+
+
+def test_ensure_notion_chart_artifacts_fills_second_page_chart_from_result_table(
+    tmp_path,
+) -> None:
+    app_state = _app_state(tmp_path)
+    record = _record()
+    chart_dir = tmp_path / "public" / "signalpilot-notion-charts"
+    chart_dir.mkdir(parents=True)
+    (chart_dir / "provided.png").write_bytes(b"provided-png")
+    record.result = notion_analysis.AnalysisResult(
+        final_answer=(
+            "| Company | Composite Score | Growth |\n"
+            "|---------|-----------------|--------|\n"
+            "| MapleCloud | 82 | 12% |\n"
+            "| Northstar | 71 | 8% |\n"
+        ),
+        notion_charts=[
+            notion_analysis.AnalysisChart(
+                title="Provided revenue trend",
+                url="/api/notion-analysis/chart/notion-test/provided.png",
+                caption="Provided revenue trend",
+                alt_text="Provided revenue trend",
+                include_in_comment=True,
+                include_on_page=True,
+            )
+        ],
+    )
+
+    notion_analysis._ensure_notion_chart_artifacts(app_state, record)
+
+    assert record.result.notion_charts is not None
+    assert [chart.title for chart in record.result.notion_charts] == [
+        "Provided revenue trend",
+        "Operating momentum composite ranking",
+    ]
+    assert all(chart.include_on_page for chart in record.result.notion_charts)

--- a/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
@@ -125,13 +125,58 @@ def test_project_root_uses_existing_project_checkout(
     )
     monkeypatch.setattr(
         project_sync,
+        "_current_git_branch",
+        lambda _repo: "analysis/slack/test",
+    )
+    monkeypatch.setattr(
+        project_sync,
         "sync_down",
         lambda *_args, **_kwargs: pytest.fail(
-            "sync_down should not run for existing checkout"
+            "sync_down should not run for existing checkout on target branch"
         ),
     )
 
     assert notion_analysis._project_root(app_state) == project_root
+
+
+def test_project_root_syncs_when_existing_checkout_is_on_wrong_branch(
+    tmp_path, monkeypatch
+) -> None:
+    from signalpilot._server.files import project_sync
+
+    project_root = tmp_path / "projects" / "project-1"
+    (project_root / ".git").mkdir(parents=True)
+    app_state = SimpleNamespace(
+        request=SimpleNamespace(
+            headers={
+                "x-gateway-project-id": "project-1",
+                "x-gateway-branch-id": "analysis/notion/current-request",
+            }
+        ),
+        session_manager=SimpleNamespace(
+            workspace=SimpleNamespace(directory=str(tmp_path / "workspace"))
+        ),
+    )
+    calls: list[tuple[str, str]] = []
+
+    def sync_down(project_id: str, branch: str) -> dict[str, str]:
+        calls.append((project_id, branch))
+        return {"local_dir": str(project_root)}
+
+    monkeypatch.setattr(
+        project_sync,
+        "local_project_dir",
+        lambda _project_id, _branch="": project_root,
+    )
+    monkeypatch.setattr(
+        project_sync,
+        "_current_git_branch",
+        lambda _repo: "analysis/notion/previous-request",
+    )
+    monkeypatch.setattr(project_sync, "sync_down", sync_down)
+
+    assert notion_analysis._project_root(app_state) == project_root
+    assert calls == [("project-1", "analysis/notion/current-request")]
 
 
 def test_project_root_syncs_project_checkout_before_workspace_fallback(
@@ -342,6 +387,9 @@ def test_analysis_prompt_requires_nearby_query_evidence_branches() -> None:
     assert "q1_gbp_revenue_df = pd.DataFrame(db.query" in prompt
     assert "q1_gbp_revenue_df.head(10)" in prompt
     assert "monthly_revenue_chart" in prompt
+    assert "Produce charts for every completed Slack/Notion data-analysis request" in prompt
+    assert "at least two visible chart outputs for Notion page content" in prompt
+    assert "first chart must also be suitable\n   for the Slack/Notion comment thread" in prompt
     assert "head of\n     the joined table/query result" in prompt
     assert "not just a branch list" in prompt
     assert "finding explanation, exact query, data head/preview" in prompt
@@ -388,6 +436,7 @@ def test_analysis_prompt_injects_warm_context_without_changing_output_contract()
     assert "notionCharts" in prompt
     assert "Do not include slackMessage, notionComment, finalAnswer, notionCharts" in prompt
     assert '"Executive Summary and Explorations" cell' in prompt
+    assert "Aim for two visible,\n  harvestable chart outputs" in prompt
 
 
 def test_warm_context_truncation_stays_under_cap() -> None:

--- a/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
@@ -47,6 +47,10 @@ def test_notebook_template_uses_compact_three_cell_scaffold() -> None:
 
     assert template.count("@app.cell") == 3
     assert template.count("@app.cell(hide_code=True)") == 3
+    assert template.count("import signalpilot as sp") == 2
+    assert template.count("    import signalpilot as sp") == 1
+    assert template.count("def _(sp):") == 2
+    assert "    return (sp,)" in template
     assert "# SignalPilot analysis" in template
     assert "AI generated title" not in template
     assert "**Source request:** https://slack.test/archives/C/p123" in template
@@ -282,9 +286,10 @@ def test_analysis_prompt_requires_nearby_query_evidence_branches() -> None:
     prompt = notion_analysis._analysis_prompt(_record(), _body())
 
     assert "`sp.init()`" in prompt
-    assert (
-        "`import signalpilot as sp`, `sp.init()`, `sp.connections()`" in prompt
-    )
+    assert "Define `sp` in exactly one notebook cell" in prompt
+    assert "must not repeat `import signalpilot as sp`" in prompt
+    assert "causes `MultipleDefinitionError`" in prompt
+    assert "`sp.init()`, `sp.connections()`" in prompt
     assert 'then `sp.connect("connection_name")`' in prompt
     assert "Markdown-only `sp.md(...)` cells" in prompt
     assert "not require `sp.init()`" in prompt

--- a/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
@@ -448,6 +448,13 @@ def test_warm_context_truncation_stays_under_cap() -> None:
     assert "Warm context truncated" in clipped
 
 
+def test_gateway_json_get_rejects_non_http_gateway_url(monkeypatch) -> None:
+    monkeypatch.setenv("SP_GATEWAY_URL", "file:///tmp/signalpilot-gateway")
+
+    with pytest.raises(RuntimeError, match="absolute http or https"):
+        notion_analysis._gateway_json_get("/api/connections")
+
+
 def test_warm_context_builder_clips_oversized_schema_link(
     tmp_path,
     monkeypatch,

--- a/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
@@ -204,6 +204,9 @@ def test_analysis_agent_runs_from_project_root(tmp_path, monkeypatch) -> None:
     from signalpilot._server.ai.claude_agent import AgentEvent
     from signalpilot._types.ids import SessionId
 
+    monkeypatch.delenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL", raising=False)
+    monkeypatch.delenv("SIGNALPILOT_WORKER_AGENT_MODEL", raising=False)
+
     class FakeStore:
         async def upsert_thread(self, thread) -> None:
             del thread
@@ -230,12 +233,9 @@ def test_analysis_agent_runs_from_project_root(tmp_path, monkeypatch) -> None:
         captured.update(kwargs)
         yield AgentEvent(
             type="text",
-            content=json.dumps(
-                {
-                    "summary": "Done",
-                    "confidenceScore": 0.9,
-                    "finalAnswer": "Done",
-                }
+            content=(
+                'FINAL_STATEMENT: {"statement":"Done","confidenceScore":0.9,'
+                '"caveats":[],"handoffNotes":["Notebook-executed SDK cells."]}'
             ),
         )
 
@@ -277,9 +277,24 @@ def test_analysis_agent_runs_from_project_root(tmp_path, monkeypatch) -> None:
     )
 
     assert captured["session_id"] == SessionId(record.session_id)
+    assert captured["model"] == notion_analysis.DEFAULT_ANALYSIS_AGENT_MODEL
     assert captured["cwd"] == str(project_root)
     assert captured["additional_disallowed_tools"] == ["Agent"]
     assert "Likely connection: `dev-db`" in str(captured["message"])
+
+
+def test_analysis_agent_model_prefers_env_override(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SIGNALPILOT_ANALYSIS_AGENT_MODEL",
+        "claude-sonnet-analysis-test",
+    )
+    monkeypatch.setenv("SIGNALPILOT_WORKER_AGENT_MODEL", "claude-sonnet-worker-test")
+
+    assert notion_analysis._analysis_agent_model() == "claude-sonnet-analysis-test"
+
+    monkeypatch.delenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL")
+
+    assert notion_analysis._analysis_agent_model() == "claude-sonnet-worker-test"
 
 
 def test_analysis_prompt_requires_nearby_query_evidence_branches() -> None:
@@ -334,7 +349,7 @@ def test_analysis_prompt_requires_nearby_query_evidence_branches() -> None:
     assert '"Evidence Trace"' not in prompt
     assert "Mermaid" not in prompt
     assert "top-line result" not in prompt
-    assert "Confidence methodology/rationale" in prompt
+    assert "confidence score/methodology rationale" in prompt
     assert "Queries must not be buried" in prompt
     assert "Previous discussion messages:" in prompt
     assert "Previous Notion discussion messages:" not in prompt
@@ -363,12 +378,16 @@ def test_analysis_prompt_injects_warm_context_without_changing_output_contract()
 
     assert "Likely connection: `dev-db`" in prompt
     assert "CREATE TABLE public.orders" in prompt
-    assert (
-        "When the analysis is complete, your final assistant message must be only valid"
-        in prompt
-    )
-    assert '"notionCharts": [' in prompt
-    assert "## Executive Summary and Explorations" in prompt
+    assert "user-friendly and audit-ready for the notebook chat thread" in prompt
+    assert "Start with a concise bullet-point answer" in prompt
+    assert "PLAN:" in prompt
+    assert "PROGRESS:" in prompt
+    assert "Never use raw machine" in prompt
+    assert 'status enums such as `"in_progress"`' in prompt
+    assert "FINAL_STATEMENT:" in prompt
+    assert "notionCharts" in prompt
+    assert "Do not include slackMessage, notionComment, finalAnswer, notionCharts" in prompt
+    assert '"Executive Summary and Explorations" cell' in prompt
 
 
 def test_warm_context_truncation_stays_under_cap() -> None:

--- a/signalpilot/web/app/integrations/page.tsx
+++ b/signalpilot/web/app/integrations/page.tsx
@@ -7,17 +7,23 @@ import {
   ExternalLink,
   Link,
   Loader2,
+  MessageSquare,
   Trash2,
   X,
 } from "lucide-react";
 import { useAppAuth } from "~/lib/auth-context";
 import {
   deleteNotionOAuthInstallation,
+  deleteSlackOAuthInstallation,
   getWorkspaceProjects,
   getNotionOAuthInstallations,
+  getSlackOAuthInstallations,
   provisionNotionOAuthInstallation,
+  provisionSlackOAuthInstallation,
   startNotionOAuth,
+  startSlackOAuth,
   type NotionOAuthInstallation,
+  type SlackOAuthInstallation,
 } from "~/lib/api";
 import type { WorkspaceProjectInfo } from "~/lib/types";
 import { PageHeader, TerminalBar } from "~/components/ui/page-header";
@@ -36,6 +42,13 @@ function oauthStatus(installation: NotionOAuthInstallation): { label: string; to
   if (installation.status === "disconnected") return { label: "disconnected", tone: "error" };
   if (installation.config?.enabled && installation.config?.default_project_id) return { label: "active", tone: "healthy" };
   if (installation.config?.enabled && !installation.config?.default_project_id) return { label: "needs setup", tone: "warning" };
+  if (installation.status === "connected") return { label: "needs setup", tone: "warning" };
+  return { label: installation.status || "unknown", tone: "unknown" };
+}
+
+function slackStatus(installation: SlackOAuthInstallation): { label: string; tone: "healthy" | "warning" | "error" | "unknown" } {
+  if (installation.status === "disconnected") return { label: "disconnected", tone: "error" };
+  if (installation.config?.enabled && installation.config?.default_project_id) return { label: "active", tone: "healthy" };
   if (installation.status === "connected") return { label: "needs setup", tone: "warning" };
   return { label: installation.status || "unknown", tone: "unknown" };
 }
@@ -69,21 +82,28 @@ function IntegrationsContent() {
   const { toast } = useToast();
 
   const [oauthInstallations, setOauthInstallations] = useState<NotionOAuthInstallation[]>([]);
+  const [slackInstallations, setSlackInstallations] = useState<SlackOAuthInstallation[]>([]);
   const [workspaceProjects, setWorkspaceProjects] = useState<WorkspaceProjectInfo[]>([]);
   const [projectSelections, setProjectSelections] = useState<Record<string, string>>({});
+  const [slackProjectSelections, setSlackProjectSelections] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [connecting, setConnecting] = useState(false);
+  const [connectingSlack, setConnectingSlack] = useState(false);
   const [provisioningId, setProvisioningId] = useState<string | null>(null);
+  const [provisioningSlackId, setProvisioningSlackId] = useState<string | null>(null);
   const [deletingOauthId, setDeletingOauthId] = useState<string | null>(null);
+  const [deletingSlackId, setDeletingSlackId] = useState<string | null>(null);
 
   const fetchIntegrations = useCallback(async () => {
     try {
-      const [installations, projectResult] = await Promise.all([
+      const [installations, slackInstalls, projectResult] = await Promise.all([
         getNotionOAuthInstallations(),
+        getSlackOAuthInstallations(),
         getWorkspaceProjects("active"),
       ]);
       setOauthInstallations(installations);
+      setSlackInstallations(slackInstalls);
       setWorkspaceProjects(projectResult.projects);
       setProjectSelections((prev) => {
         const next = { ...prev };
@@ -99,8 +119,22 @@ function IntegrationsContent() {
         }
         return next;
       });
+      setSlackProjectSelections((prev) => {
+        const next = { ...prev };
+        const activeInstallationIds = new Set(slackInstalls.map((installation) => installation.id));
+        for (const id of Object.keys(next)) {
+          if (!activeInstallationIds.has(id)) delete next[id];
+        }
+        for (const installation of slackInstalls) {
+          const configuredProjectId = installation.config?.default_project_id || "";
+          if (configuredProjectId || next[installation.id] === undefined) {
+            next[installation.id] = configuredProjectId;
+          }
+        }
+        return next;
+      });
       setLoadError(false);
-      return installations;
+      return { notionInstallations: installations, slackInstallations: slackInstalls };
     } catch {
       setLoadError(true);
       toast("failed to load integrations", "error");
@@ -116,12 +150,57 @@ function IntegrationsContent() {
     const params = new URLSearchParams(window.location.search);
     const notion = params.get("notion");
     const installationId = params.get("installation_id");
-    if (!notion) return;
+    const slack = params.get("slack");
+    const slackInstallationId = params.get("slack_installation_id");
+    if (!notion && !slack) return;
     params.delete("notion");
     params.delete("installation_id");
+    params.delete("slack");
+    params.delete("slack_installation_id");
     const next = params.toString();
     window.history.replaceState(null, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
 
+    if (slack) {
+      if (slack !== "connected" || !slackInstallationId) {
+        toast(slack === "connected" ? "slack connected" : `slack ${slack}`, slack === "connected" ? "success" : "error");
+        return;
+      }
+
+      const oauthInstallationId = slackInstallationId;
+      let active = true;
+      async function refreshSlackInstall() {
+        setLoading(true);
+        try {
+          const result = await fetchIntegrations();
+
+          if (!result) return;
+
+          const installation = result.slackInstallations.find((candidate) => candidate.id === oauthInstallationId);
+          if (installation?.config?.enabled) {
+            if (active) toast("slack connected", "success");
+            return;
+          }
+          if (!installation) {
+            if (active) toast("slack connected, but installation was not found", "error");
+            return;
+          }
+
+          if (active) toast("slack connected; select a project", "success");
+        } catch (e) {
+          if (active) {
+            setLoading(false);
+            toast(`failed to load slack install: ${e}`, "error", 6000);
+          }
+        }
+      }
+
+      refreshSlackInstall();
+      return () => {
+        active = false;
+      };
+    }
+
+    if (!notion) return;
     if (notion !== "connected" || !installationId) {
       toast(notion === "connected" ? "notion connected" : `notion ${notion}`, notion === "connected" ? "success" : "error");
       return;
@@ -132,11 +211,11 @@ function IntegrationsContent() {
     async function refreshOAuthInstall() {
       setLoading(true);
       try {
-        const installations = await fetchIntegrations();
+        const result = await fetchIntegrations();
 
-        if (!installations) return;
+        if (!result) return;
 
-        const installation = installations.find((candidate) => candidate.id === oauthInstallationId);
+        const installation = result.notionInstallations.find((candidate) => candidate.id === oauthInstallationId);
         if (installation?.config?.enabled) {
           if (active) toast("notion connected", "success");
           return;
@@ -172,6 +251,17 @@ function IntegrationsContent() {
     }
   }
 
+  async function handleConnectSlack() {
+    setConnectingSlack(true);
+    try {
+      const response = await startSlackOAuth(window.location.origin + "/integrations");
+      window.location.href = response.authorize_url;
+    } catch (e) {
+      toast(`failed to start slack oauth: ${e}`, "error");
+      setConnectingSlack(false);
+    }
+  }
+
   async function handleProvision(installationId: string) {
     const selectedProjectId = projectSelections[installationId] || "";
     const selectedProject = workspaceProjects.find((project) => project.id === selectedProjectId);
@@ -199,6 +289,34 @@ function IntegrationsContent() {
     }
   }
 
+  async function handleProvisionSlack(installationId: string) {
+    const selectedProjectId = slackProjectSelections[installationId] || "";
+    const selectedProject = workspaceProjects.find((project) => project.id === selectedProjectId);
+    if (!selectedProject) {
+      toast("select a project", "error");
+      return;
+    }
+
+    const installation = slackInstallations.find((candidate) => candidate.id === installationId);
+    const alreadyProvisioned = Boolean(installation?.config?.enabled);
+
+    setProvisioningSlackId(installationId);
+    try {
+      await provisionSlackOAuthInstallation(installationId, {
+        default_project_id: selectedProject.id,
+        default_branch: selectedProject.default_branch || "main",
+        analysis_branch_mode: "per_request",
+        allowed_channel_ids: installation?.config?.allowed_channel_ids || [],
+      });
+      toast(alreadyProvisioned ? "slack default project saved" : "slack workspace enabled", "success");
+      await fetchIntegrations();
+    } catch (e) {
+      toast(`slack setup failed: ${e}`, "error");
+    } finally {
+      setProvisioningSlackId(null);
+    }
+  }
+
   async function handleDeleteOAuth(installationId: string) {
     try {
       await deleteNotionOAuthInstallation(installationId);
@@ -210,11 +328,27 @@ function IntegrationsContent() {
     }
   }
 
+  async function handleDeleteSlackOAuth(installationId: string) {
+    try {
+      await deleteSlackOAuthInstallation(installationId);
+      setDeletingSlackId(null);
+      toast("slack install disconnected", "success");
+      await fetchIntegrations();
+    } catch (e) {
+      toast(`failed: ${e}`, "error");
+    }
+  }
+
   if (loading) return <ApiKeysSkeleton />;
 
   const visibleInstallations = oauthInstallations.filter((installation) => installation.status !== "disconnected");
+  const visibleSlackInstallations = slackInstallations.filter((installation) => installation.status !== "disconnected");
   const hasConnectedInstall = visibleInstallations.length > 0;
+  const hasConnectedSlackInstall = visibleSlackInstallations.length > 0;
   const activeOauthCount = visibleInstallations.filter(
+    (installation) => installation.config?.enabled && installation.config?.default_project_id,
+  ).length;
+  const activeSlackCount = visibleSlackInstallations.filter(
     (installation) => installation.config?.enabled && installation.config?.default_project_id,
   ).length;
   const projectsById = new Map(workspaceProjects.map((project) => [project.id, project]));
@@ -223,17 +357,17 @@ function IntegrationsContent() {
     <div className="p-8 max-w-3xl animate-fade-in">
       <PageHeader
         title="integrations"
-        subtitle="notion"
+        subtitle="notion + slack"
         description="connect external services to signalpilot"
       />
 
       <TerminalBar
         path="integrations --list"
-        status={<StatusDot status={activeOauthCount > 0 ? "healthy" : "unknown"} size={4} />}
+        status={<StatusDot status={activeOauthCount + activeSlackCount > 0 ? "healthy" : "unknown"} size={4} />}
       >
         <div className="flex items-center gap-6 text-xs">
           <span className="text-[var(--color-text-dim)]">
-            active: <code className="text-[12px] text-[var(--color-text)]">{activeOauthCount}</code>
+            active: <code className="text-[12px] text-[var(--color-text)]">{activeOauthCount + activeSlackCount}</code>
           </span>
         </div>
       </TerminalBar>
@@ -405,6 +539,156 @@ function IntegrationsContent() {
                       >
                         {provisioningId === installation.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Database className="w-3 h-3" />}
                         {installation.config?.enabled ? "save project" : "provision workspace"}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })()}
+            </div>
+          );
+        })}
+      </section>
+
+      <section className="mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <SectionHeader icon={MessageSquare} title="slack oauth" />
+          {!hasConnectedSlackInstall && (
+            <button
+              onClick={handleConnectSlack}
+              disabled={connectingSlack}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-bg)] bg-[var(--color-text)] hover:opacity-90 transition-all tracking-wider uppercase disabled:opacity-30"
+            >
+              {connectingSlack ? <Loader2 className="w-3 h-3 animate-spin" /> : <MessageSquare className="w-3 h-3" />}
+              connect slack
+            </button>
+          )}
+        </div>
+
+        {!loadError && visibleSlackInstallations.length === 0 && (
+          <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-8 text-center">
+            <MessageSquare className="w-6 h-6 text-[var(--color-text-dim)] mx-auto mb-3" strokeWidth={1} />
+            <p className="text-[12px] text-[var(--color-text-dim)] tracking-wider mb-3">
+              no slack workspaces connected
+            </p>
+            <button
+              onClick={handleConnectSlack}
+              disabled={connectingSlack}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-[12px] tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
+            >
+              {connectingSlack ? <Loader2 className="w-3 h-3 animate-spin" /> : <MessageSquare className="w-3 h-3" />}
+              connect slack
+            </button>
+          </div>
+        )}
+
+        {visibleSlackInstallations.map((installation) => {
+          const status = slackStatus(installation);
+          return (
+            <div key={installation.id} className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5 mb-3">
+              <div className="flex items-start justify-between gap-4 mb-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-2">
+                    <MessageSquare className="w-3.5 h-3.5 text-[var(--color-text-dim)] flex-shrink-0" strokeWidth={1.5} />
+                    <span className="text-[13px] text-[var(--color-text)] tracking-wider font-medium">
+                      {installation.team_name || installation.team_id}
+                    </span>
+                    <StatusDot status={status.tone} size={4} />
+                    <span className="text-[10px] text-[var(--color-text-dim)] tracking-wider uppercase">{status.label}</span>
+                  </div>
+                  <div className="space-y-1 text-[11px] text-[var(--color-text-dim)] tracking-wider">
+                    <p className="flex items-center gap-1.5">
+                      <span>team:</span>
+                      <span className="text-[var(--color-text-muted)] font-mono">{installation.team_id}</span>
+                    </p>
+                    <p className="flex items-center gap-1.5">
+                      <span>bot user:</span>
+                      <span className="text-[var(--color-text-muted)] font-mono">{installation.bot_user_id}</span>
+                    </p>
+                    <p className="flex items-center gap-1.5">
+                      <span>
+                        default project:
+                        {!installation.config?.default_project_id && (
+                          <span className="ml-1 text-[var(--color-error)]">*</span>
+                        )}
+                      </span>
+                      <span className="text-[var(--color-text-muted)] font-mono truncate">
+                        {(() => {
+                          const project = installation.config?.default_project_id
+                            ? projectsById.get(installation.config.default_project_id)
+                            : null;
+                          return project
+                            ? projectLabel(project)
+                            : shortenedId(installation.config?.default_project_id);
+                        })()}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+
+                {deletingSlackId === installation.id ? (
+                  <div className="flex items-center gap-1.5">
+                    <button onClick={() => handleDeleteSlackOAuth(installation.id)} className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-error)] border border-[var(--color-error)]/30 hover:border-[var(--color-error)] transition-all tracking-wider uppercase">confirm</button>
+                    <button onClick={() => setDeletingSlackId(null)} className="p-1.5 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"><X className="w-3 h-3" /></button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setDeletingSlackId(installation.id)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-error)]/50 hover:text-[var(--color-error)] transition-all tracking-wider uppercase"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                    disconnect
+                  </button>
+                )}
+              </div>
+
+              {(() => {
+                const configuredProjectId = installation.config?.default_project_id || "";
+                const selectedProjectId = slackProjectSelections[installation.id] ?? configuredProjectId;
+                const selectedProject = selectedProjectId ? projectsById.get(selectedProjectId) : null;
+                const projectChanged = selectedProjectId !== configuredProjectId;
+                const canSubmitProject =
+                  Boolean(selectedProject) &&
+                  provisioningSlackId !== installation.id &&
+                  (!installation.config?.enabled || projectChanged);
+
+                return (
+                  <div className="border-t border-[var(--color-border)] pt-4">
+                    <label htmlFor={`slack-project-${installation.id}`} className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">
+                      default project
+                      <span className="ml-1 text-[var(--color-error)]">*</span>
+                    </label>
+                    <div className="flex flex-col sm:flex-row gap-2">
+                      <select
+                        id={`slack-project-${installation.id}`}
+                        value={selectedProjectId}
+                        onChange={(event) => {
+                          setSlackProjectSelections((prev) => ({
+                            ...prev,
+                            [installation.id]: event.target.value,
+                          }));
+                        }}
+                        disabled={workspaceProjects.length === 0 || provisioningSlackId === installation.id}
+                        className="min-w-0 flex-1 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs focus:outline-none disabled:opacity-40"
+                      >
+                        <option value="">
+                          {workspaceProjects.length === 0 && !selectedProjectId ? "no active projects" : "select a project..."}
+                        </option>
+                        {selectedProjectId && !selectedProject && (
+                          <option value={selectedProjectId}>configured project unavailable</option>
+                        )}
+                        {workspaceProjects.map((project) => (
+                          <option key={project.id} value={project.id}>
+                            {projectLabel(project)}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => handleProvisionSlack(installation.id)}
+                        disabled={!canSubmitProject}
+                        className="flex items-center justify-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-[12px] tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
+                      >
+                        {provisioningSlackId === installation.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Database className="w-3 h-3" />}
+                        {installation.config?.enabled ? "save project" : "enable workspace"}
                       </button>
                     </div>
                   </div>

--- a/signalpilot/web/lib/api.ts
+++ b/signalpilot/web/lib/api.ts
@@ -827,6 +827,50 @@ export const provisionNotionOAuthInstallation = (installationId: string, payload
 export const deleteNotionOAuthInstallation = (installationId: string) =>
   request<void>(`/api/integrations/notion/oauth/${installationId}`, { method: "DELETE" });
 
+// Slack Integrations
+export type SlackOAuthInstallationConfig = {
+  enabled: boolean;
+  default_project_id: string | null;
+  default_branch: string;
+  analysis_branch_mode: "per_request" | "default_branch";
+  allowed_channel_ids: string[];
+};
+export type SlackOAuthInstallation = {
+  id: string;
+  team_id: string;
+  team_name: string | null;
+  enterprise_id: string | null;
+  enterprise_name: string | null;
+  app_id: string | null;
+  bot_user_id: string;
+  authed_user_id: string | null;
+  scopes: string[];
+  status: string;
+  created_at: string | null;
+  updated_at: string | null;
+  org_id: string | null;
+  config: SlackOAuthInstallationConfig | null;
+};
+export const startSlackOAuth = (redirectAfter?: string) => {
+  const qs = redirectAfter ? `?redirect_after=${encodeURIComponent(redirectAfter)}` : "";
+  return request<{ authorize_url: string; state: string }>(`/api/integrations/slack/oauth/start${qs}`);
+};
+export const getSlackOAuthInstallations = () =>
+  request<SlackOAuthInstallation[]>("/api/integrations/slack/oauth/installations");
+export type SlackProvisionPayload = {
+  default_project_id: string;
+  default_branch?: string;
+  analysis_branch_mode?: "per_request" | "default_branch";
+  allowed_channel_ids?: string[];
+};
+export const provisionSlackOAuthInstallation = (installationId: string, payload: SlackProvisionPayload) =>
+  request<{ installation: SlackOAuthInstallation }>(`/api/integrations/slack/oauth/${installationId}/provision`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+export const deleteSlackOAuthInstallation = (installationId: string) =>
+  request<void>(`/api/integrations/slack/oauth/${installationId}`, { method: "DELETE" });
+
 // Metrics SSE (uses fetch instead of EventSource so we can send auth headers)
 export function subscribeMetrics(cb: (data: import("./types").MetricsSnapshot) => void): () => void {
   let aborted = false;


### PR DESCRIPTION
## Summary
- route Slack and Notion final delivery through the trace-backed orchestrator instead of worker-emitted final JSON
- make Notion progress live in the comment thread, then delete the progress comment and post a fresh final comment with chart attachments
- attach generated charts in Slack/Notion and harden notebook chart/trail URL handling
- tune analysis/delivery prompts so final user-facing messages are bullet-oriented and human-readable

## Verification
- `cd signalpilot/gateway && .venv/bin/python -m pytest tests/test_notion_analysis.py tests/test_slack_poc_worker.py tests/test_analysis_delivery.py tests/test_notion_oauth.py -q`
- `cd signalpilot/notebook-server && .venv/bin/python -m pytest tests/_server/api/test_notion_analysis_template.py tests/_server/api/test_notion_analysis_charts.py -q`
- gateway and notebook-server `ruff check` on changed files
- gateway and notebook-server `py_compile` on changed files
- `git diff --check`