### PR TITLE
Persist final statement trace metadata

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/renderer.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/renderer.py
@@ -60,8 +60,15 @@ class DeliveryRenderer:
             return fallback
         try:
             rendered = await self._anthropic_render(packet)
-        except Exception as exc:
-            LOGGER.info("Analysis delivery renderer unavailable; using FINAL_STATEMENT fallback: %s", exc)
+        except Exception:
+            LOGGER.info(
+                "Analysis delivery renderer unavailable; using FINAL_STATEMENT fallback "
+                "model=%s packet_status=%s has_final_statement=%s",
+                self.model,
+                packet.status,
+                packet.final_statement is not None,
+                exc_info=True,
+            )
             return fallback
         return rendered or fallback
 

--- a/signalpilot/gateway/gateway/analysis_delivery/trace_loader.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/trace_loader.py
@@ -162,6 +162,9 @@ def load_delivery_packet_from_events(
     if status_payload.get("error"):
         _append_unique(known_errors, _string(status_payload.get("error")), 8)
 
+    if final_statement is None and latest_result:
+        final_statement = _parse_final_statement_from_result(latest_result)
+
     status = _status_from_sources(thread_status, status_payload, known_errors)
     return DeliveryPacket(
         user_request=user_request,
@@ -219,6 +222,38 @@ def _parse_final_statement(payload: dict[str, Any]) -> FinalStatement | None:
         confidence_score=confidence,
         caveats=caveats,
         handoff_notes=notes,
+    )
+
+
+def _parse_final_statement_from_result(
+    result: dict[str, Any]
+) -> FinalStatement | None:
+    statement = _string(
+        result.get("finalAnswer")
+        or result.get("final_answer")
+        or result.get("summary")
+        or result.get("notionComment")
+        or result.get("notion_comment")
+    ).strip()
+    if not statement:
+        return None
+    caveats = result.get("gotchas", result.get("caveats", []))
+    if caveats not in (None, "") and not isinstance(caveats, list):
+        caveats = [caveats]
+    handoff_notes = result.get("handoffNotes", result.get("handoff_notes"))
+    if handoff_notes in (None, ""):
+        handoff_notes = result.get("analysisMethod", result.get("analysis_method"))
+    if handoff_notes not in (None, "") and not isinstance(handoff_notes, list):
+        handoff_notes = [handoff_notes]
+    return _parse_final_statement(
+        {
+            "statement": statement,
+            "confidenceScore": result.get(
+                "confidenceScore", result.get("confidence_score")
+            ),
+            "caveats": caveats,
+            "handoffNotes": handoff_notes or [],
+        }
     )
 
 

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -239,25 +239,60 @@ def _analysis_detail_blocks(status: dict[str, Any]) -> list[dict[str, Any]]:
     return blocks[: notion_formatting.NOTION_BLOCK_CHILD_LIMIT]
 
 
+_INCOMPLETE_ANALYSIS_FALLBACK_FIELDS = (
+    "summary",
+    "finalAnswer",
+    "notionComment",
+    "analysisMethod",
+)
+_INCOMPLETE_ANALYSIS_FALLBACK_MARKERS = (
+    "analysis could not be completed",
+    "did not emit the required final_statement marker",
+    "api error: overloaded",
+    "transient overload response",
+)
+
+
+def _incomplete_analysis_fallback_match(
+    status: dict[str, Any]
+) -> dict[str, str] | None:
+    for field in _INCOMPLETE_ANALYSIS_FALLBACK_FIELDS:
+        raw = str(status.get(field) or "")
+        text = raw.lower()
+        for marker in _INCOMPLETE_ANALYSIS_FALLBACK_MARKERS:
+            index = text.find(marker)
+            if index == -1:
+                continue
+            return {
+                "field": field,
+                "marker": marker,
+                "snippet": _matched_status_snippet(raw, index),
+            }
+    return None
+
+
 def _is_incomplete_analysis_fallback(status: dict[str, Any]) -> bool:
-    text = "\n".join(
-        str(status.get(key) or "")
-        for key in (
-            "summary",
-            "finalAnswer",
-            "notionComment",
-            "analysisMethod",
-        )
-    ).lower()
-    return any(
-        marker in text
-        for marker in (
-            "analysis could not be completed",
-            "did not emit the required final_statement marker",
-            "api error: overloaded",
-            "transient overload response",
-        )
+    return _incomplete_analysis_fallback_match(status) is not None
+
+
+def _log_incomplete_analysis_fallback_skip(
+    request_id: str,
+    match: dict[str, str],
+) -> None:
+    logger.info(
+        "Skipping Notion HTML deliverable for incomplete analysis fallback: "
+        "request_id=%s field=%s marker=%s snippet=%s",
+        request_id,
+        match["field"],
+        match["marker"],
+        match["snippet"],
     )
+
+
+def _matched_status_snippet(value: str, index: int, limit: int = 180) -> str:
+    start = max(index - 40, 0)
+    end = min(index + limit, len(value))
+    return re.sub(r"\s+", " ", value[start:end]).strip()
 
 
 def _analysis_request_id(source: str, discussion_id: str) -> str:
@@ -1943,10 +1978,10 @@ async def process_routed_comment_event(
         delivery = await render_delivery(packet, api_key=delivery_api_key)
         rendered_status = delivery_result_to_status(delivery, packet, base_status=public_status)
         html_delivery_error: str | None = None
-        if html_deliverable and _is_incomplete_analysis_fallback(final_status):
-            logger.info(
-                "Skipping Notion HTML deliverable for incomplete analysis fallback: request_id=%s",
-                route.request_id,
+        incomplete_fallback_match = _incomplete_analysis_fallback_match(final_status)
+        if html_deliverable and incomplete_fallback_match:
+            _log_incomplete_analysis_fallback_skip(
+                route.request_id, incomplete_fallback_match
             )
             html_deliverable = False
         if html_deliverable:

--- a/signalpilot/gateway/gateway/trace_markers.py
+++ b/signalpilot/gateway/gateway/trace_markers.py
@@ -73,8 +73,11 @@ def _find_marker_matches(content: str) -> list[_MarkerMatch]:
     decoder = json.JSONDecoder()
     matches: list[_MarkerMatch] = []
     marker_pattern = "|".join(re.escape(marker) for marker in TRACE_CONTROL_MARKERS)
-    for match in re.finditer(rf"(?m)^[ \t]*({marker_pattern})[ \t]*:[ \t]*", content):
-        marker = _normalize_marker(match.group(1))
+    for match in re.finditer(
+        rf"(?m)^[ \t]*(?P<wrapper>\*\*)?(?P<marker>{marker_pattern})[ \t]*:[ \t]*",
+        content,
+    ):
+        marker = _normalize_marker(match.group("marker"))
         if marker is None:
             continue
         remainder = content[match.end() :]
@@ -86,7 +89,11 @@ def _find_marker_matches(content: str) -> list[_MarkerMatch]:
             continue
         if not isinstance(parsed, dict):
             continue
-        end = _extend_to_marker_line_end(content, match.end() + offset + json_end)
+        end = _extend_to_marker_line_end(
+            content,
+            match.end() + offset + json_end,
+            closing_wrapper=match.group("wrapper"),
+        )
         matches.append(_MarkerMatch(marker=marker, payload=parsed, start=match.start(), end=end))
     matches.sort(key=lambda item: item.start)
     return _drop_overlapping(matches)
@@ -102,10 +109,19 @@ def _redact_matches(content: str, matches: list[_MarkerMatch]) -> str:
     return re.sub(r"\n{3,}", "\n\n", "".join(pieces)).strip()
 
 
-def _extend_to_marker_line_end(content: str, end: int) -> int:
+def _extend_to_marker_line_end(
+    content: str,
+    end: int,
+    *,
+    closing_wrapper: str | None = None,
+) -> int:
     cursor = end
     while cursor < len(content) and content[cursor] in " \t":
         cursor += 1
+    if closing_wrapper and content.startswith(closing_wrapper, cursor):
+        cursor += len(closing_wrapper)
+        while cursor < len(content) and content[cursor] in " \t":
+            cursor += 1
     if cursor < len(content) and content[cursor] == "\r":
         cursor += 1
         if cursor < len(content) and content[cursor] == "\n":

--- a/signalpilot/gateway/tests/test_analysis_delivery.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery.py
@@ -261,6 +261,96 @@ def test_trace_control_markers_are_redacted_into_metadata_for_delivery() -> None
     assert packet.final_statement.handoff_notes == ["Used notebook SDK."]
 
 
+def test_trace_loader_uses_final_statement_metadata_with_empty_content() -> None:
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "done",
+                "content": "",
+                "metadata": {
+                    "control_markers": [
+                        {
+                            "marker": "FINAL_STATEMENT",
+                            "payload": {
+                                "statement": "Revenue increased.",
+                                "confidenceScore": "high",
+                                "caveats": ["Excludes refunds"],
+                                "handoffNotes": ["Used notebook SDK."],
+                            },
+                        }
+                    ],
+                    "result": {"summary": "Revenue increased."},
+                },
+            }
+        ],
+        status_payload={"status": "Done"},
+        thread_status="done",
+    )
+
+    assert packet.final_statement is not None
+    assert packet.final_statement.statement == "Revenue increased."
+    assert packet.final_statement.confidence_score == "high"
+    assert packet.final_statement.caveats == ["Excludes refunds"]
+    assert packet.final_statement.handoff_notes == ["Used notebook SDK."]
+
+
+def test_trace_loader_falls_back_to_done_result_final_statement() -> None:
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "done",
+                "content": "",
+                "metadata": {
+                    "result": {
+                        "final_answer": "Legacy result completed.",
+                        "confidence_score": "medium",
+                        "gotchas": ["Limited rows"],
+                        "analysis_method": "Used notebook SDK.",
+                    }
+                },
+            }
+        ],
+        status_payload={"status": "Done"},
+        thread_status="done",
+    )
+
+    assert packet.final_statement is not None
+    assert packet.final_statement.statement == "Legacy result completed."
+    assert packet.final_statement.confidence_score == "medium"
+    assert packet.final_statement.caveats == ["Limited rows"]
+    assert packet.final_statement.handoff_notes == ["Used notebook SDK."]
+
+
+def test_markdown_wrapped_trace_marker_is_compatibility_parsed() -> None:
+    content, metadata = redact_trace_control_markers(
+        '**FINAL_STATEMENT: {"statement":"Revenue increased.",'
+        '"confidenceScore":"high","caveats":[],"handoffNotes":[]}**'
+    )
+
+    assert content == ""
+    assert metadata is not None
+    assert metadata["control_markers"][0]["payload"]["statement"] == "Revenue increased."
+
+    packet = load_delivery_packet_from_events(
+        [
+            {
+                "idx": 1,
+                "type": "text",
+                "content": (
+                    '**FINAL_STATEMENT: {"statement":"Revenue increased.",'
+                    '"confidenceScore":"high","caveats":[],"handoffNotes":[]}**'
+                ),
+            }
+        ],
+        status_payload={"status": "Done"},
+    )
+
+    assert packet.final_statement is not None
+    assert packet.final_statement.statement == "Revenue increased."
+
+
 def test_slack_progress_waits_for_worker_plan_then_uses_exact_steps() -> None:
     no_plan = load_delivery_packet_from_events([], user_request="Analyze revenue")
 

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1660,6 +1661,35 @@ def test_incomplete_analysis_fallback_skips_html_deliverable() -> None:
             "finalAnswer": "Portfolio revenue grew and margin expanded.",
         }
     )
