### PR TITLE
chore: trigger notebook rebuild timing

### DIFF
--- a/Dockerfile.notebook
+++ b/Dockerfile.notebook
@@ -1,5 +1,7 @@
 FROM python:3.13-slim
 
+# Deploy timing probe: keep this comment-only change rebuild-visible.
+
 RUN groupadd -g 10001 notebook && \
     useradd -r -u 10001 -g notebook notebook && \
     mkdir -p /workspace /home/notebook/.sp && \

--- a/signalpilot/notebook-server/.deploy-trigger
+++ b/signalpilot/notebook-server/.deploy-trigger
@@ -1,1 +1,0 @@
-deploy timing trigger


### PR DESCRIPTION
Dummy PR to trigger the notebook deploy pipeline with a tracked Dockerfile comment change.\n\nAlso removes the previous marker file. No functional changes intended.