### PR TITLE
Fix generated analysis trail report loading

### DIFF
--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/ws/analysis_trails.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/ws/analysis_trails.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+ANALYSIS_BRANCH_PREFIX = "analysis/"
+ANALYSIS_NOTEBOOK_RELPATH_PREFIXES = {
+    "notion": "notebooks/notion/",
+    "slack": "notebooks/slack/",
+}
+
+
+def is_generated_analysis_trail_notebook(
+    *,
+    project_id: str | None,
+    branch: str | None,
+    file_key: str | None,
+) -> bool:
+    """Return True for project-backed generated Slack/Notion analysis trails."""
+    if not project_id or not branch or not file_key:
+        return False
+    if not branch.startswith(ANALYSIS_BRANCH_PREFIX):
+        return False
+
+    normalized = file_key.replace("\\", "/").lstrip("/")
+    return any(
+        branch.startswith(f"{ANALYSIS_BRANCH_PREFIX}{source}/")
+        and normalized.startswith(prefix)
+        for source, prefix in ANALYSIS_NOTEBOOK_RELPATH_PREFIXES.items()
+    )

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/ws/ws_connection_validator.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/ws/ws_connection_validator.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
 from signalpilot import _loggers
 from signalpilot._server.api.auth import validate_auth
 from signalpilot._server.api.deps import AppState
+from signalpilot._server.api.endpoints.ws.analysis_trails import (
+    is_generated_analysis_trail_notebook,
+)
 from signalpilot._server.codes import WebSocketCodes
 from signalpilot._server.workspace import SpFileKey
 from signalpilot._types.ids import SessionId
@@ -75,6 +78,7 @@ class WebSocketConnectionValidator:
             self.app_state.query_params(FILE_QUERY_PARAM_KEY)
             or self.app_state.session_manager.workspace.get_unique_file_key()
         )