+
+
+def test_incomplete_analysis_fallback_log_includes_match_context(caplog: pytest.LogCaptureFixture) -> None:
+    status = {
+        "status": "Done",
+        "summary": "Portfolio revenue grew.",
+        "finalAnswer": (
+            "The agent did not emit the required FINAL_STATEMENT marker. "
+            "API Error: Overloaded"
+        ),
+    }
+
+    match = notion_analysis._incomplete_analysis_fallback_match(status)
+
+    assert match is not None
+    assert match["field"] == "finalAnswer"
+    assert match["marker"] == "did not emit the required final_statement marker"
+    assert "FINAL_STATEMENT marker" in match["snippet"]
+
+    with caplog.at_level(logging.INFO, logger=notion_analysis.logger.name):
+        notion_analysis._log_incomplete_analysis_fallback_skip(
+            "notion-test", match
+        )
+
+    logged = caplog.text
+    assert "request_id=notion-test" in logged
+    assert "field=finalAnswer" in logged
+    assert "marker=did not emit the required final_statement marker" in logged
+    assert "FINAL_STATEMENT marker" in logged
 
 
 @pytest.mark.asyncio

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/notion_analysis.py
@@ -67,6 +67,8 @@ OutputMode = Literal["answer", "deliverable"]
 DEFAULT_ANALYSIS_AGENT_MODEL = "claude-sonnet-4-5-20250929"
 DEFAULT_SNAPSHOT_MAX_BYTES = 1_000_000
 MAX_DATA_SNAPSHOTS = 5
