### PR TITLE
Use account Anthropic key for analysis delivery

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/__init__.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/__init__.py
@@ -1,5 +1,6 @@
 """Shared orchestration helpers for notebook-backed external analysis."""
 
+from .credentials import delivery_api_key_for_user
 from .preflight import (
     AnalysisPreflightDecision,
     AnalysisPreflightKind,
@@ -38,6 +39,7 @@ __all__ = [
     "WorkerPlan",
     "WorkerProgress",
     "classify_analysis_request",
+    "delivery_api_key_for_user",
     "delivery_result_to_status",
     "load_delivery_packet",
     "load_delivery_packet_from_events",

--- a/signalpilot/gateway/gateway/analysis_delivery/credentials.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/credentials.py
@@ -1,0 +1,30 @@
+"""Credential helpers for account-scoped analysis delivery."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.store import user_secrets as user_secrets_store
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def delivery_api_key_for_user(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str | None,
+) -> str:
+    """Return the user's Anthropic key for delivery rendering, or disable model delivery."""
+    if not user_id:
+        return ""
+    try:
+        return await user_secrets_store.get_user_anthropic_key(session, org_id, user_id) or ""
+    except Exception as exc:
+        LOGGER.info(
+            "Could not load user Anthropic key for analysis delivery; using fallback delivery: %s",
+            exc,
+        )
+        return ""

--- a/signalpilot/gateway/gateway/analysis_delivery/renderer.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/renderer.py
@@ -103,8 +103,11 @@ async def render_delivery(
     packet: DeliveryPacket,
     *,
     renderer: DeliveryRenderer | None = None,
+    api_key: str | None = None,
 ) -> DeliveryResult:
-    return await (renderer or DeliveryRenderer()).render(packet)
+    if renderer is not None:
+        return await renderer.render(packet)
+    return await DeliveryRenderer(api_key=api_key).render(packet)
 
 
 def fallback_delivery(packet: DeliveryPacket) -> DeliveryResult:
@@ -127,8 +130,12 @@ def fallback_delivery(packet: DeliveryPacket) -> DeliveryResult:
     return DeliveryResult(
         summary=_clip(_string(notebook_outputs.get("summary")) or fallback_text, 500),
         slack_message=fallback_text,
-        notion_comment=_clip(_string(notebook_outputs.get("notionComment") or notebook_outputs.get("notion_comment")) or fallback_text, 1200),
-        final_answer=_string(notebook_outputs.get("finalAnswer") or notebook_outputs.get("final_answer")) or fallback_text,
+        notion_comment=_clip(
+            _string(notebook_outputs.get("notionComment") or notebook_outputs.get("notion_comment")) or fallback_text,
+            1200,
+        ),
+        final_answer=_string(notebook_outputs.get("finalAnswer") or notebook_outputs.get("final_answer"))
+        or fallback_text,
         gotchas=gotchas,
         analysis_method=method,
         notion_charts=[_clean_chart_labels(chart) for chart in packet.charts],
@@ -195,7 +202,9 @@ def _delivery_result_from_payload(payload: dict[str, Any], packet: DeliveryPacke
     charts_raw = payload.get("notionCharts")
     if not isinstance(gotchas_raw, list) or not isinstance(charts_raw, list):
         return None
-    allowed_chart_keys = {_string(chart.get("url")) or _string(chart.get("title")) for chart in packet.charts if isinstance(chart, dict)}
+    allowed_chart_keys = {
+        _string(chart.get("url")) or _string(chart.get("title")) for chart in packet.charts if isinstance(chart, dict)
+    }
     charts: list[dict[str, Any]] = []
     for chart in charts_raw:
         if not isinstance(chart, dict):

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from gateway.analysis_delivery import (
     AnalysisPreflightKind,
     classify_analysis_request,
+    delivery_api_key_for_user,
     delivery_result_to_status,
     load_delivery_packet,
     load_delivery_packet_from_events,
@@ -140,13 +141,17 @@ def _chart_image_block(chart: dict[str, Any]) -> dict[str, Any]:
         "image": {
             "type": "file_upload",
             "file_upload": {"id": _chart_file_upload_id(chart)},
-            "caption": notion_formatting.markdown_rich_text(caption, max_chars=NOTION_RICH_TEXT_MAX_LENGTH) if caption else [],
+            "caption": notion_formatting.markdown_rich_text(caption, max_chars=NOTION_RICH_TEXT_MAX_LENGTH)
+            if caption
+            else [],
         },
     }
 
 
 def _chart_detail_blocks(status: dict[str, Any]) -> list[dict[str, Any]]:
-    chart_blocks = [_chart_image_block(chart) for chart in _selected_charts(status, "page") if _chart_file_upload_id(chart)]
+    chart_blocks = [
+        _chart_image_block(chart) for chart in _selected_charts(status, "page") if _chart_file_upload_id(chart)
+    ]
     if not chart_blocks:
         return []
     return [_heading_block("Charts"), *chart_blocks]
@@ -191,7 +196,9 @@ def _analysis_detail_blocks(status: dict[str, Any]) -> list[dict[str, Any]]:
         *chart_blocks,
         _heading_block("Executive Summary and Explorations"),
         *notion_formatting.markdown_blocks(status.get("summary") or answer),
-        notion_formatting.toggle_heading_block("Detailed Research", notion_formatting.markdown_blocks(answer) or [_paragraph_block(answer)]),
+        notion_formatting.toggle_heading_block(
+            "Detailed Research", notion_formatting.markdown_blocks(answer) or [_paragraph_block(answer)]
+        ),
         notion_formatting.toggle_heading_block(
             f"Confidence Score: {confidence_text}",
             [notion_formatting.bulleted_list_item_block(str(gotcha)) for gotcha in gotchas],
@@ -773,7 +780,11 @@ async def _upload_chart_images_to_notion(
     return {
         **status,
         "notionCharts": [
-            {**chart, "fileUploadId": uploads[_chart_value(chart, "url")]["id"], "fileName": uploads[_chart_value(chart, "url")]["fileName"]}
+            {
+                **chart,
+                "fileUploadId": uploads[_chart_value(chart, "url")]["id"],
+                "fileName": uploads[_chart_value(chart, "url")]["fileName"],
+            }
             if _chart_value(chart, "url") in uploads
             else chart
             for chart in _status_charts(status)
@@ -846,7 +857,9 @@ async def _create_failure_comment(
 
 def mint_internal_notebook_jwt(org_id: str, user_id: str | None, scopes: list[str] | None = None) -> str:
     """Mint the internal JWT used by the notebook API for org-scoped work."""
-    secret = os.getenv("SIGNALPILOT_INTERNAL_JWT_SECRET") or os.getenv("SP_INTERNAL_JWT_SECRET") or load_session_jwt_secret()
+    secret = (
+        os.getenv("SIGNALPILOT_INTERNAL_JWT_SECRET") or os.getenv("SP_INTERNAL_JWT_SECRET") or load_session_jwt_secret()
+    )
     now = datetime.now(UTC)
     payload = {
         "iss": "signalpilot-gateway",
@@ -989,7 +1002,9 @@ async def process_routed_comment_event(
     page_id = payload.get("data", {}).get("page_id")
     parent_block_id = payload.get("data", {}).get("parent", {}).get("id")
     if not comment_id or not page_id:
-        return _ignored("missing_comment_or_page_id", event_id=payload.get("id"), comment_id=comment_id, page_id=page_id)
+        return _ignored(
+            "missing_comment_or_page_id", event_id=payload.get("id"), comment_id=comment_id, page_id=page_id
+        )
 
     block_id = parent_block_id or page_id
     comments = await notion_client.list_comments(token, block_id)
@@ -999,7 +1014,9 @@ async def process_routed_comment_event(
             trigger_comment = await notion_client.retrieve_comment(token, str(comment_id))
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
-                return _ignored("comment_not_found", event_id=payload.get("id"), comment_id=comment_id, block_id=block_id)
+                return _ignored(
+                    "comment_not_found", event_id=payload.get("id"), comment_id=comment_id, block_id=block_id
+                )
             raise
     if notion_client.is_bot_comment(trigger_comment):
         return _ignored("bot_comment", event_id=payload.get("id"), comment_id=comment_id)
@@ -1087,7 +1104,9 @@ async def process_routed_comment_event(
         )
         return NotionCommentProcessResult(status="processed")
 
-    await notion_client.update_page_properties(token, request_page_id, {"Status": {"rich_text": _rich_text("Analyzing")}})
+    await notion_client.update_page_properties(
+        token, request_page_id, {"Status": {"rich_text": _rich_text("Analyzing")}}
+    )
     progress_comment_id = await _create_start_comment(
         token,
         discussion_id=discussion_id,
@@ -1224,11 +1243,17 @@ async def process_routed_comment_event(
     if final_status.get("status") == "Done" and not final_status.get("error"):
         public_status = _with_public_chart_urls(final_status, runtime)
         public_trail_url = _public_signalpilot_url(public_status.get("trailUrl") or start_trail_url, runtime)
+        delivery_user_id = routed.installation.user_id or route.analysis_user_id
+        delivery_api_key = await delivery_api_key_for_user(
+            db,
+            org_id=routed.installation.org_id,
+            user_id=delivery_user_id,
+        )
         try:
             packet = await load_delivery_packet(
                 db,
                 org_id=routed.installation.org_id,
-                user_id=routed.installation.user_id or route.analysis_user_id,
+                user_id=delivery_user_id,
                 thread_id=f"session-{route.request_id}",
                 user_request=prompt,
                 status_payload=public_status,
@@ -1243,7 +1268,7 @@ async def process_routed_comment_event(
                 trail_url=public_trail_url,
                 thread_status="done",
             )
-        delivery = await render_delivery(packet)
+        delivery = await render_delivery(packet, api_key=delivery_api_key)
         rendered_status = delivery_result_to_status(delivery, packet, base_status=public_status)
         uploaded_status = await _upload_chart_images_to_notion(token, rendered_status, runtime)
         final_status_for_notion = _with_public_chart_urls(uploaded_status, runtime)
@@ -1252,9 +1277,16 @@ async def process_routed_comment_event(
             request_page_id,
             {
                 "Status": {"rich_text": _rich_text("Done")},
-                "Trail URL": {"url": _public_signalpilot_url(final_status_for_notion.get("trailUrl") or start_trail_url, runtime) or None},
+                "Trail URL": {
+                    "url": _public_signalpilot_url(final_status_for_notion.get("trailUrl") or start_trail_url, runtime)
+                    or None
+                },
                 "Confidence score": {"number": final_status_for_notion.get("confidenceScore")},
-                "Summary": {"rich_text": _rich_text(final_status_for_notion.get("summary") or final_status_for_notion.get("finalAnswer") or "")},
+                "Summary": {
+                    "rich_text": _rich_text(
+                        final_status_for_notion.get("summary") or final_status_for_notion.get("finalAnswer") or ""
+                    )
+                },
             },
         )
         await _create_final_comment(

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -29,6 +29,7 @@ from gateway.analysis_delivery import (
     AnalysisPreflightKind,
     SlackTraceProgressReporter,
     classify_analysis_request,
+    delivery_api_key_for_user,
     delivery_result_to_status,
     load_delivery_packet,
     load_delivery_packet_from_events,
@@ -157,7 +158,9 @@ class SlackRequest:
 
 
 class SlackApiClient:
-    def __init__(self, bot_token: str, app_token: str | None = None, *, http_client: httpx.AsyncClient | None = None) -> None:
+    def __init__(
+        self, bot_token: str, app_token: str | None = None, *, http_client: httpx.AsyncClient | None = None
+    ) -> None:
         self.bot_token = bot_token
         self.app_token = app_token
         self._owned_client = http_client is None
@@ -167,7 +170,9 @@ class SlackApiClient:
         if self._owned_client:
             await self._client.aclose()
 
-    async def _api(self, method: str, payload: dict[str, Any] | None = None, *, token: str | None = None) -> dict[str, Any]:
+    async def _api(
+        self, method: str, payload: dict[str, Any] | None = None, *, token: str | None = None
+    ) -> dict[str, Any]:
         response = await self._client.post(
             f"{SLACK_API_BASE}/{method}",
             headers={"Authorization": f"Bearer {token or self.bot_token}", "Content-Type": "application/json"},
@@ -504,8 +509,14 @@ class SlackPoCWorker:
                     status=status,
                 )
             public_status = notebook_analysis._with_public_chart_urls(status, runtime)
+            delivery_api_key = ""
             try:
                 async with self.session_factory() as db:
+                    delivery_api_key = await delivery_api_key_for_user(
+                        db,
+                        org_id=self.config.org_id,
+                        user_id=analysis_user_id,
+                    )
                     packet = await load_delivery_packet(
                         db,
                         org_id=self.config.org_id,
@@ -524,7 +535,7 @@ class SlackPoCWorker:
                     trail_url=trail_url or "",
                     thread_status="done",
                 )
-            delivery = await render_delivery(packet)
+            delivery = await render_delivery(packet, api_key=delivery_api_key)
             slack_status = delivery_result_to_status(delivery, packet, base_status=public_status)
             await self._update_or_post_result_message(
                 channel=request.channel_id,
@@ -576,7 +587,9 @@ class SlackPoCWorker:
         try:
             await self.slack.remove_reaction(channel=request.channel_id, timestamp=request.event_ts, name=name)
         except Exception as exc:
-            LOGGER.info("Could not remove Slack reaction=%s event_id=%s: %s", name, request.event_id, exc, exc_info=True)
+            LOGGER.info(
+                "Could not remove Slack reaction=%s event_id=%s: %s", name, request.event_id, exc, exc_info=True
+            )
 
     async def _mark_request_done(self, request: SlackRequest) -> None:
         await self._add_request_reaction(request, SLACK_DONE_REACTION)
@@ -1114,7 +1127,9 @@ def load_config_from_env() -> SlackPoCConfig:
         bot_user_id=os.getenv("SLACK_BOT_USER_ID") or None,
         org_id=os.getenv("SLACK_POC_ORG_ID") or os.getenv("SIGNALPILOT_SLACK_ORG_ID") or "slack-poc",
         user_id=os.getenv("SLACK_POC_USER_ID") or os.getenv("SIGNALPILOT_SLACK_USER_ID") or None,
-        default_project_id=os.getenv("SLACK_POC_DEFAULT_PROJECT_ID") or os.getenv("SIGNALPILOT_SLACK_DEFAULT_PROJECT_ID") or None,
+        default_project_id=os.getenv("SLACK_POC_DEFAULT_PROJECT_ID")
+        or os.getenv("SIGNALPILOT_SLACK_DEFAULT_PROJECT_ID")
+        or None,
         default_branch=os.getenv("SLACK_POC_DEFAULT_BRANCH") or "main",
         analysis_branch_mode=os.getenv("SLACK_POC_ANALYSIS_BRANCH_MODE") or "per_request",
         channel_defaults=_channel_defaults_from_env(),
@@ -1137,7 +1152,9 @@ def load_http_config_from_env() -> SlackPoCConfig:
         bot_user_id=os.getenv("SLACK_BOT_USER_ID") or None,
         org_id=os.getenv("SLACK_POC_ORG_ID") or os.getenv("SIGNALPILOT_SLACK_ORG_ID") or "slack-poc",
         user_id=os.getenv("SLACK_POC_USER_ID") or os.getenv("SIGNALPILOT_SLACK_USER_ID") or None,
-        default_project_id=os.getenv("SLACK_POC_DEFAULT_PROJECT_ID") or os.getenv("SIGNALPILOT_SLACK_DEFAULT_PROJECT_ID") or None,
+        default_project_id=os.getenv("SLACK_POC_DEFAULT_PROJECT_ID")
+        or os.getenv("SIGNALPILOT_SLACK_DEFAULT_PROJECT_ID")
+        or None,
         default_branch=os.getenv("SLACK_POC_DEFAULT_BRANCH") or "main",
         analysis_branch_mode=os.getenv("SLACK_POC_ANALYSIS_BRANCH_MODE") or "per_request",
         channel_defaults=_channel_defaults_from_env(),
@@ -1155,7 +1172,9 @@ def _apply_local_runtime_defaults() -> None:
     if os.getenv("SP_DEPLOYMENT_MODE", "").lower() == "cloud":
         return
     os.environ.setdefault("SP_DEPLOYMENT_MODE", "local")
-    os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://signalpilot:changeme_dev_only@localhost:5601/signalpilot")
+    os.environ.setdefault(
+        "DATABASE_URL", "postgresql+asyncpg://signalpilot:changeme_dev_only@localhost:5601/signalpilot"
+    )
     os.environ.setdefault("SP_NOTEBOOK_DIRECT_URL", "http://localhost:2718")
     os.environ.setdefault("SIGNALPILOT_NOTEBOOK_PUBLIC_URL", "http://localhost:3200/notebook")
     os.environ.setdefault("SP_WEB_URL", "http://localhost:3200")

--- a/signalpilot/gateway/tests/test_analysis_delivery.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery.py
@@ -10,12 +10,14 @@ from gateway.analysis_delivery import (
     AnalysisPreflightKind,
     DeliveryRenderer,
     classify_analysis_request,
+    delivery_api_key_for_user,
     delivery_result_to_status,
     load_delivery_packet,
     load_delivery_packet_from_events,
     render_slack_final_message,
     render_slack_progress_message,
 )
+from gateway.analysis_delivery import credentials as credentials_module
 from gateway.analysis_delivery import trace_loader as trace_loader_module
 from gateway.analysis_delivery.renderer import fallback_delivery
 from gateway.trace_markers import redact_trace_control_markers
@@ -210,6 +212,30 @@ def test_slack_progress_waits_for_worker_plan_then_uses_exact_steps() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delivery_api_key_for_user_reads_stored_account_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_user_anthropic_key = AsyncMock(return_value="sk-ant-user")
+    monkeypatch.setattr(credentials_module.user_secrets_store, "get_user_anthropic_key", get_user_anthropic_key)
+
+    api_key = await delivery_api_key_for_user(AsyncMock(), org_id="org-1", user_id="user-1")
+
+    assert api_key == "sk-ant-user"
+    get_user_anthropic_key.assert_awaited_once()
+    assert get_user_anthropic_key.await_args.args[1:] == ("org-1", "user-1")
+
+
+@pytest.mark.asyncio
+async def test_delivery_api_key_for_user_disables_model_delivery_without_account_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_user_anthropic_key = AsyncMock(return_value=None)
+    monkeypatch.setattr(credentials_module.user_secrets_store, "get_user_anthropic_key", get_user_anthropic_key)
+
+    api_key = await delivery_api_key_for_user(AsyncMock(), org_id="org-1", user_id="user-1")
+
+    assert api_key == ""
+
+
+@pytest.mark.asyncio
 async def test_delivery_renderer_falls_back_to_final_statement_without_model() -> None:
     packet = load_delivery_packet_from_events(
         [
@@ -237,6 +263,36 @@ async def test_delivery_renderer_falls_back_to_final_statement_without_model() -
     assert "- Revenue increased." in slack_text
     assert "*Confidence:* 0.8" in slack_text
     assert "<https://app.test/projects?file=analysis.py|Open authenticated notebook>" in slack_text
+
+
+@pytest.mark.asyncio
+async def test_delivery_renderer_empty_api_key_ignores_server_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "server-ant-key")
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    'FINAL_STATEMENT: {"statement":"Revenue increased.",'
+                    '"confidenceScore":0.8,"caveats":[],"handoffNotes":[]}'
+                ),
+            }
+        ],
+        status_payload={"status": "Done"},
+    )
+
+    class FailingClient:
+        async def post(self, *_args, **_kwargs):
+            raise AssertionError("server env key should not trigger model rendering")
+
+    delivery = await DeliveryRenderer(
+        model="claude-haiku-test",
+        api_key="",
+        http_client=FailingClient(),
+    ).render(packet)  # type: ignore[arg-type]
+
+    assert delivery.slack_message == "- Revenue increased."
 
 
 @pytest.mark.asyncio
@@ -336,7 +392,9 @@ async def test_delivery_renderer_preserves_packet_charts_when_model_returns_empt
             del headers, json
             return FakeResponse()
 
-    delivery = await DeliveryRenderer(model="claude-haiku-test", api_key="test-key", http_client=FakeClient()).render(packet)  # type: ignore[arg-type]
+    delivery = await DeliveryRenderer(model="claude-haiku-test", api_key="test-key", http_client=FakeClient()).render(
+        packet
+    )  # type: ignore[arg-type]
     status = delivery_result_to_status(delivery, packet)
 
     assert [chart["title"] for chart in delivery.notion_charts] == ["Revenue trend", "Margin ranking"]

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gateway.analysis_delivery import DeliveryPacket, WorkerPlan, WorkerProgress
+from gateway.analysis_delivery import DeliveryPacket, DeliveryResult, WorkerPlan, WorkerProgress
 from gateway.db.models import NotionInstallation, NotionInstallationConfig
 from gateway.notebooks.session_service import NotebookRuntime
 from gateway.notion import analysis as notion_analysis
@@ -240,7 +240,9 @@ async def test_missing_default_project_posts_setup_required_failure(monkeypatch:
 
 
 @pytest.mark.asyncio
-async def test_notion_preflight_greeting_posts_direct_reply_without_request_page(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_notion_preflight_greeting_posts_direct_reply_without_request_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[str] = []
     install = NotionInstallation(
         id="install-1",
@@ -347,6 +349,147 @@ async def test_notion_trace_progress_updates_comment_only(monkeypatch: pytest.Mo
     assert "Loading:" not in comment_text
 
 
+@pytest.mark.asyncio
+async def test_process_routed_comment_event_uses_user_secret_for_delivery_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    render_api_keys: list[str | None] = []
+    install = NotionInstallation(
+        id="install-1",
+        org_id="org-1",
+        user_id="user-1",
+        workspace_id="workspace-1",
+        bot_id="bot-1",
+        access_token_enc=b"encrypted",
+        status="active",
+    )
+    config = NotionInstallationConfig(
+        installation_id="install-1",
+        parent_page_id=None,
+        trigger_page_id="trigger-1",
+        requests_data_source_id="ds-1",
+        requests_database_page_id="db-1",
+        enabled=True,
+        default_project_id="project-1",
+        default_branch="main",
+        analysis_branch_mode="per_request",
+    )
+    routed = RoutedNotionInstallation(installation=install, config=config, access_token="token-1")
+    db = MagicMock()
+    payload = {
+        "id": "event-1",
+        "entity": {"id": "comment-1"},
+        "data": {"page_id": "page-1"},
+        "authors": [{"id": "notion-user-1", "type": "person"}],
+    }
+    comment = {"id": "comment-1", "discussion_id": "discussion-1", "rich_text": []}
+    runtime = NotebookRuntime(
+        session_id="runtime-1",
+        internal_base_url="http://notebook.internal/notebook/runtime-1",
+        public_base_url="https://app.test/notebook/runtime-1",
+    )
+    route = notion_analysis.AnalysisRoute(
+        source="notion",
+        request_id="notion-req-1",
+        project_id="project-1",
+        branch="analysis/notion/notion-req-1-revenue",
+        default_branch="main",
+        analysis_user_id="analysis:notion:notion-req-1",
+    )
+
+    async def list_comments(*args, **kwargs):
+        return [comment]
+
+    async def query_request_page_by_source(*args, **kwargs):
+        return None
+
+    async def create_request_page(*args, **kwargs):
+        return {"id": "request-page-1", "url": "https://notion.test/request-page-1"}
+
+    async def update_page_properties(*args, **kwargs):
+        return None
+
+    async def append_page_blocks(*args, **kwargs):
+        return None
+
+    async def create_comment(*args, **kwargs):
+        return {"id": "progress-comment-1"}
+
+    async def delete_comment(*args, **kwargs):
+        return None
+
+    async def resolve_route(*args, **kwargs):
+        return route
+
+    async def ensure_runtime(*args, **kwargs):
+        return runtime
+
+    async def noop_async(*args, **kwargs):
+        return None
+
+    async def call_notebook(*args, **kwargs):
+        return {"requestId": "notion-req-1", "trailUrl": "https://app.test/projects?file=analysis.py"}
+
+    async def poll_analysis(*args, **kwargs):
+        return {
+            "status": "Done",
+            "requestId": "notion-req-1",
+            "sessionId": "session-notion-req-1",
+            "summary": "Done",
+        }
+
+    async def load_delivery_packet(*args, **kwargs):
+        assert kwargs["user_id"] == "user-1"
+        return DeliveryPacket(user_request="Analyze revenue by month", status="done")
+
+    async def delivery_api_key_for_user(*args, **kwargs):
+        assert args == (db,)
+        assert kwargs == {"org_id": "org-1", "user_id": "user-1"}
+        return "sk-ant-user"
+
+    async def render_delivery(packet, *, api_key=None, renderer=None):
+        del packet, renderer
+        render_api_keys.append(api_key)
+        return DeliveryResult(
+            summary="Done",
+            slack_message="- Done",
+            notion_comment="- Done",
+            final_answer="- Done",
+            confidence_score=1.0,
+        )
+
+    async def upload_chart_images_to_notion(_token, status, _runtime):
+        return status
+
+    monkeypatch.setattr(notion_client, "list_comments", list_comments)
+    monkeypatch.setattr(notion_client, "query_request_page_by_source", query_request_page_by_source)
+    monkeypatch.setattr(notion_client, "create_request_page", create_request_page)
+    monkeypatch.setattr(notion_client, "update_page_properties", update_page_properties)
+    monkeypatch.setattr(notion_client, "append_page_blocks", append_page_blocks)
+    monkeypatch.setattr(notion_client, "create_comment", create_comment)
+    monkeypatch.setattr(notion_client, "delete_comment", delete_comment)
+    monkeypatch.setattr(notion_client, "is_bot_comment", lambda _comment: False)
+    monkeypatch.setattr(notion_client, "comment_has_page_mention", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "Analyze revenue by month")
+    monkeypatch.setattr(notion_analysis, "resolve_configured_analysis_route", resolve_route)
+    monkeypatch.setattr(notion_analysis, "ensure_analysis_notebook_session", ensure_runtime)
+    monkeypatch.setattr(notion_analysis, "upsert_analysis_trail_seed", noop_async)
+    monkeypatch.setattr(notion_analysis, "upsert_analysis_trail_from_status", noop_async)
+    monkeypatch.setattr(notion_analysis, "update_analysis_trail_from_status", noop_async)
+    monkeypatch.setattr(notion_analysis, "_call_notebook", call_notebook)
+    monkeypatch.setattr(notion_analysis, "_poll_analysis", poll_analysis)
+    monkeypatch.setattr(notion_analysis, "_with_public_chart_urls", lambda status, runtime: status)
+    monkeypatch.setattr(notion_analysis, "_upload_chart_images_to_notion", upload_chart_images_to_notion)
+    monkeypatch.setattr(notion_analysis, "load_delivery_packet", load_delivery_packet)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key_for_user)
+    monkeypatch.setattr(notion_analysis, "render_delivery", render_delivery)
+
+    result = await notion_analysis.process_routed_comment_event(routed, payload, db=db)
+
+    assert result.status == "processed"
+    assert render_api_keys == ["sk-ant-user"]
+
+
 def test_public_signalpilot_url_preserves_durable_notebooks_trail_url() -> None:
     runtime = NotebookRuntime(
         session_id="runtime-session-1",
@@ -379,8 +522,7 @@ def test_public_signalpilot_url_rewrites_internal_notebooks_trail_to_app_origin(
     rewritten = notion_analysis._public_signalpilot_url(wrong_url, runtime)
 
     assert (
-        rewritten
-        == "https://app.signalpilot.ai/projects?"
+        rewritten == "https://app.signalpilot.ai/projects?"
         "file=signalpilot-notion-analyses/do-an-analysis-of-my-db-9a50e7.py"
         "&session_id=session-notion-97728a45b49a50e7"
     )
@@ -403,8 +545,7 @@ def test_public_signalpilot_url_rewrites_relative_notebooks_trail_to_app_origin(
         rewritten = notion_analysis._public_signalpilot_url(url, runtime)
 
         assert (
-            rewritten
-            == "https://app.signalpilot.ai/projects?"
+            rewritten == "https://app.signalpilot.ai/projects?"
             "file=signalpilot-notion-analyses/analysis.py&session_id=session-notion-abc123"
         )
 
@@ -417,19 +558,12 @@ def test_public_signalpilot_url_rewrites_runtime_urls_to_public_runtime_proxy() 
     )
 
     rewritten = notion_analysis._public_signalpilot_url(
-        "http://10.0.0.5:2718/notebook/runtime-session-1/"
-        "api/notion-analysis/chart/notion-1/chart.png",
+        "http://10.0.0.5:2718/notebook/runtime-session-1/api/notion-analysis/chart/notion-1/chart.png",
         runtime,
     )
 
-    expected = (
-        "https://app.signalpilot.ai/notebook/runtime-session-1/"
-        "api/notion-analysis/chart/notion-1/chart.png"
-    )
-    assert (
-        rewritten
-        == expected
-    )
+    expected = "https://app.signalpilot.ai/notebook/runtime-session-1/api/notion-analysis/chart/notion-1/chart.png"
+    assert rewritten == expected
 
 
 def test_final_comment_rich_text_formats_bullets_links_and_code() -> None:
@@ -447,7 +581,9 @@ def test_final_comment_rich_text_formats_bullets_links_and_code() -> None:
         part.get("text", {}).get("content") == "orders" and part.get("annotations", {}).get("code") is True
         for part in rich_text
     )
-    assert any(part.get("text", {}).get("link", {}).get("url") == "https://charts.test/revenue.png" for part in rich_text)
+    assert any(
+        part.get("text", {}).get("link", {}).get("url") == "https://charts.test/revenue.png" for part in rich_text
+    )
     assert any(part.get("text", {}).get("link", {}).get("url") == request_url for part in rich_text)
 
 
@@ -467,8 +603,7 @@ def test_final_comment_rich_text_avoids_duplicate_bullet_markers_and_formats_bol
     assert content.startswith("• MapleCloud Software")
     assert "\n• Northstar Logistics" in content
     assert any(
-        part.get("text", {}).get("content") == "MapleCloud Software"
-        and part.get("annotations", {}).get("bold") is True
+        part.get("text", {}).get("content") == "MapleCloud Software" and part.get("annotations", {}).get("bold") is True
         for part in rich_text
     )
 
@@ -477,9 +612,7 @@ def test_final_comment_rich_text_formats_italic_and_strikethrough() -> None:
     rich_text = notion_analysis._final_comment_rich_text(
         {
             "notionComment": (
-                "- *Expansion revenue* improved.\n"
-                "- _Pipeline coverage_ strengthened.\n"
-                "- ~~Legacy score~~ was removed."
+                "- *Expansion revenue* improved.\n- _Pipeline coverage_ strengthened.\n- ~~Legacy score~~ was removed."
             )
         },
         "https://notion.test/request-page-1",
@@ -490,13 +623,11 @@ def test_final_comment_rich_text_formats_italic_and_strikethrough() -> None:
     assert "_Pipeline coverage_" not in content
     assert "~~Legacy score~~" not in content
     assert any(
-        part.get("text", {}).get("content") == "Expansion revenue"
-        and part.get("annotations", {}).get("italic") is True
+        part.get("text", {}).get("content") == "Expansion revenue" and part.get("annotations", {}).get("italic") is True
         for part in rich_text
     )
     assert any(
-        part.get("text", {}).get("content") == "Pipeline coverage"
-        and part.get("annotations", {}).get("italic") is True
+        part.get("text", {}).get("content") == "Pipeline coverage" and part.get("annotations", {}).get("italic") is True
         for part in rich_text
     )
     assert any(
@@ -607,8 +738,7 @@ def test_analysis_detail_blocks_prepend_uploaded_chart_images() -> None:
     assert blocks[1]["image"]["type"] == "file_upload"
     assert blocks[1]["image"]["file_upload"]["id"] == "upload-1"
     assert any(
-        part.get("text", {}).get("content") == "MapleCloud"
-        and part.get("annotations", {}).get("bold") is True
+        part.get("text", {}).get("content") == "MapleCloud" and part.get("annotations", {}).get("bold") is True
         for part in blocks[1]["image"]["caption"]
     )
 
@@ -736,10 +866,7 @@ async def test_create_final_comment_deletes_progress_comment_then_posts_attached
             "create",
             {
                 "text": (
-                    "• MapleCloud leads.\n\n"
-                    "Request page: request details\n\n"
-                    "Charts attached:\n"
-                    "• Momentum ranking"
+                    "• MapleCloud leads.\n\nRequest page: request details\n\nCharts attached:\n• Momentum ranking"
                 ),
                 "attachments": [
                     {
@@ -782,9 +909,7 @@ def test_analysis_detail_blocks_render_markdown_as_notion_blocks() -> None:
     blocks = notion_analysis._analysis_detail_blocks(status)
     block_types = [block["type"] for block in blocks]
     block_text = "".join(
-        rich_text.get("text", {}).get("content", "")
-        for block in blocks
-        for rich_text in _block_rich_text(block)
+        rich_text.get("text", {}).get("content", "") for block in blocks for rich_text in _block_rich_text(block)
     )
 
     assert block_types.count("heading_2") == 3
@@ -836,7 +961,8 @@ def test_analysis_detail_blocks_render_markdown_tables_and_bold_text() -> None:
 
     blocks = notion_analysis._analysis_detail_blocks(status)
     detail = next(
-        block for block in blocks
+        block
+        for block in blocks
         if block["type"] == "heading_2" and block["heading_2"]["rich_text"][0]["text"]["content"] == "Detailed Research"
     )
     children = detail["heading_2"]["children"]

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from gateway.analysis_delivery import DeliveryResult
 from gateway.db.models import SlackInstallation, SlackInstallationConfig
 from gateway.slack_poc import worker as worker_module
 from gateway.slack_poc.progress import COMPLETING_PROGRESS_TEXT, INITIAL_PROGRESS_TEXT
@@ -242,6 +243,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     events: list[str] = []
     progress_seen = asyncio.Event()
     slack_events: list[tuple[str, str]] = []
+    render_api_keys: list[str | None] = []
 
     class SessionContext:
         async def __aenter__(self):
@@ -313,6 +315,25 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     monkeypatch.setattr(worker_module.notebook_analysis, "_poll_analysis", poll_analysis)
     monkeypatch.setattr(worker_module.notebook_analysis, "_public_signalpilot_url", lambda url, runtime: url)
     monkeypatch.setattr(worker_module.notebook_analysis, "_with_public_chart_urls", lambda status, runtime: status)
+
+    async def delivery_api_key_for_user(*args, **kwargs):
+        assert args == ("db",)
+        assert kwargs == {"org_id": "org-1", "user_id": "user-1"}
+        return "sk-ant-user"
+
+    async def render_delivery(packet, *, api_key=None, renderer=None):
+        del packet, renderer
+        render_api_keys.append(api_key)
+        return DeliveryResult(
+            summary="Done",
+            slack_message="- Done",
+            notion_comment="- Done",
+            final_answer="- Done",
+            confidence_score=1.0,
+        )
+
+    monkeypatch.setattr(worker_module, "delivery_api_key_for_user", delivery_api_key_for_user)
+    monkeypatch.setattr(worker_module, "render_delivery", render_delivery)
 
     slack = AsyncMock(spec=SlackApiClient)
     slack.thread_messages.return_value = []
@@ -398,6 +419,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     assert slack_events[-1][0] == "update"
     assert "*Analysis complete*" in slack_events[-1][1]
     assert slack.post_message.await_count == 1
+    assert render_api_keys == ["sk-ant-user"]
     slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
     slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="white_check_mark")
     slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
@@ -482,9 +504,7 @@ async def test_worker_uploads_chart_images_as_slack_thread_files(monkeypatch: py
         AsyncMock(),
     )
 
-    slack.fetch_bytes.assert_awaited_once_with(
-        "http://notebook.test/api/notion-analysis/chart/notion-1/chart.png"
-    )
+    slack.fetch_bytes.assert_awaited_once_with("http://notebook.test/api/notion-analysis/chart/notion-1/chart.png")
     slack.upload_file.assert_awaited_once_with(
         channel="C1",
         thread_ts="1.0",


### PR DESCRIPTION
## Summary
- Resolve the account owner's stored Anthropic key for Slack and Notion analysis delivery rendering.
- Pass an explicit delivery API key into the shared renderer so missing account keys use deterministic fallback instead of server `ANTHROPIC_API_KEY`.
- Add focused coverage for the credential boundary and Slack/Notion delivery call sites.

## Tests
- `cd signalpilot/gateway && .venv/bin/python -m pytest tests/test_analysis_delivery.py tests/test_slack_poc_worker.py tests/test_notion_analysis.py -q`
- `cd signalpilot/gateway && .venv/bin/python -m ruff check gateway/analysis_delivery/credentials.py gateway/analysis_delivery/renderer.py gateway/analysis_delivery/__init__.py gateway/slack_poc/worker.py gateway/notion/analysis.py tests/test_analysis_delivery.py tests/test_slack_poc_worker.py tests/test_notion_analysis.py`
- `git diff --check`