+        requested_file_key = file_key
 
         if file_key is None:
             await self.websocket.close(
@@ -84,8 +88,8 @@ class WebSocketConnectionValidator:
 
         # For cloud projects, resolve relative file_key to absolute synced path
         project_id = self.app_state.query_params("project")
+        branch = self.app_state.query_params("branch") or "main"
         if project_id and file_key and not Path(file_key).is_absolute():
-            branch = self.app_state.query_params("branch") or "main"
             try:
                 from signalpilot._server.files.project_sync import local_project_dir
                 local_dir = local_project_dir(project_id, branch)
@@ -108,6 +112,12 @@ class WebSocketConnectionValidator:
         config = self.app_state.config_manager_at_file(file_key).get_config()
         rtc_enabled = config.get("experimental", {}).get("rtc_v2", False)
         auto_instantiate = config["runtime"]["auto_instantiate"]
+        if is_generated_analysis_trail_notebook(
+            project_id=project_id,
+            branch=branch,
+            file_key=requested_file_key,
+        ):
+            auto_instantiate = False
 
         return ConnectionParams(
             session_id=session_id,

--- a/signalpilot/notebook-server/tests/_server/api/endpoints/test_ws_connection_validator.py
+++ b/signalpilot/notebook-server/tests/_server/api/endpoints/test_ws_connection_validator.py
@@ -1,0 +1,51 @@
+from signalpilot._server.api.endpoints.ws.analysis_trails import (
+    is_generated_analysis_trail_notebook,
+)
+
+
+def test_project_backed_slack_analysis_trail_is_lazy() -> None:
+    assert is_generated_analysis_trail_notebook(
+        project_id="907a47d1-b196-428b-89de-7f4a8b7acc41",
+        branch="analysis/slack/slack-ba96530d8fb3514d-hi",
+        file_key="notebooks/slack/hi-can-you-figure-out-if-our-fin-db.py",
+    )
+
+
+def test_project_backed_notion_analysis_trail_is_lazy() -> None:
+    assert is_generated_analysis_trail_notebook(
+        project_id="907a47d1-b196-428b-89de-7f4a8b7acc41",
+        branch="analysis/notion/notion-ba96530d8fb3514d-hi",
+        file_key="notebooks/notion/hi-can-you-figure-out-if-our-fin-db.py",
+    )
+
+
+def test_regular_project_notebook_keeps_runtime_default() -> None:
+    assert not is_generated_analysis_trail_notebook(
+        project_id="907a47d1-b196-428b-89de-7f4a8b7acc41",
+        branch="main",
+        file_key="notebooks/slack/handwritten-notebook.py",
+    )
+
+
+def test_non_analysis_notebook_under_analysis_branch_keeps_runtime_default() -> None:
+    assert not is_generated_analysis_trail_notebook(
+        project_id="907a47d1-b196-428b-89de-7f4a8b7acc41",
+        branch="analysis/slack/slack-ba96530d8fb3514d-hi",
+        file_key="notebooks/intro.py",
+    )
+
+
+def test_mismatched_analysis_source_keeps_runtime_default() -> None:
+    assert not is_generated_analysis_trail_notebook(
+        project_id="907a47d1-b196-428b-89de-7f4a8b7acc41",
+        branch="analysis/notion/notion-ba96530d8fb3514d-hi",
+        file_key="notebooks/slack/hi-can-you-figure-out-if-our-fin-db.py",
+    )
+
+
+def test_non_project_notebook_keeps_runtime_default() -> None:
+    assert not is_generated_analysis_trail_notebook(
+        project_id=None,
+        branch="analysis/slack/slack-ba96530d8fb3514d-hi",
+        file_key="notebooks/slack/hi-can-you-figure-out-if-our-fin-db.py",
+    )

--- a/signalpilot/web/components/notebook/analysis-trails.ts
+++ b/signalpilot/web/components/notebook/analysis-trails.ts
@@ -1,0 +1,31 @@
+export const ANALYSIS_BRANCH_PREFIX = "analysis/";
+export const ANALYSIS_NOTEBOOK_RELPATH_PREFIXES = {
+  notion: "notebooks/notion/",
+  slack: "notebooks/slack/",
+} as const;
+
+export function isGeneratedAnalysisTrailNotebook({
+  project,
+  branch,
+  file,
+}: {
+  project?: string | null;
+  branch?: string | null;
+  file?: string | null;
+}): boolean {
+  if (!project || !branch || !file) return false;
+  if (!branch.startsWith(ANALYSIS_BRANCH_PREFIX)) return false;
+
+  const normalized = file.replace(/\\/g, "/").replace(/^\/+/, "");
+  return Object.entries(ANALYSIS_NOTEBOOK_RELPATH_PREFIXES).some(
+    ([source, prefix]) =>
+      branch.startsWith(`${ANALYSIS_BRANCH_PREFIX}${source}/`) &&
+      normalized.startsWith(prefix),
+  );
+}
+
+export const ANALYSIS_TRAIL_CONFIG_OVERRIDES = {
+  runtime: {
+    auto_instantiate: false,
+  },
+} as const;

--- a/signalpilot/web/components/notebook/boot-runtime.ts
+++ b/signalpilot/web/components/notebook/boot-runtime.ts
@@ -7,6 +7,7 @@ import {
   isNotionTrailParams,
   notionRequestIdFromSessionId,
 } from "@/core/notion/trail";
+import { isGeneratedAnalysisTrailNotebook } from "./analysis-trails";
 import type { NotebookConfig } from "./notebook-context";
 
 export type BootPhase = "health" | "notion" | "syncing" | "sessions" | "ready";
@@ -269,19 +270,45 @@ export async function bootRuntime(
 
   // ── Phase 5: Fetch notebook static data (file content + session) ──
   const staticData: NotebookStaticData = { filename: config.file, gatewayToken: bootToken ?? "" };
+  const isGeneratedAnalysisTrail = isGeneratedAnalysisTrailNotebook({
+    project: config.project,
+    branch: config.branch,
+    file: config.file,
+  });
 
   if (config.file) {
     try {
-      const detailsResp = await fetch(`${runtimeUrl}/api/files/file_details`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ path: config.file }),
-        signal,
-      });
-      if (detailsResp.ok) {
-        const details = (await detailsResp.json()) as { contents?: string };
-        if (details.contents) {
-          staticData.code = details.contents;
+      if (isGeneratedAnalysisTrail) {
+        const staticResp = await fetch(
+          `${runtimeUrl}/api/notebook/static?file=${encodeURIComponent(config.file)}`,
+          { headers, signal },
+        );
+        if (staticResp.ok) {
+          const payload = (await staticResp.json()) as {
+            code?: string;
+            filename?: string;
+            session?: unknown;
+            notebook?: unknown;
+          };
+          staticData.code = payload.code;
+          staticData.filename = payload.filename || config.file;
+          staticData.session = payload.session;
+          staticData.notebook = payload.notebook;
+        }
+      }
+
+      if (!staticData.code) {
+        const detailsResp = await fetch(`${runtimeUrl}/api/files/file_details`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ path: config.file }),
+          signal,
+        });
+        if (detailsResp.ok) {
+          const details = (await detailsResp.json()) as { contents?: string };
+          if (details.contents) {
+            staticData.code = details.contents;
+          }
         }
       }
     } catch (err) {

--- a/signalpilot/web/components/notebook/notebook-boot.tsx
+++ b/signalpilot/web/components/notebook/notebook-boot.tsx
@@ -11,6 +11,10 @@ import {
   bootRuntime,
   type NotebookStaticData,
 } from "./boot-runtime";
+import {
+  ANALYSIS_TRAIL_CONFIG_OVERRIDES,
+  isGeneratedAnalysisTrailNotebook,
+} from "./analysis-trails";
 
 const PHASE_LABELS: Record<string, string> = {
   health: "starting runtime...",
@@ -139,6 +143,11 @@ export default function NotebookBoot({
   }
 
   const staticData = staticDataRef.current;
+  const isGeneratedAnalysisTrail = isGeneratedAnalysisTrailNotebook({
+    project: config.project,
+    branch: config.branch,
+    file: config.file,
+  });
 
   return (
     <>
@@ -151,6 +160,9 @@ export default function NotebookBoot({
           initialCode: staticData.code,
           session: staticData.session,
           notebook: staticData.notebook,
+          configOverrides: isGeneratedAnalysisTrail
+            ? ANALYSIS_TRAIL_CONFIG_OVERRIDES
+            : undefined,
         }}
         className="h-full"
       />


### PR DESCRIPTION
## Summary
- detect generated Slack/Notion analysis trail notebooks in backend websocket setup and disable autorun for those sessions
- hydrate generated analysis trails from /api/notebook/static before falling back to file contents
- pass a scoped frontend config override so trail reports do not rerun on load

## Verification
- cd signalpilot/notebook-server && .venv/bin/python -m pytest tests/_server/api/endpoints/test_ws_connection_validator.py tests/_server/api/test_notion_analysis_urls.py -q
- cd signalpilot/notebook-server && .venv/bin/python -m py_compile signalpilot/_server/api/endpoints/ws/analysis_trails.py signalpilot/_server/api/endpoints/ws/ws_connection_validator.py

## Notes
- Frontend lint/typecheck tooling was not cleanly runnable locally: next lint treats lint as a project directory, direct ESLint expects eslint.config.*, and bounded tsc timed out without diagnostics.