+CONTROL_MARKERS_METADATA_KEY = "control_markers"
+FINAL_STATEMENT_MARKER = "FINAL_STATEMENT"
 _ANALYSIS_AGENT_MODEL_ENV_NAMES = (
     "SIGNALPILOT_ANALYSIS_AGENT_MODEL",
     "SIGNALPILOT_WORKER_AGENT_MODEL",
@@ -1278,37 +1280,124 @@ def _parse_result(text: str) -> AnalysisResult:
     )
 
 
-def _parse_final_statement_result(text: str) -> AnalysisResult:
-    data = _extract_marker_json(text, "FINAL_STATEMENT")
+def _canonical_final_statement_payload(text: str) -> dict[str, Any]:
+    return _canonical_final_statement_payload_from_data(
+        _extract_marker_json(text, FINAL_STATEMENT_MARKER)
+    )
+
+
+def _canonical_final_statement_payload_from_data(
+    data: dict[str, Any]
+) -> dict[str, Any]:
     statement = str(data.get("statement", "")).strip()
     if not statement:
         raise ValueError("Agent did not emit FINAL_STATEMENT.statement")
+    return {
+        "statement": statement,
+        "confidenceScore": _confidence_label(
+            data.get("confidenceScore", data.get("confidence_score"))
+        ),
+        "caveats": _string_list(data.get("caveats")),
+        "handoffNotes": _string_list(
+            data.get("handoffNotes", data.get("handoff_notes"))
+        ),
+    }
+
+
+def _final_statement_payload_from_result(
+    result: dict[str, Any]
+) -> dict[str, Any] | None:
+    statement = str(
+        result.get("finalAnswer")
+        or result.get("final_answer")
+        or result.get("summary")
+        or result.get("notionComment")
+        or result.get("notion_comment")
+        or ""
+    ).strip()
+    if not statement:
+        return None
+    return {
+        "statement": statement,
+        "confidenceScore": _confidence_label(
+            result.get("confidenceScore", result.get("confidence_score"))
+        ),
+        "caveats": _string_list(result.get("gotchas", result.get("caveats"))),
+        "handoffNotes": _string_list(
+            result.get(
+                "handoffNotes",
+                result.get(
+                    "handoff_notes",
+                    result.get("analysisMethod", result.get("analysis_method")),
+                ),
+            )
+        ),
+    }
+
+
+def _analysis_result_from_final_statement_payload(
+    payload: dict[str, Any]
+) -> AnalysisResult:
+    statement = str(payload.get("statement", "")).strip()
+    if not statement:
+        raise ValueError("Agent did not emit FINAL_STATEMENT.statement")
     confidence = _confidence_label(
-        data.get("confidenceScore", data.get("confidence_score"))
+        payload.get("confidenceScore", payload.get("confidence_score"))
     )
