### PR TITLE
fix: surface Anthropic HTML errors

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
@@ -25,7 +25,9 @@ _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT_SECONDS = 240.0
 _DEFAULT_MAX_TOKENS = 20_000
+_MAX_TOKENS_RETRY_FLOOR = 8_192
 _DEFAULT_TOOL_LOOP_LIMIT = 8
+_ANTHROPIC_ERROR_BODY_MAX_CHARS = 2_000
 _DELIVERABLE_TOOL_NAMES = {"create_dashboard", "create_report", "edit_dashboard", "edit_report"}
 _COMPONENT_LAYOUT_GUARD_ID = "sp-component-layout-guard"
 _COMPONENT_LAYOUT_GUARD = f"""<style id="{_COMPONENT_LAYOUT_GUARD_ID}">
@@ -977,11 +979,15 @@ class HtmlOrchestrator:
         }
         if self._http_client is not None:
             response = await self._http_client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
-            response.raise_for_status()
+            if await _should_retry_anthropic_request_with_lower_max_tokens(response, request_body):
+                response = await self._http_client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+            _raise_anthropic_for_status(response, request_body)
             return response.json()
         async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
             response = await client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
-            response.raise_for_status()
+            if await _should_retry_anthropic_request_with_lower_max_tokens(response, request_body):
+                response = await client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+            _raise_anthropic_for_status(response, request_body)
             return response.json()
 
     async def _result_from_content(
@@ -1170,6 +1176,66 @@ def _max_tokens() -> int:
         except ValueError:
             LOGGER.warning("Invalid SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS=%r; using default", raw)
     return _DEFAULT_MAX_TOKENS
+
+
+async def _should_retry_anthropic_request_with_lower_max_tokens(response: Any, request_body: dict[str, Any]) -> bool:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    max_tokens = request_body.get("max_tokens")
+    if status_code != 400 or not isinstance(max_tokens, int) or max_tokens <= _MAX_TOKENS_RETRY_FLOOR:
+        return False
+    body = _anthropic_error_body(response).lower()
+    if "max_tokens" not in body:
+        return False
+    request_body["max_tokens"] = _MAX_TOKENS_RETRY_FLOOR
+    LOGGER.warning(
+        "Anthropic HTML orchestrator rejected max_tokens=%s; retrying with max_tokens=%s",
+        max_tokens,
+        _MAX_TOKENS_RETRY_FLOOR,
+    )
+    return True
+
+
+def _raise_anthropic_for_status(response: Any, request_body: dict[str, Any]) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        body = _anthropic_error_body(response)
+        payload_chars = _request_body_chars(request_body)
+        status_code = getattr(response, "status_code", None)
+        raise RuntimeError(
+            "Anthropic HTML orchestrator request failed "
+            f"(status={status_code}, model={request_body.get('model')}, "
+            f"max_tokens={request_body.get('max_tokens')}, payload_chars={payload_chars}): {body}"
+        ) from exc
+
+
+def _anthropic_error_body(response: Any) -> str:
+    text = ""
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = _string(error.get("message"))
+            error_type = _string(error.get("type"))
+            text = f"{error_type}: {message}" if error_type else message
+        else:
+            text = _string(payload)
+    if not text:
+        text = _string(getattr(response, "text", ""))
+    text = text.strip() or "<empty response body>"
+    if len(text) > _ANTHROPIC_ERROR_BODY_MAX_CHARS:
+        text = f"{text[:_ANTHROPIC_ERROR_BODY_MAX_CHARS]}..."
+    return text
+
+
+def _request_body_chars(request_body: dict[str, Any]) -> int:
+    try:
+        return len(json.dumps(request_body, ensure_ascii=True, separators=(",", ":")))
+    except Exception:
+        return -1
 
 
 def _tool_loop_limit() -> int:

--- a/signalpilot/gateway/tests/test_html_orchestrator.py
+++ b/signalpilot/gateway/tests/test_html_orchestrator.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 
+import httpx
 import pytest
 
 from gateway.analysis_delivery.html_orchestrator import (
@@ -38,8 +40,24 @@ class _Client:
         self.requests = []
 
     async def post(self, url, *, headers, json):
-        self.requests.append({"url": url, "headers": headers, "json": json})
-        return _Response(self.payloads.pop(0))
+        self.requests.append({"url": url, "headers": headers, "json": deepcopy(json)})
+        payload = self.payloads.pop(0)
+        return payload if hasattr(payload, "raise_for_status") else _Response(payload)
+
+
+class _ErrorResponse:
+    def __init__(self, payload, *, status_code: int = 400):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self) -> None:
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        response = httpx.Response(self.status_code, text=self.text, request=request)
+        raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+    def json(self):
+        return self._payload
 
 
 @pytest.mark.asyncio
@@ -279,6 +297,82 @@ async def test_html_orchestrator_renders_followup_with_existing_report_payload()
     assert "fetch_snapshot" not in tool_names
     assert client.requests[0]["json"]["tool_choice"] == {"type": "tool", "name": "edit_dashboard"}
     assert client.requests[0]["json"]["max_tokens"] == 20_000
+
+
+@pytest.mark.asyncio
+async def test_html_orchestrator_retries_lower_max_tokens_when_anthropic_rejects() -> None:
+    client = _Client(
+        _ErrorResponse(
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "max_tokens: Input should be less than or equal to 8192",
+                }
+            }
+        ),
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "edit-1",
+                    "name": "edit_dashboard",
+                    "input": {
+                        "report_id": "report-1",
+                        "title": "Revenue Dashboard",
+                        "html": '<!doctype html><html><body><script type="application/json" id="sp-data">{}</script></body></html>',
+                    },
+                }
+            ]
+        },
+    )
+
+    result = await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
+        instruction="Make the title shorter.",
+        existing={
+            "report_id": "report-1",
+            "kind": "dashboard",
+            "title": "Revenue Dashboard",
+            "html": "<html>old</html>",
+            "data_json": {},
+        },
+        packet=None,
+        mode="edit_existing",
+    )
+
+    assert result.title == "Revenue Dashboard"
+    assert [request["json"]["max_tokens"] for request in client.requests] == [20_000, 8_192]
+
+
+@pytest.mark.asyncio
+async def test_html_orchestrator_surfaces_anthropic_error_body() -> None:
+    client = _Client(
+        _ErrorResponse(
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "messages.0.content: Input is too long for the model context window",
+                }
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
+            instruction="Make the title shorter.",
+            existing={
+                "report_id": "report-1",
+                "kind": "dashboard",
+                "title": "Revenue Dashboard",
+                "html": "<html>old</html>",
+                "data_json": {},
+            },
+            packet=None,
+            mode="edit_existing",
+        )
+
+    message = str(exc_info.value)
+    assert "invalid_request_error: messages.0.content: Input is too long" in message
+    assert "payload_chars=" in message
 
 
 def test_malformed_tool_args_return_none() -> None:


### PR DESCRIPTION
## Summary
- include Anthropic's 400 response body in HTML orchestrator failures instead of the generic httpx/MDN message
- log and retry once with max_tokens=8192 when Anthropic explicitly rejects the configured max_tokens
- include bounded request metadata such as model, max_tokens, and payload_chars for debugging oversized edit requests without logging the prompt or API key

## Tests
- cd signalpilot/gateway && uv run pytest tests/test_notion_analysis.py tests/test_notion_store_deliverables.py tests/test_html_orchestrator.py -q
- cd signalpilot/gateway && uv run ruff check gateway/notion/analysis.py gateway/store/notion.py gateway/api/notion.py gateway/analysis_delivery/html_orchestrator.py tests/test_notion_analysis.py tests/test_notion_store_deliverables.py tests/test_html_orchestrator.py