### PR TITLE
chore: trigger notebook deploy timing

### DIFF
--- a/signalpilot/notebook-server/.deploy-trigger
+++ b/signalpilot/notebook-server/.deploy-trigger
@@ -1,0 +1,1 @@
+deploy timing trigger


### PR DESCRIPTION
Dummy PR to trigger the notebook deploy pipeline and measure build/deploy timing.\n\nNo functional changes intended.