-    caveats = data.get("caveats") or []
-    if not isinstance(caveats, list):
-        caveats = [str(caveats)]
-    handoff_notes = (
-        data.get("handoffNotes", data.get("handoff_notes", [])) or []
+    caveats = _string_list(payload.get("caveats"))
+    handoff_notes = _string_list(
+        payload.get("handoffNotes", payload.get("handoff_notes"))
     )
-    if not isinstance(handoff_notes, list):
-        handoff_notes = [str(handoff_notes)]
     return AnalysisResult(
         summary=statement[:500],
         confidence_score=confidence,
         final_answer=statement,
-        gotchas=[str(item) for item in caveats],
-        analysis_method="; ".join(str(item) for item in handoff_notes),
+        gotchas=caveats,
+        analysis_method="; ".join(handoff_notes),
         notion_comment=statement[:1200],
         notion_charts=[],
     )
 
 
+def _parse_final_statement_result(text: str) -> AnalysisResult:
+    return _analysis_result_from_final_statement_payload(
+        _canonical_final_statement_payload(text)
+    )
+
+
+def _done_trace_metadata(
+    record: AnalysisRecord,
+    final_statement_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "request_id": record.request_id,
+        "status": record.status,
+        "result": asdict(record.result) if record.result else None,
+    }
+    if final_statement_payload is not None:
+        metadata[CONTROL_MARKERS_METADATA_KEY] = [
+            {
+                "marker": FINAL_STATEMENT_MARKER,
+                "payload": dict(final_statement_payload),
+            }
+        ]
+    return metadata
+
+
+def _string_list(value: Any) -> list[str]:
+    if value in (None, ""):
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [text for item in items if (text := str(item).strip())]
+
+
 def _extract_marker_json(text: str, marker: str) -> dict[str, Any]:
     decoder = json.JSONDecoder()
     latest: dict[str, Any] | None = None
-    for match in re.finditer(rf"(?m)^\s*{re.escape(marker)}\s*:\s*", text):
+    for match in re.finditer(
+        rf"(?m)^\s*(?:\*\*)?{re.escape(marker)}\s*:\s*",
+        text,
+    ):
         try:
             parsed, _ = decoder.raw_decode(text[match.end() :].lstrip())
         except json.JSONDecodeError:
@@ -3233,6 +3322,7 @@ async def _run_analysis(
         output_mode=record.output_mode,
     )
     text_parts: list[str] = []
+    final_statement_payload: dict[str, Any] | None = None
     store = get_gateway_chat_trace_store()
 
     async def append_trace_event(event_data: dict[str, Any]) -> int:
@@ -3367,17 +3457,18 @@ async def _run_analysis(
                     "is_error": False,
                     "cost_usd": None,
                     "turn": 0,
-                    "metadata": {
-                        "request_id": record.request_id,
-                        "status": record.status,
-                        "result": asdict(record.result),
-                    },
+                    "metadata": _done_trace_metadata(record),
                 },
             )
             return
 
         try:
-            record.result = _parse_final_statement_result("".join(text_parts))
+            final_statement_payload = _canonical_final_statement_payload(
+                "".join(text_parts)
+            )
+            record.result = _analysis_result_from_final_statement_payload(
+                final_statement_payload
+            )
         except Exception:
             if not _is_transient_agent_overload("".join(text_parts)):
                 raise
@@ -3407,7 +3498,12 @@ async def _run_analysis(
                 _agent_overload_retry_prompt(body.prompt),
                 new_chat_for_run=False,
             )
-            record.result = _parse_final_statement_result("".join(text_parts))
+            final_statement_payload = _canonical_final_statement_payload(
+                "".join(text_parts)
+            )
+            record.result = _analysis_result_from_final_statement_payload(
+                final_statement_payload
+            )
         record.status = "Done"
         record.error = None
         _persist_record_completion_artifacts(app_state, record, checkpoint=checkpoint_completion)
@@ -3433,18 +3529,22 @@ async def _run_analysis(
                 "is_error": False,
                 "cost_usd": None,
                 "turn": 0,
-                "metadata": {
-                    "request_id": record.request_id,
-                    "status": record.status,
-                    "result": asdict(record.result) if record.result else None,
-                },
+                "metadata": _done_trace_metadata(
+                    record, final_statement_payload
+                ),
             },
         )
     except Exception as e:
         LOGGER.exception("Notion analysis %s failed", record.request_id)
         failed = False
