### PR TITLE
fix: harden Notion deliverable follow-ups

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
@@ -25,6 +25,7 @@ _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT_SECONDS = 240.0
 _DEFAULT_MAX_TOKENS = 20_000
+_DEFAULT_TOOL_LOOP_LIMIT = 8
 _DELIVERABLE_TOOL_NAMES = {"create_dashboard", "create_report", "edit_dashboard", "edit_report"}
 _COMPONENT_LAYOUT_GUARD_ID = "sp-component-layout-guard"
 _COMPONENT_LAYOUT_GUARD = f"""<style id="{_COMPONENT_LAYOUT_GUARD_ID}">
@@ -885,6 +886,7 @@ class HtmlOrchestrator:
         self.model = (model or os.getenv("SIGNALPILOT_ORCHESTRATOR_MODEL") or DEFAULT_DELIVERY_MODEL).strip()
         self.timeout_seconds = _timeout_seconds(timeout_seconds)
         self.max_tokens = _max_tokens()
+        self.tool_loop_limit = _tool_loop_limit()
         self.api_key = api_key if api_key is not None else os.getenv("ANTHROPIC_API_KEY")
         self._http_client = http_client
         self._fetch_snapshot = fetch_snapshot
@@ -929,7 +931,7 @@ class HtmlOrchestrator:
         ]
         fetched_snapshots: dict[str, Any] = {}
         tool_choice = _tool_choice_for_payload(payload)
-        for _ in range(4):
+        for _ in range(self.tool_loop_limit):
             response = await self._anthropic_request(
                 messages,
                 allow_fetch_snapshot=packet is not None,
@@ -949,7 +951,7 @@ class HtmlOrchestrator:
                 raise ValueError("HTML orchestrator did not return a deliverable")
             messages.append({"role": "assistant", "content": content})
             messages.append({"role": "user", "content": tool_results})
-        raise TimeoutError("HTML orchestrator exceeded tool loop limit")
+        raise TimeoutError(f"HTML orchestrator exceeded tool loop limit ({self.tool_loop_limit})")
 
     async def _anthropic_request(
         self,
@@ -1168,6 +1170,16 @@ def _max_tokens() -> int:
         except ValueError:
             LOGGER.warning("Invalid SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS=%r; using default", raw)
     return _DEFAULT_MAX_TOKENS
+
+
+def _tool_loop_limit() -> int:
+    raw = os.getenv("SIGNALPILOT_ORCHESTRATOR_TOOL_LOOP_LIMIT", "").strip()
+    if raw:
+        try:
+            return max(int(raw), 2)
+        except ValueError:
+            LOGGER.warning("Invalid SIGNALPILOT_ORCHESTRATOR_TOOL_LOOP_LIMIT=%r; using default", raw)
+    return _DEFAULT_TOOL_LOOP_LIMIT
 
 
 def _tool_choice_for_payload(payload: dict[str, Any]) -> str | None:

--- a/signalpilot/gateway/gateway/api/notion.py
+++ b/signalpilot/gateway/gateway/api/notion.py
@@ -78,6 +78,13 @@ def _log_notion_webhook_decision(
     )
 
 
+async def _rollback_session_best_effort(session: AsyncSession) -> None:
+    try:
+        await session.rollback()
+    except Exception:
+        logger.debug("Could not roll back Notion webhook session after processor error", exc_info=True)
+
+
 def _notion_oauth_client_id() -> str:
     value = os.getenv("NOTION_OAUTH_CLIENT_ID")
     if not value:
@@ -239,13 +246,14 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
             )
             return
         installation, config, token = record
+        installation_org_id = installation.org_id
         if config is None:
             _log_notion_webhook_decision(
                 "failed",
                 event_id=event_id,
                 payload=payload,
                 installation_id=installation_id,
-                org_id=installation.org_id,
+                org_id=installation_org_id,
                 reason="installation_not_provisioned",
                 level=logging.WARNING,
             )
@@ -254,7 +262,7 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
                 event_id,
                 status="failed",
                 installation_id=installation_id,
-                org_id=installation.org_id,
+                org_id=installation_org_id,
                 error="Notion installation is not provisioned",
                 processed=True,
             )
@@ -268,16 +276,17 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
                 "Notion webhook processing failed: event_id=%s installation_id=%s org_id=%s error=%s",
                 event_id,
                 installation_id,
-                installation.org_id,
+                installation_org_id,
                 error,
                 exc_info=True,
             )
+            await _rollback_session_best_effort(session)
             await notion_store.record_webhook_delivery(
                 session,
                 event_id,
                 status="failed",
                 installation_id=installation_id,
-                org_id=installation.org_id,
+                org_id=installation_org_id,
                 error=error[:1000],
                 processed=True,
             )
@@ -287,16 +296,17 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
                 "Notion webhook processing failed: event_id=%s installation_id=%s org_id=%s error=%s",
                 event_id,
                 installation_id,
-                installation.org_id,
+                installation_org_id,
                 str(exc)[:500],
                 exc_info=True,
             )
+            await _rollback_session_best_effort(session)
             await notion_store.record_webhook_delivery(
                 session,
                 event_id,
                 status="failed",
                 installation_id=installation_id,
-                org_id=installation.org_id,
+                org_id=installation_org_id,
                 error=str(exc)[:1000],
                 processed=True,
             )
@@ -307,7 +317,7 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
                 event_id=event_id,
                 payload=payload,
                 installation_id=installation_id,
-                org_id=installation.org_id,
+                org_id=installation_org_id,
                 reason=result.reason or "processor_ignored",
             )
             await notion_store.record_webhook_delivery(
@@ -315,7 +325,7 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
                 event_id,
                 status="ignored",
                 installation_id=installation_id,
-                org_id=installation.org_id,
+                org_id=installation_org_id,
                 error=result.reason,
                 processed=True,
             )
@@ -325,7 +335,7 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
             event_id=event_id,
             payload=payload,
             installation_id=installation_id,
-            org_id=installation.org_id,
+            org_id=installation_org_id,
             reason="processor_completed",
         )
         await notion_store.record_webhook_delivery(
@@ -333,7 +343,7 @@ async def _process_notion_event_task(event_id: str, installation_id: str, payloa
             event_id,
             status="processed",
             installation_id=installation_id,
-            org_id=installation.org_id,
+            org_id=installation_org_id,
             processed=True,
         )
 

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 import logging
 import os
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import NAMESPACE_URL, uuid4, uuid5
@@ -876,6 +878,17 @@ def _existing_report_payload(report: Any) -> dict[str, Any]:
     }
 
 
+def _freeze_deliverable_context(context: Any) -> Any:
+    return SimpleNamespace(
+        project_id=getattr(context, "project_id", None),
+        branch=getattr(context, "branch", None),
+        base_notebook_code=getattr(context, "base_notebook_code", None),
+        base_chat_events=getattr(context, "base_chat_events", None),
+        base_final_packet=getattr(context, "base_final_packet", None),
+        base_notebook_path=getattr(context, "base_notebook_path", None),
+    )
+
+
 def _packet_from_status(prompt: str, status: dict[str, Any], trail_url: str = "") -> DeliveryPacket:
     return load_delivery_packet_from_events(
         [],
@@ -1310,6 +1323,38 @@ async def _comment_deliverable_followup(
     )
 
 
+async def _release_db_session(db: AsyncSession) -> None:
+    """End an idle transaction before long external work can outlive its DB connection."""
+    rollback = getattr(db, "rollback", None)
+    if rollback is None:
+        return
+    try:
+        result = rollback()
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        logger.debug("Could not release DB session before external Notion deliverable work", exc_info=True)
+
+
+async def _mark_deliverable_update_failed_best_effort(
+    db: AsyncSession,
+    *,
+    update_id: str | None,
+    deliverable_id: str,
+    error: str,
+) -> None:
+    try:
+        await notion_store.mark_deliverable_update_failed(
+            db,
+            update_id=update_id,
+            deliverable_id=deliverable_id,
+            error=error,
+        )
+    except Exception:
+        logger.warning("Could not mark Notion deliverable update failed", exc_info=True)
+        await _release_db_session(db)
+
+
 def _followup_refresh_route(context: Any, ephemeral_run_id: str) -> AnalysisRoute:
     project_id = _text(getattr(context, "project_id", None))
     branch = _text(getattr(context, "branch", None)) or "main"
@@ -1351,7 +1396,8 @@ async def _load_refresh_delivery_packet(
 async def _run_ephemeral_deliverable_refresh(
     *,
     db: AsyncSession,
-    routed: RoutedNotionInstallation,
+    org_id: str,
+    user_id: str | None,
     context: Any,
     deliverable_id: str,
     ephemeral_run_id: str,
@@ -1363,18 +1409,19 @@ async def _run_ephemeral_deliverable_refresh(
         raise RuntimeError("Refresh context is missing project_id; rebuild the deliverable once before refreshing.")
     runtime = await ensure_analysis_notebook_session(
         db,
-        org_id=routed.installation.org_id,
+        org_id=org_id,
         source=route.source,
         request_id=route.request_id,
         project_id=route.project_id,
         branch=route.branch,
-        credential_user_id=routed.installation.user_id,
+        credential_user_id=user_id,
     )
+    await _release_db_session(db)
     start = await _call_notebook(
         runtime,
         "/api/notion-analysis/refresh",
-        routed.installation.org_id,
-        routed.installation.user_id,
+        org_id,
+        user_id,
         {
             "method": "POST",
             "json": {
@@ -1397,8 +1444,8 @@ async def _run_ephemeral_deliverable_refresh(
     status = await _poll_analysis(
         str(start.get("requestId") or ephemeral_run_id),
         runtime,
-        routed.installation.org_id,
-        routed.installation.user_id,
+        org_id,
+        user_id,
         route,
     )
     if status.get("status") != "Done" or status.get("error"):
@@ -1407,13 +1454,14 @@ async def _run_ephemeral_deliverable_refresh(
     trail_url = _public_signalpilot_url(public_status.get("trailUrl") or "", runtime)
     packet = await _load_refresh_delivery_packet(
         db,
-        org_id=routed.installation.org_id,
-        user_id=routed.installation.user_id or route.analysis_user_id,
+        org_id=org_id,
+        user_id=user_id or route.analysis_user_id,
         thread_id=f"session-{ephemeral_run_id}",
         prompt=data_instruction,
         status=public_status,
         trail_url=trail_url,
     )
+    await _release_db_session(db)
     return packet, runtime
 
 
@@ -1426,6 +1474,13 @@ async def _process_deliverable_followup(
     discussion_id: str,
     prompt: str,
 ) -> NotionCommentProcessResult:
+    org_id = routed.installation.org_id
+    user_id = routed.installation.user_id
+    deliverable_id = deliverable.id
+    report_id = deliverable.report_id
+    embed_block_id = deliverable.embed_block_id
+    file_upload_id = getattr(deliverable, "file_upload_id", None)
+
     plan = plan_deliverable_followup(prompt)
     if plan.mode == "clarify":
         await _comment_deliverable_followup(
@@ -1437,8 +1492,8 @@ async def _process_deliverable_followup(
 
     report = await reports_store.get_report(
         db,
-        org_id=routed.installation.org_id,
-        report_id=deliverable.report_id,
+        org_id=org_id,
+        report_id=report_id,
     )
     if report is None:
         await _comment_deliverable_followup(
@@ -1447,14 +1502,14 @@ async def _process_deliverable_followup(
             "I found this dashboard/report block, but its saved SignalPilot report is missing.",
         )
         return NotionCommentProcessResult(status="processed")
-    if not deliverable.embed_block_id:
+    if not embed_block_id:
         await _comment_deliverable_followup(
             token,
             discussion_id,
             "I can edit saved reports, but this older deliverable does not have a replaceable Notion embed block.",
         )
         return NotionCommentProcessResult(status="processed")
-    if not getattr(deliverable, "file_upload_id", None):
+    if not file_upload_id:
         await _comment_deliverable_followup(
             token,
             discussion_id,
@@ -1466,17 +1521,19 @@ async def _process_deliverable_followup(
         )
         return NotionCommentProcessResult(status="processed")
 
-    theme = await _org_deliverable_theme(db, routed.installation.org_id)
+    existing_report = _existing_report_payload(report)
+    report_data_json = report.data_json
+    theme = await _org_deliverable_theme(db, org_id)
     ephemeral_run_id = f"notion-refresh-{uuid4().hex[:16]}" if plan.requires_ephemeral_run else None
     update = await notion_store.create_deliverable_update(
         db,
-        deliverable_id=deliverable.id,
-        org_id=routed.installation.org_id,
+        deliverable_id=deliverable_id,
+        org_id=org_id,
         mode=plan.mode,
         prompt=prompt,
         data_instruction=plan.data_instruction,
         render_instruction=plan.render_instruction,
-        old_file_upload_id=deliverable.file_upload_id,
+        old_file_upload_id=file_upload_id,
         ephemeral_run_id=ephemeral_run_id,
     )
 
@@ -1484,25 +1541,28 @@ async def _process_deliverable_followup(
         runtime: NotebookRuntime | None = None
         packet: DeliveryPacket | None = None
         if plan.requires_ephemeral_run:
-            context = await notion_store.latest_deliverable_context_snapshot(db, deliverable_id=deliverable.id)
+            context = await notion_store.latest_deliverable_context_snapshot(db, deliverable_id=deliverable_id)
             if context is None or not context.base_notebook_code:
                 message = (
                     "I can edit this dashboard/report, but refresh requires a rebuild once with "
                     "captured SignalPilot context. Rebuild it once, then refresh will be available."
                 )
-                await notion_store.mark_deliverable_update_failed(
+                await _mark_deliverable_update_failed_best_effort(
                     db,
                     update_id=update.id,
-                    deliverable_id=deliverable.id,
+                    deliverable_id=deliverable_id,
                     error=message,
                 )
                 await _comment_deliverable_followup(token, discussion_id, message)
                 return NotionCommentProcessResult(status="processed")
+            context = _freeze_deliverable_context(context)
+            await _release_db_session(db)
             packet, runtime = await _run_ephemeral_deliverable_refresh(
                 db=db,
-                routed=routed,
+                org_id=org_id,
+                user_id=user_id,
                 context=context,
-                deliverable_id=deliverable.id,
+                deliverable_id=deliverable_id,
                 ephemeral_run_id=ephemeral_run_id or f"notion-refresh-{uuid4().hex[:16]}",
                 data_instruction=plan.data_instruction,
                 theme=theme,
@@ -1517,12 +1577,13 @@ async def _process_deliverable_followup(
         )
         delivery_api_key = await delivery_api_key_for_user(
             db,
-            org_id=routed.installation.org_id,
-            user_id=routed.installation.user_id,
+            org_id=org_id,
+            user_id=user_id,
         )
+        await _release_db_session(db)
         html_result = await render_followup(
             plan.render_instruction,
-            _existing_report_payload(report),
+            existing_report,
             packet,
             "refresh_data" if plan.requires_ephemeral_run else "edit_existing",
             api_key=delivery_api_key or None,
@@ -1531,25 +1592,25 @@ async def _process_deliverable_followup(
         )
         replaced = await notion_dashboards.replace_html_deliverable(
             token,
-            embed_block_id=deliverable.embed_block_id,
+            embed_block_id=embed_block_id,
             title=html_result.title,
             html=html_result.html,
-            report_id=deliverable.report_id,
+            report_id=report_id,
         )
         await reports_store.update_report_html(
             db,
-            org_id=routed.installation.org_id,
-            report_id=deliverable.report_id,
+            org_id=org_id,
+            report_id=report_id,
             payload=ReportUpdate(
                 title=html_result.title,
                 html=html_result.html,
-                data_json=html_result.data_json if html_result.data_json is not None else report.data_json,
+                data_json=html_result.data_json if html_result.data_json is not None else report_data_json,
             ),
         )
         await notion_store.mark_deliverable_update_succeeded(
             db,
             update_id=update.id,
-            deliverable_id=deliverable.id,
+            deliverable_id=deliverable_id,
             new_file_upload_id=replaced.file_upload_id,
             html_bytes=len(html_result.html.encode("utf-8")),
         )
@@ -1564,10 +1625,11 @@ async def _process_deliverable_followup(
     except Exception as exc:
         logger.info("Could not update Notion HTML deliverable follow-up", exc_info=True)
         message = str(exc) or exc.__class__.__name__
-        await notion_store.mark_deliverable_update_failed(
+        await _release_db_session(db)
+        await _mark_deliverable_update_failed_best_effort(
             db,
             update_id=update.id,
-            deliverable_id=deliverable.id,
+            deliverable_id=deliverable_id,
             error=message,
         )
         await _comment_deliverable_followup(

--- a/signalpilot/gateway/gateway/store/notion.py
+++ b/signalpilot/gateway/gateway/store/notion.py
@@ -8,8 +8,9 @@ import time
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select, update as sa_update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import select
+from sqlalchemy import update as sa_update
+from sqlalchemy.exc import DBAPIError, IntegrityError, InterfaceError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.db.models import (
@@ -32,6 +33,31 @@ from gateway.models.notion import (
 from gateway.store.crypto import _decrypt_with_migration, _encrypt
 
 logger = logging.getLogger(__name__)
+
+
+def _looks_like_closed_connection(exc: BaseException) -> bool:
+    if isinstance(exc, DBAPIError) and getattr(exc, "connection_invalidated", False):
+        return True
+    message = str(exc).lower()
+    return (
+        "connection is closed" in message
+        or "connection was closed" in message
+        or "connection has been closed" in message
+    )
+
+
+async def _run_with_closed_connection_retry(session: AsyncSession, operation, description: str):
+    try:
+        return await operation()
+    except (InterfaceError, OperationalError, DBAPIError) as exc:
+        if not _looks_like_closed_connection(exc):
+            raise
+        logger.warning("Stale DB connection during %s; retrying once", description, exc_info=True)
+        try:
+            await session.rollback()
+        except Exception:
+            logger.debug("Rollback after stale DB connection failed", exc_info=True)
+        return await operation()
 
 
 def _normalize_notion_id(value: str | None) -> str:
@@ -468,21 +494,30 @@ async def mark_deliverable_update_succeeded(
     new_file_upload_id: str | None,
     html_bytes: int,
 ) -> NotionDeliverableUpdate | None:
-    update = await session.get(NotionDeliverableUpdate, update_id)
-    deliverable = await session.get(NotionDeliverable, deliverable_id)
-    if update is None:
-        return None
-    update.status = "succeeded"
-    update.error = None
-    update.new_file_upload_id = new_file_upload_id
-    update.html_bytes = html_bytes
-    if deliverable is not None:
+    now = datetime.now(UTC)
+
+    async def _write() -> bool:
+        result = await session.execute(
+            sa_update(NotionDeliverableUpdate)
+            .where(NotionDeliverableUpdate.id == update_id)
+            .values(
+                status="succeeded",
+                error=None,
+                new_file_upload_id=new_file_upload_id,
+                html_bytes=html_bytes,
+                updated_at=now,
+            )
+            .execution_options(synchronize_session="fetch")
+        )
+        if not result.rowcount:
+            await session.commit()
+            return False
         values: dict[str, object | None] = {
             "latest_file_upload_id": new_file_upload_id,
             "latest_html_bytes": html_bytes,
             "status": "active",
             "error": None,
-            "updated_at": datetime.now(UTC),
+            "updated_at": now,
         }
         if new_file_upload_id:
             values["file_upload_id"] = new_file_upload_id
@@ -490,14 +525,20 @@ async def mark_deliverable_update_succeeded(
             sa_update(NotionDeliverable)
             .where(
                 NotionDeliverable.id == deliverable_id,
-                NotionDeliverable.latest_update_id == update.id,
+                NotionDeliverable.latest_update_id == update_id,
             )
             .values(**values)
-            .execution_options(synchronize_session=False)
+            .execution_options(synchronize_session="fetch")
         )
-    await session.commit()
-    await session.refresh(update)
-    return update
+        await session.commit()
+        return True
+
+    updated = await _run_with_closed_connection_retry(
+        session,
+        _write,
+        "mark Notion deliverable update succeeded",
+    )
+    return await session.get(NotionDeliverableUpdate, update_id) if updated else None
 
 
 async def mark_deliverable_update_failed(
@@ -507,32 +548,48 @@ async def mark_deliverable_update_failed(
     deliverable_id: str,
     error: str,
 ) -> NotionDeliverableUpdate | None:
-    update = await session.get(NotionDeliverableUpdate, update_id) if update_id else None
-    deliverable = await session.get(NotionDeliverable, deliverable_id)
-    if update is not None:
-        update.status = "failed"
-        update.error = error
-    if deliverable is not None and update is not None:
-        await session.execute(
-            sa_update(NotionDeliverable)
-            .where(
-                NotionDeliverable.id == deliverable_id,
-                NotionDeliverable.latest_update_id == update.id,
+    now = datetime.now(UTC)
+
+    async def _write() -> bool:
+        if update_id is not None:
+            result = await session.execute(
+                sa_update(NotionDeliverableUpdate)
+                .where(NotionDeliverableUpdate.id == update_id)
+                .values(status="failed", error=error, updated_at=now)
+                .execution_options(synchronize_session="fetch")
             )
-            .values(
-                status="failed",
-                error=error,
-                updated_at=datetime.now(UTC),
+            if not result.rowcount:
+                await session.commit()
+                return False
+            await session.execute(
+                sa_update(NotionDeliverable)
+                .where(
+                    NotionDeliverable.id == deliverable_id,
+                    NotionDeliverable.latest_update_id == update_id,
+                )
+                .values(
+                    status="failed",
+                    error=error,
+                    updated_at=now,
+                )
+                .execution_options(synchronize_session="fetch")
             )
-            .execution_options(synchronize_session=False)
-        )
-    elif deliverable is not None and update_id is None:
-        deliverable.status = "failed"
-        deliverable.error = error
-    await session.commit()
-    if update is not None:
-        await session.refresh(update)
-    return update
+        else:
+            await session.execute(
+                sa_update(NotionDeliverable)
+                .where(NotionDeliverable.id == deliverable_id)
+                .values(status="failed", error=error, updated_at=now)
+                .execution_options(synchronize_session="fetch")
+            )
+        await session.commit()
+        return True
+
+    updated = await _run_with_closed_connection_retry(
+        session,
+        _write,
+        "mark Notion deliverable update failed",
+    )
+    return await session.get(NotionDeliverableUpdate, update_id) if update_id and updated else None
 
 
 async def upsert_oauth_installation(

--- a/signalpilot/gateway/tests/test_html_orchestrator.py
+++ b/signalpilot/gateway/tests/test_html_orchestrator.py
@@ -504,3 +504,15 @@ def test_html_orchestrator_timeout_reads_env(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("SIGNALPILOT_ORCHESTRATOR_TIMEOUT_SECONDS", "120")
 
     assert HtmlOrchestrator(api_key="key").timeout_seconds == 120.0
+
+
+def test_html_orchestrator_tool_loop_limit_defaults_to_eight(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SIGNALPILOT_ORCHESTRATOR_TOOL_LOOP_LIMIT", raising=False)
+
+    assert HtmlOrchestrator(api_key="key").tool_loop_limit == 8
+
+
+def test_html_orchestrator_tool_loop_limit_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SIGNALPILOT_ORCHESTRATOR_TOOL_LOOP_LIMIT", "12")
+
+    assert HtmlOrchestrator(api_key="key").tool_loop_limit == 12

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -1224,6 +1224,70 @@ async def test_patch_failure_does_not_update_report_or_success_pointers(
     assert result.status == "processed"
     assert calls == ["comment", "replace", "failed", "comment"]
     assert deliverable.file_upload_id == "file-old"
+
+
+@pytest.mark.asyncio
+async def test_followup_posts_original_failure_when_failed_status_write_loses_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+    routed = _routed_installation_for_followup()
+    deliverable = SimpleNamespace(
+        id="deliverable-1",
+        report_id="report-1",
+        embed_block_id="embed-block-1",
+        file_upload_id="file-old",
+    )
+    report = SimpleNamespace(id="report-1", kind="dashboard", title="Dashboard", html="<html>old</html>", data_json={})
+    db = MagicMock()
+    db.rollback = AsyncMock()
+
+    async def list_comments(*args, **kwargs):
+        return [{"id": "comment-1", "discussion_id": "discussion-1", "rich_text": []}]
+
+    async def create_update(*args, **kwargs):
+        return SimpleNamespace(id="update-1")
+
+    async def find_deliverable(*args, **kwargs):
+        return deliverable
+
+    async def get_report(*args, **kwargs):
+        return report
+
+    async def delivery_api_key(*args, **kwargs):
+        return ""
+
+    async def render_followup(*args, **kwargs):
+        raise TimeoutError("HTML orchestrator exceeded tool loop limit (8)")
+
+    async def mark_failed(*args, **kwargs):
+        calls.append(("failed", kwargs["error"]))
+        raise RuntimeError("connection is closed")
+
+    async def create_comment(*args, **kwargs):
+        calls.append(("comment", _rich_text_content(kwargs["rich_text"])))
+
+    monkeypatch.setattr(notion_client, "list_comments", list_comments)
+    monkeypatch.setattr(notion_client, "create_comment", create_comment)
+    monkeypatch.setattr(notion_client, "is_bot_comment", lambda _comment: False)
+    monkeypatch.setattr(notion_client, "comment_has_page_mention", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(notion_client, "extract_comment_text", lambda _comment: "make it shorter")
+    monkeypatch.setattr(notion_analysis.notion_store, "find_deliverable_by_embed_block", find_deliverable)
+    monkeypatch.setattr(notion_analysis.reports_store, "get_report", get_report)
+    monkeypatch.setattr(notion_analysis.notion_store, "create_deliverable_update", create_update)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
+    monkeypatch.setattr(notion_analysis.notion_store, "mark_deliverable_update_failed", mark_failed)
+
+    result = await notion_analysis.process_routed_comment_event(routed, _followup_payload(), db=db)
+
+    assert result.status == "processed"
+    comments = [payload for name, payload in calls if name == "comment"]
+    assert comments[0] == "Updating this dashboard/report."
+    assert "HTML orchestrator exceeded tool loop limit (8)" in comments[-1]
+    assert "connection is closed" not in comments[-1]
+    assert ("failed", "HTML orchestrator exceeded tool loop limit (8)") in calls
+    assert db.rollback.await_count >= 2
 
 
 def test_public_signalpilot_url_rewrites_internal_notebooks_trail_to_app_origin() -> None:

--- a/signalpilot/gateway/tests/test_notion_store_deliverables.py
+++ b/signalpilot/gateway/tests/test_notion_store_deliverables.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine


### PR DESCRIPTION
## Summary
- release the Notion follow-up DB session before long notebook, Anthropic, and Notion calls so idle transactions do not keep stale connections checked out
- make deliverable update success/failure writes use direct SQL updates with a closed-connection retry
- keep webhook failure auditing from touching expired ORM attributes after rollback
- make the HTML orchestrator tool loop limit configurable and raise the default from 4 to 8

## Tests
- cd signalpilot/gateway && uv run pytest tests/test_notion_analysis.py tests/test_notion_store_deliverables.py tests/test_html_orchestrator.py -q
- cd signalpilot/gateway && uv run ruff check gateway/notion/analysis.py gateway/store/notion.py gateway/api/notion.py gateway/analysis_delivery/html_orchestrator.py tests/test_notion_analysis.py tests/test_notion_store_deliverables.py tests/test_html_orchestrator.py