### PR TITLE
fix: harden HTML orchestrator rendering

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 from collections.abc import Awaitable, Callable
@@ -24,11 +25,25 @@ LOGGER = logging.getLogger(__name__)
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT_SECONDS = 240.0
-_DEFAULT_MAX_TOKENS = 20_000
-_MAX_TOKENS_RETRY_FLOOR = 8_192
+_ANTHROPIC_MAX_OUTPUT_TOKENS = 8_192
+_DEFAULT_MAX_TOKENS = _ANTHROPIC_MAX_OUTPUT_TOKENS
+_MAX_TOKENS_RETRY_FLOOR = _ANTHROPIC_MAX_OUTPUT_TOKENS
 _DEFAULT_TOOL_LOOP_LIMIT = 8
 _ANTHROPIC_ERROR_BODY_MAX_CHARS = 2_000
 _DELIVERABLE_TOOL_NAMES = {"create_dashboard", "create_report", "edit_dashboard", "edit_report"}
+_DIV_TAG_RE = re.compile(r"</?div\b[^>]*>", flags=re.IGNORECASE)
+_CLASS_ATTR_RE = re.compile(r"\bclass=[\"']([^\"']*)[\"']", flags=re.IGNORECASE)
+_SVG_RE = re.compile(r"<svg\b(?P<attrs>[^>]*)>(?P<body>.*?)</svg>", flags=re.IGNORECASE | re.DOTALL)
+_VIEWBOX_RE = re.compile(
+    r"\bviewBox=[\"']\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s*[\"']",
+    flags=re.IGNORECASE,
+)
+_PATH_TAG_RE = re.compile(r"<path\b(?P<attrs>[^>]*)>(?P<body>\s*</path>)?", flags=re.IGNORECASE)
+_PATH_D_ATTR_RE = re.compile(r"\s+d=([\"']).*?\1", flags=re.IGNORECASE | re.DOTALL)
+_LEGEND_PERCENT_RE = re.compile(
+    r"\b(?:legend-value|sp-pie-legend-value|sp-donut-legend-value)\b[^>]*>\s*([+-]?\d+(?:\.\d+)?)\s*%",
+    flags=re.IGNORECASE,
+)
 _COMPONENT_LAYOUT_GUARD_ID = "sp-component-layout-guard"
 _COMPONENT_LAYOUT_GUARD = f"""<style id="{_COMPONENT_LAYOUT_GUARD_ID}">
 .sp-dashboard,
@@ -885,7 +900,12 @@ class HtmlOrchestrator:
         fetch_snapshot: SnapshotFetcher | None = None,
     ) -> None:
         self.provider = (provider or "anthropic").strip().lower()
-        self.model = (model or os.getenv("SIGNALPILOT_ORCHESTRATOR_MODEL") or DEFAULT_DELIVERY_MODEL).strip()
+        self.model = (
+            model
+            or os.getenv("SIGNALPILOT_ORCHESTRATOR_MODEL")
+            or os.getenv("SIGNALPILOT_DELIVERY_MODEL")
+            or DEFAULT_DELIVERY_MODEL
+        ).strip()
         self.timeout_seconds = _timeout_seconds(timeout_seconds)
         self.max_tokens = _max_tokens()
         self.tool_loop_limit = _tool_loop_limit()
@@ -1172,7 +1192,7 @@ def _max_tokens() -> int:
     raw = os.getenv("SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS", "").strip()
     if raw:
         try:
-            return max(int(raw), 1024)
+            return min(max(int(raw), 1024), _ANTHROPIC_MAX_OUTPUT_TOKENS)
         except ValueError:
             LOGGER.warning("Invalid SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS=%r; using default", raw)
     return _DEFAULT_MAX_TOKENS
@@ -1188,9 +1208,16 @@ async def _should_retry_anthropic_request_with_lower_max_tokens(response: Any, r
         return False
     request_body["max_tokens"] = _MAX_TOKENS_RETRY_FLOOR
     LOGGER.warning(
-        "Anthropic HTML orchestrator rejected max_tokens=%s; retrying with max_tokens=%s",
+        "Anthropic HTML orchestrator rejected max_tokens=%s; retrying with max_tokens=%s "
+        "(status=%s, model=%s, payload_chars=%s, messages=%s, tool_choice=%s, error=%s)",
         max_tokens,
         _MAX_TOKENS_RETRY_FLOOR,
+        status_code,
+        request_body.get("model"),
+        _request_body_chars(request_body),
+        _message_count(request_body),
+        _tool_choice_name(request_body),
+        _anthropic_error_body(response),
     )
     return True
 
@@ -1202,11 +1229,43 @@ def _raise_anthropic_for_status(response: Any, request_body: dict[str, Any]) -> 
         body = _anthropic_error_body(response)
         payload_chars = _request_body_chars(request_body)
         status_code = getattr(response, "status_code", None)
+        LOGGER.error(
+            "Anthropic HTML orchestrator request failed "
+            "status=%s model=%s max_tokens=%s payload_chars=%s messages=%s tools=%s tool_choice=%s error=%s",
+            status_code,
+            request_body.get("model"),
+            request_body.get("max_tokens"),
+            payload_chars,
+            _message_count(request_body),
+            _tool_names(request_body),
+            _tool_choice_name(request_body),
+            body,
+        )
         raise RuntimeError(
             "Anthropic HTML orchestrator request failed "
             f"(status={status_code}, model={request_body.get('model')}, "
             f"max_tokens={request_body.get('max_tokens')}, payload_chars={payload_chars}): {body}"
         ) from exc
+
+
+def _message_count(request_body: dict[str, Any]) -> int:
+    messages = request_body.get("messages")
+    return len(messages) if isinstance(messages, list) else 0
+
+
+def _tool_names(request_body: dict[str, Any]) -> str:
+    tools = request_body.get("tools")
+    if not isinstance(tools, list):
+        return ""
+    names = [_string(tool.get("name")) for tool in tools if isinstance(tool, dict) and tool.get("name")]
+    return ",".join(names)
+
+
+def _tool_choice_name(request_body: dict[str, Any]) -> str:
+    tool_choice = request_body.get("tool_choice")
+    if not isinstance(tool_choice, dict):
+        return ""
+    return _string(tool_choice.get("name"))
 
 
 def _anthropic_error_body(response: Any) -> str:
@@ -1391,6 +1450,7 @@ def _normalize_html_result(
 ) -> HtmlDeliverableResult:
     data_json = _merged_data_json(result.data_json, fetched_snapshots)
     html = _inject_data_island(result.html, data_json)
+    html = _normalize_pie_slice_geometry(html)
     html = _stabilize_common_chart_layouts(html, theme=theme)
     if html == result.html and data_json is result.data_json:
         return result
@@ -1480,6 +1540,133 @@ def _uses_chart_or_table_components(html: str) -> bool:
             flags=re.IGNORECASE,
         )
     )
+
+
+def _normalize_pie_slice_geometry(html: str) -> str:
+    replacements: list[tuple[int, int, str]] = []
+    for start, end in _div_blocks_with_class(html, "sp-pie-chart"):
+        block = html[start:end]
+        normalized = _normalize_pie_block(block)
+        if normalized != block:
+            replacements.append((start, end, normalized))
+    if not replacements:
+        return html
+    updated = html
+    for start, end, replacement in reversed(replacements):
+        updated = updated[:start] + replacement + updated[end:]
+    return updated
+
+
+def _div_blocks_with_class(html: str, class_name: str) -> list[tuple[int, int]]:
+    blocks: list[tuple[int, int]] = []
+    tags = list(_DIV_TAG_RE.finditer(html))
+    index = 0
+    while index < len(tags):
+        tag = tags[index]
+        text = tag.group(0)
+        if text.startswith("</") or not _tag_has_class(text, class_name):
+            index += 1
+            continue
+        depth = 1
+        cursor = index + 1
+        while cursor < len(tags):
+            next_tag = tags[cursor].group(0)
+            depth += -1 if next_tag.startswith("</") else 1
+            if depth == 0:
+                blocks.append((tag.start(), tags[cursor].end()))
+                index = cursor
+                break
+            cursor += 1
+        index += 1
+    return blocks
+
+
+def _tag_has_class(tag: str, class_name: str) -> bool:
+    match = _CLASS_ATTR_RE.search(tag)
+    if match is None:
+        return False
+    return class_name in match.group(1).split()
+
+
+def _normalize_pie_block(block: str) -> str:
+    svg_match = _SVG_RE.search(block)
+    if svg_match is None:
+        return block
+    percentages = [float(match.group(1)) for match in _LEGEND_PERCENT_RE.finditer(block)]
+    if len(percentages) < 2 or sum(value for value in percentages if value > 0) <= 0:
+        return block
+    svg = svg_match.group(0)
+    path_matches = list(_PATH_TAG_RE.finditer(svg))
+    if len(path_matches) != len(percentages):
+        return block
+    viewbox = _svg_viewbox(svg_match.group("attrs"))
+    if viewbox is None:
+        return block
+    x, y, width, height = viewbox
+    cx = x + width / 2
+    cy = y + height / 2
+    radius = min(width, height) * 0.45
+    paths = _pie_paths_from_values(percentages, cx=cx, cy=cy, radius=radius)
+    rewritten_svg = svg
+    for path_match, path in reversed(list(zip(path_matches, paths, strict=True))):
+        rewritten = _replace_path_d(path_match.group(0), path)
+        rewritten_svg = rewritten_svg[: path_match.start()] + rewritten + rewritten_svg[path_match.end() :]
+    return block[: svg_match.start()] + rewritten_svg + block[svg_match.end() :]
+
+
+def _svg_viewbox(attrs: str) -> tuple[float, float, float, float] | None:
+    match = _VIEWBOX_RE.search(attrs)
+    if match is None:
+        return None
+    x, y, width, height = match.groups()
+    return float(x), float(y), float(width), float(height)
+
+
+def _pie_paths_from_values(values: list[float], *, cx: float, cy: float, radius: float) -> list[str]:
+    positive_values = [max(value, 0.0) for value in values]
+    total = sum(positive_values)
+    if total <= 0:
+        return []
+    paths: list[str] = []
+    angle = -math.pi / 2
+    for value in positive_values:
+        share = value / total
+        next_angle = angle + (share * math.tau)
+        start_x = cx + radius * math.cos(angle)
+        start_y = cy + radius * math.sin(angle)
+        end_x = cx + radius * math.cos(next_angle)
+        end_y = cy + radius * math.sin(next_angle)
+        large_arc = 1 if share > 0.5 else 0
+        paths.append(
+            "M "
+            f"{_fmt_svg_number(cx)} {_fmt_svg_number(cy)} "
+            "L "
+            f"{_fmt_svg_number(start_x)} {_fmt_svg_number(start_y)} "
+            "A "
+            f"{_fmt_svg_number(radius)} {_fmt_svg_number(radius)} 0 {large_arc} 1 "
+            f"{_fmt_svg_number(end_x)} {_fmt_svg_number(end_y)} Z"
+        )
+        angle = next_angle
+    return paths
+
+
+def _replace_path_d(path_tag: str, d: str) -> str:
+    attrs_match = _PATH_TAG_RE.fullmatch(path_tag)
+    if attrs_match is None:
+        return path_tag
+    attrs = attrs_match.group("attrs")
+    body = attrs_match.group("body") or "</path>"
+    if attrs.rstrip().endswith("/"):
+        attrs = attrs.rstrip()[:-1]
+    attrs = _PATH_D_ATTR_RE.sub("", attrs, count=1)
+    return f'<path d="{d}"{attrs}>{body.lstrip()}'
+
+
+def _fmt_svg_number(value: float) -> str:
+    if abs(value) < 0.000001:
+        value = 0.0
+    formatted = f"{value:.2f}".rstrip("0").rstrip(".")
+    return formatted or "0"
 
 
 def _inject_head_style(html: str, *, style_id: str, style: str) -> str:

--- a/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py
@@ -25,7 +25,9 @@ _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT_SECONDS = 240.0
 _DEFAULT_MAX_TOKENS = 20_000
+_MAX_TOKENS_RETRY_FLOOR = 8_192
 _DEFAULT_TOOL_LOOP_LIMIT = 8
+_ANTHROPIC_ERROR_BODY_MAX_CHARS = 2_000
 _DELIVERABLE_TOOL_NAMES = {"create_dashboard", "create_report", "edit_dashboard", "edit_report"}
 _COMPONENT_LAYOUT_GUARD_ID = "sp-component-layout-guard"
 _COMPONENT_LAYOUT_GUARD = f"""<style id="{_COMPONENT_LAYOUT_GUARD_ID}">