+        final_statement_payload = None
         try:
-            record.result = _parse_final_statement_result("".join(text_parts))
+            final_statement_payload = _canonical_final_statement_payload(
+                "".join(text_parts)
+            )
+            record.result = _analysis_result_from_final_statement_payload(
+                final_statement_payload
+            )
             record.status = "Done"
             record.error = None
         except Exception:
@@ -3519,13 +3619,9 @@ async def _run_analysis(
                     "is_error": False,
                     "cost_usd": None,
                     "turn": 0,
-                    "metadata": {
-                        "request_id": record.request_id,
-                        "status": record.status,
-                        "result": asdict(record.result)
-                        if record.result
-                        else None,
-                    },
+                    "metadata": _done_trace_metadata(
+                        record, final_statement_payload
+                    ),
                 },
             )
     finally:
@@ -3617,6 +3713,47 @@ def _mark_stale_analysis_failed(
     )
 
 
+def _trace_event_metadata(event: dict[str, Any]) -> dict[str, Any]:
+    metadata = event.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = event.get("metadata_json")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _final_statement_payload_from_trace_events(
+    events: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    latest_marker_payload: dict[str, Any] | None = None
+    latest_result_payload: dict[str, Any] | None = None
+    for event in events:
+        metadata = _trace_event_metadata(event)
+        raw_markers = metadata.get(CONTROL_MARKERS_METADATA_KEY)
+        if isinstance(raw_markers, list):
+            for item in raw_markers:
+                if not isinstance(item, dict):
+                    continue
+                marker = str(item.get("marker") or "").strip().upper()
+                payload = item.get("payload")
+                if marker != FINAL_STATEMENT_MARKER or not isinstance(payload, dict):
+                    continue
+                try:
+                    latest_marker_payload = (
+                        _canonical_final_statement_payload_from_data(payload)
+                    )
+                except ValueError:
+                    continue
+
+        if str(event.get("type") or "").lower() == "done":
+            result = metadata.get("result")
+            if isinstance(result, dict):
+                latest_result_payload = (
+                    _final_statement_payload_from_result(result)
+                    or latest_result_payload
+                )
+
+    return latest_marker_payload or latest_result_payload
+
+
 async def _recover_completed_record_from_trace(
     app_state: AppState, record: AnalysisRecord
 ) -> bool:
@@ -3632,6 +3769,15 @@ async def _recover_completed_record_from_trace(
         if not isinstance(thread, dict) or thread.get("status") != "done":
             return False
         events = await store.get_events(record.session_id)
+        payload = _final_statement_payload_from_trace_events(events)
+        if payload is not None:
+            record.result = _analysis_result_from_final_statement_payload(
+                payload
+            )
+            record.status = "Done"
+            record.error = None
+            _save_registry(app_state)
+            return True
         text = "".join(
             str(event.get("content") or "")
             for event in events

--- a/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
+++ b/signalpilot/notebook-server/tests/_server/api/test_notion_analysis_template.py
@@ -362,6 +362,8 @@ def test_analysis_agent_parses_streamed_final_statement(
     from signalpilot._server.ai import chat_store, claude_agent
     from signalpilot._server.ai.claude_agent import AgentEvent
 
+    appended_events: list[dict] = []
+
     class FakeStore:
         async def upsert_thread(self, thread) -> None:
             del thread
@@ -370,7 +372,8 @@ def test_analysis_agent_parses_streamed_final_statement(
             del thread_id
 
         async def append_event(self, thread_id: str, event_data: dict) -> int:
-            del thread_id, event_data
+            del thread_id
+            appended_events.append(event_data)
             return 0
 
     project_root = tmp_path / "projects" / "project-1"
@@ -431,6 +434,106 @@ def test_analysis_agent_parses_streamed_final_statement(
     assert record.status == "Done"
     assert record.result is not None
     assert record.result.final_answer == "Streamed done"
+    done_event = [event for event in appended_events if event["type"] == "done"][-1]
+    marker = done_event["metadata"]["control_markers"][0]
+    assert marker == {
+        "marker": "FINAL_STATEMENT",
+        "payload": {
+            "statement": "Streamed done",
+            "confidenceScore": "high",
+            "caveats": [],
+            "handoffNotes": [],
+        },
+    }
+
+
+def test_analysis_agent_parses_markdown_wrapped_final_statement(
+    tmp_path, monkeypatch
+) -> None:
+    from signalpilot._server.ai import chat_store, claude_agent
+    from signalpilot._server.ai.claude_agent import AgentEvent
+
+    appended_events: list[dict] = []
+
+    class FakeStore:
+        async def upsert_thread(self, thread) -> None:
+            del thread
+
+        async def clear_events(self, thread_id: str) -> None:
+            del thread_id
+
+        async def append_event(self, thread_id: str, event_data: dict) -> int:
+            del thread_id
+            appended_events.append(event_data)
+            return 0
+
+    project_root = tmp_path / "projects" / "project-1"
+    project_root.mkdir(parents=True)
+    app_state = SimpleNamespace(
+        request=SimpleNamespace(app=object(), headers={}),
+        session_manager=SimpleNamespace(
+            workspace=SimpleNamespace(directory=str(tmp_path / "workspace"))
+        ),
+    )
+    record = _record()
+
+    async def fake_run_notebook_agent(**kwargs: object):
+        del kwargs
+        yield AgentEvent(
+            type="text",
+            content=(
+                '**FINAL_STATEMENT: {"statement":"Bold wrapped done",'
+                '"confidenceScore":"medium","caveats":["Limited rows"],'
+                '"handoffNotes":["Used notebook SDK."]}**'
+            ),
+        )
+
+    monkeypatch.setattr(
+        notion_analysis, "_project_root", lambda _app_state: project_root
+    )
+    monkeypatch.setattr(
+        notion_analysis,
+        "_build_analysis_warm_context",
+        lambda *_args, **_kwargs: "",
+    )
+    monkeypatch.setattr(
+        notion_analysis, "_ensure_session", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        notion_analysis, "_save_registry", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        notion_analysis,
+        "_persist_record_completion_artifacts",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_store, "get_gateway_chat_trace_store", lambda: FakeStore()
+    )
+    monkeypatch.setattr(
+        claude_agent, "run_notebook_agent", fake_run_notebook_agent
+    )
+
+    asyncio.run(
+        notion_analysis._run_analysis(
+            app_state,
+            record,
+            _body(),
+            new_chat=True,
+        )
+    )
+
+    assert record.status == "Done"
+    assert record.result is not None
+    assert record.result.final_answer == "Bold wrapped done"
+    assert "Analysis could not be completed" not in record.result.final_answer
+    done_event = [event for event in appended_events if event["type"] == "done"][-1]
+    assert done_event["metadata"]["control_markers"][0]["payload"] == {
+        "statement": "Bold wrapped done",
+        "confidenceScore": "medium",
+        "caveats": ["Limited rows"],
+        "handoffNotes": ["Used notebook SDK."],
+    }
 
 
 def test_analysis_agent_retries_once_after_transient_overload(
@@ -717,6 +820,72 @@ def test_status_recover_completed_refresh_from_trace(monkeypatch) -> None:
     assert record.error is None
     assert record.result is not None
     assert record.result.final_answer == "Recovered"
+    assert calls == ["save_registry"]
+
+
+def test_status_recover_completed_refresh_from_structured_trace_metadata(
+    monkeypatch,
+) -> None:
+    record = _record()
+    record.status = "Analyzing"
+
+    class FakeTraceStore:
+        async def get_thread(self, thread_id: str):
+            assert thread_id == record.session_id
+            return {"status": "done"}
+
+        async def get_events(self, thread_id: str):
+            assert thread_id == record.session_id
+            return [
+                {
+                    "type": "done",
+                    "content": "",
+                    "metadata": {
+                        "control_markers": [
+                            {
+                                "marker": "FINAL_STATEMENT",
+                                "payload": {
+                                    "statement": "Recovered from metadata",
+                                    "confidenceScore": "medium",
+                                    "caveats": ["Limited rows"],
+                                    "handoffNotes": ["Used notebook SDK."],
+                                },
+                            }
+                        ],
+                        "result": {
+                            "final_answer": "Should not win over marker metadata"
+                        },
+                    },
+                }
+            ]
+
+    from signalpilot._server.ai import chat_store
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        chat_store, "get_gateway_chat_trace_store", lambda: FakeTraceStore()
+    )
+    monkeypatch.setattr(
+        notion_analysis,
+        "_save_registry",
+        lambda *_args, **_kwargs: calls.append("save_registry"),
+    )
+
+    recovered = asyncio.run(
+        notion_analysis._recover_completed_record_from_trace(
+            SimpleNamespace(), record
+        )
+    )
+
+    assert recovered is True
+    assert record.status == "Done"
+    assert record.error is None
+    assert record.result is not None
+    assert record.result.final_answer == "Recovered from metadata"
+    assert record.result.confidence_score == "medium"
+    assert record.result.gotchas == ["Limited rows"]
+    assert record.result.analysis_method == "Used notebook SDK."
     assert calls == ["save_registry"]
 
 


### PR DESCRIPTION
## Summary
- Persist FINAL_STATEMENT as structured trace metadata on notebook-server done events.
- Recover and load delivery packets from control_markers first, then done.metadata.result, with legacy text parsing as compatibility fallback.
- Support markdown-wrapped FINAL_STATEMENT markers only as recovery compatibility, and improve fallback/renderer diagnostics.

## Evidence
- Queried local SignalPilot Postgres for session-notion-e05fe29398045de7; local DB returned 0 rows.
- Older local Notion cloud-demo gateway DB did not have gateway_chat_trace_events.

## Tests
- cd signalpilot/gateway && uv run pytest tests/test_analysis_delivery.py tests/test_notion_analysis.py
- cd signalpilot/notebook-server && uv run pytest tests/_server/api/test_notion_analysis_template.py
- cd signalpilot/gateway && uv run ruff check gateway/analysis_delivery/renderer.py gateway/analysis_delivery/trace_loader.py gateway/notion/analysis.py gateway/trace_markers.py tests/test_analysis_delivery.py tests/test_notion_analysis.py
- cd signalpilot/notebook-server && uv run ruff check signalpilot/_server/api/endpoints/notion_analysis.py tests/_server/api/test_notion_analysis_template.py