@@ -977,11 +979,15 @@ class HtmlOrchestrator:
         }
         if self._http_client is not None:
             response = await self._http_client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
-            response.raise_for_status()
+            if await _should_retry_anthropic_request_with_lower_max_tokens(response, request_body):
+                response = await self._http_client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+            _raise_anthropic_for_status(response, request_body)
             return response.json()
         async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
             response = await client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
-            response.raise_for_status()
+            if await _should_retry_anthropic_request_with_lower_max_tokens(response, request_body):
+                response = await client.post(_ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
+            _raise_anthropic_for_status(response, request_body)
             return response.json()
 
     async def _result_from_content(
@@ -1170,6 +1176,66 @@ def _max_tokens() -> int:
         except ValueError:
             LOGGER.warning("Invalid SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS=%r; using default", raw)
     return _DEFAULT_MAX_TOKENS
+
+
+async def _should_retry_anthropic_request_with_lower_max_tokens(response: Any, request_body: dict[str, Any]) -> bool:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    max_tokens = request_body.get("max_tokens")
+    if status_code != 400 or not isinstance(max_tokens, int) or max_tokens <= _MAX_TOKENS_RETRY_FLOOR:
+        return False
+    body = _anthropic_error_body(response).lower()
+    if "max_tokens" not in body:
+        return False
+    request_body["max_tokens"] = _MAX_TOKENS_RETRY_FLOOR
+    LOGGER.warning(
+        "Anthropic HTML orchestrator rejected max_tokens=%s; retrying with max_tokens=%s",
+        max_tokens,
+        _MAX_TOKENS_RETRY_FLOOR,
+    )
+    return True
+
+
+def _raise_anthropic_for_status(response: Any, request_body: dict[str, Any]) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        body = _anthropic_error_body(response)
+        payload_chars = _request_body_chars(request_body)
+        status_code = getattr(response, "status_code", None)
+        raise RuntimeError(
+            "Anthropic HTML orchestrator request failed "
+            f"(status={status_code}, model={request_body.get('model')}, "
+            f"max_tokens={request_body.get('max_tokens')}, payload_chars={payload_chars}): {body}"
+        ) from exc
+
+
+def _anthropic_error_body(response: Any) -> str:
+    text = ""
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = _string(error.get("message"))
+            error_type = _string(error.get("type"))
+            text = f"{error_type}: {message}" if error_type else message
+        else:
+            text = _string(payload)
+    if not text:
+        text = _string(getattr(response, "text", ""))
+    text = text.strip() or "<empty response body>"
+    if len(text) > _ANTHROPIC_ERROR_BODY_MAX_CHARS:
+        text = f"{text[:_ANTHROPIC_ERROR_BODY_MAX_CHARS]}..."
+    return text
+
+
+def _request_body_chars(request_body: dict[str, Any]) -> int:
+    try:
+        return len(json.dumps(request_body, ensure_ascii=True, separators=(",", ":")))
+    except Exception:
+        return -1
 
 
 def _tool_loop_limit() -> int:

--- a/signalpilot/gateway/tests/test_html_orchestrator.py
+++ b/signalpilot/gateway/tests/test_html_orchestrator.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 
+import httpx
 import pytest
 
 from gateway.analysis_delivery.html_orchestrator import (
@@ -38,8 +40,24 @@ class _Client:
         self.requests = []
 
     async def post(self, url, *, headers, json):
-        self.requests.append({"url": url, "headers": headers, "json": json})
-        return _Response(self.payloads.pop(0))
+        self.requests.append({"url": url, "headers": headers, "json": deepcopy(json)})
+        payload = self.payloads.pop(0)
+        return payload if hasattr(payload, "raise_for_status") else _Response(payload)
+
+
+class _ErrorResponse:
+    def __init__(self, payload, *, status_code: int = 400):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self) -> None:
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        response = httpx.Response(self.status_code, text=self.text, request=request)
+        raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+    def json(self):
+        return self._payload
 
 
 @pytest.mark.asyncio
@@ -279,6 +297,82 @@ async def test_html_orchestrator_renders_followup_with_existing_report_payload()
     assert "fetch_snapshot" not in tool_names
     assert client.requests[0]["json"]["tool_choice"] == {"type": "tool", "name": "edit_dashboard"}
     assert client.requests[0]["json"]["max_tokens"] == 20_000
+
+
+@pytest.mark.asyncio
+async def test_html_orchestrator_retries_lower_max_tokens_when_anthropic_rejects() -> None:
+    client = _Client(
+        _ErrorResponse(
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "max_tokens: Input should be less than or equal to 8192",
+                }
+            }
+        ),
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "edit-1",
+                    "name": "edit_dashboard",
+                    "input": {
+                        "report_id": "report-1",
+                        "title": "Revenue Dashboard",
+                        "html": '<!doctype html><html><body><script type="application/json" id="sp-data">{}</script></body></html>',
+                    },
+                }
+            ]
+        },
+    )
+
+    result = await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
+        instruction="Make the title shorter.",
+        existing={
+            "report_id": "report-1",
+            "kind": "dashboard",
+            "title": "Revenue Dashboard",
+            "html": "<html>old</html>",
+            "data_json": {},
+        },
+        packet=None,
+        mode="edit_existing",
+    )
+
+    assert result.title == "Revenue Dashboard"
+    assert [request["json"]["max_tokens"] for request in client.requests] == [20_000, 8_192]
+
+
+@pytest.mark.asyncio
+async def test_html_orchestrator_surfaces_anthropic_error_body() -> None:
+    client = _Client(
+        _ErrorResponse(
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "messages.0.content: Input is too long for the model context window",
+                }
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
+            instruction="Make the title shorter.",
+            existing={
+                "report_id": "report-1",
+                "kind": "dashboard",
+                "title": "Revenue Dashboard",
+                "html": "<html>old</html>",
+                "data_json": {},
+            },
+            packet=None,
+            mode="edit_existing",
+        )
+
+    message = str(exc_info.value)
+    assert "invalid_request_error: messages.0.content: Input is too long" in message
+    assert "payload_chars=" in message
 
 
 def test_malformed_tool_args_return_none() -> None:

--- a/signalpilot/gateway/tests/test_html_orchestrator.py
+++ b/signalpilot/gateway/tests/test_html_orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from copy import deepcopy
 
 import httpx
@@ -296,7 +297,7 @@ async def test_html_orchestrator_renders_followup_with_existing_report_payload()
     assert payload["freshAnalysis"] is None
     assert "fetch_snapshot" not in tool_names
     assert client.requests[0]["json"]["tool_choice"] == {"type": "tool", "name": "edit_dashboard"}
-    assert client.requests[0]["json"]["max_tokens"] == 20_000
+    assert client.requests[0]["json"]["max_tokens"] == 8_192
 
 
 @pytest.mark.asyncio
@@ -326,7 +327,10 @@ async def test_html_orchestrator_retries_lower_max_tokens_when_anthropic_rejects
         },
     )
 
-    result = await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
+    orchestrator = HtmlOrchestrator(api_key="key", http_client=client)
+    orchestrator.max_tokens = 20_000
+
+    result = await orchestrator.render_followup(
         instruction="Make the title shorter.",
         existing={
             "report_id": "report-1",
@@ -344,7 +348,7 @@ async def test_html_orchestrator_retries_lower_max_tokens_when_anthropic_rejects
 
 
 @pytest.mark.asyncio
-async def test_html_orchestrator_surfaces_anthropic_error_body() -> None:
+async def test_html_orchestrator_surfaces_and_logs_anthropic_error_body(caplog: pytest.LogCaptureFixture) -> None:
     client = _Client(
         _ErrorResponse(
             {
@@ -356,23 +360,32 @@ async def test_html_orchestrator_surfaces_anthropic_error_body() -> None:
         )
     )
 
-    with pytest.raises(RuntimeError) as exc_info:
-        await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
-            instruction="Make the title shorter.",
-            existing={
-                "report_id": "report-1",
-                "kind": "dashboard",
-                "title": "Revenue Dashboard",
-                "html": "<html>old</html>",
-                "data_json": {},
-            },
-            packet=None,
-            mode="edit_existing",
-        )
+    with caplog.at_level(logging.ERROR, logger="gateway.analysis_delivery.html_orchestrator"):
+        with pytest.raises(RuntimeError) as exc_info:
+            await HtmlOrchestrator(api_key="key", http_client=client).render_followup(
+                instruction="Make the title shorter.",
+                existing={
+                    "report_id": "report-1",
+                    "kind": "dashboard",
+                    "title": "Revenue Dashboard",
+                    "html": "<html>old</html>",
+                    "data_json": {},
+                },
+                packet=None,
+                mode="edit_existing",
+            )
 
     message = str(exc_info.value)
     assert "invalid_request_error: messages.0.content: Input is too long" in message
     assert "payload_chars=" in message
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "status=400" in log_text
+    assert "model=claude-sonnet-4-5-20250929" in log_text
+    assert "max_tokens=8192" in log_text
+    assert "payload_chars=" in log_text
+    assert "messages=1" in log_text
+    assert "tool_choice=edit_dashboard" in log_text
+    assert "invalid_request_error: messages.0.content: Input is too long" in log_text
 
 
 def test_malformed_tool_args_return_none() -> None:
@@ -586,6 +599,52 @@ def test_html_orchestrator_injects_ranked_chart_and_pie_styles() -> None:
     assert ".sp-pie-graphic" in result.html
     assert "aspect-ratio: 1 / 1;" in result.html
     assert ".sp-pie-slice-label" in result.html
+
+
+def test_html_orchestrator_normalizes_generated_pie_slice_geometry() -> None:
+    html = """<!doctype html><html><head></head><body>
+<main class="sp-report">
+  <section class="sp-chart-card">
+    <div class="sp-chart sp-pie-chart">
+      <div class="sp-pie-graphic">
+        <svg viewBox="0 0 200 200" preserveAspectRatio="xMidYMid meet">
+          <path d="M 100 100 L 100 10 A 90 90 0 0 1 177.94 64.95 Z" style="fill: var(--sp-chart-1);"></path>
+          <path d="M 100 100 L 177.94 64.95 A 90 90 0 0 1 164.95 157.94 Z" style="fill: var(--sp-chart-2);"></path>
+          <path d="M 100 100 L 164.95 157.94 A 90 90 0 0 1 35.05 157.94 Z" style="fill: var(--sp-chart-3);"></path>
+          <path d="M 100 100 L 35.05 157.94 A 90 90 0 0 1 100 10 Z" style="fill: var(--sp-chart-4);"></path>
+        </svg>
+      </div>
+      <div class="legend">
+        <div class="legend-item"><div class="legend-value">35%</div></div>
+        <div class="legend-item"><div class="legend-value">28%</div></div>
+        <div class="legend-item"><div class="legend-value">22%</div></div>
+        <div class="legend-item"><div class="legend-value">15%</div></div>
+      </div>
+    </div>
+  </section>
+</main>
+</body></html>"""
+
+    result = _normalize_html_result(
+        HtmlDeliverableResult(kind="dashboard", title="Customers", html=html),
+        {},
+    )
+
+    assert "L 177.94 64.95" not in result.html
+    assert "M 100 100 L 100 10 A 90 90 0 0 1 172.81 152.9 Z" in result.html
+    assert 'style="fill: var(--sp-chart-1);"' in result.html
+
+
+def test_html_orchestrator_default_max_tokens_uses_anthropic_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS", raising=False)
+
+    assert HtmlOrchestrator(api_key="key").max_tokens == 8_192
+
+
+def test_html_orchestrator_caps_env_max_tokens_to_anthropic_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SIGNALPILOT_ORCHESTRATOR_MAX_TOKENS", "20000")
+
+    assert HtmlOrchestrator(api_key="key").max_tokens == 8_192
 
 
 def test_html_orchestrator_timeout_defaults_to_long_dashboard_window(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- cap HTML orchestrator max_tokens at Anthropic's 8192 limit and keep retry diagnostics for forced high-token requests
- log Anthropic HTML orchestrator failures with status, model, max_tokens, payload size, message count, tools, tool choice, and sanitized error body
- normalize generated pie SVG paths from legend percentages so malformed model-authored pie geometry does not ship

## Validation
- signalpilot/gateway/.venv/bin/python -m pytest signalpilot/gateway/tests/test_html_orchestrator.py -q
- signalpilot/gateway/.venv/bin/python -m ruff check signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py signalpilot/gateway/tests/test_html_orchestrator.py
- signalpilot/gateway/.venv/bin/python -m ruff format --check signalpilot/gateway/gateway/analysis_delivery/html_orchestrator.py signalpilot/gateway/tests/test_html_orchestrator.py
- git diff --check