### PR TITLE
chore: trigger gateway and notebook source rebuilds

### DIFF
--- a/signalpilot/gateway/gateway/__init__.py
+++ b/signalpilot/gateway/gateway/__init__.py
@@ -1,3 +1,5 @@
 """SignalPilot Gateway — governed MCP server for AI database access."""
 
+# Deploy timing probe: source-level touch for gateway image rebuilds.
+
 __version__ = "0.1.0"

--- a/signalpilot/notebook-server/signalpilot/__init__.py
+++ b/signalpilot/notebook-server/signalpilot/__init__.py
@@ -13,6 +13,8 @@ sp is designed to be:
     5. fun
 """
 
+# Deploy timing probe: source-level touch for notebook image rebuilds.
+
 __all__ = [  # noqa: RUF022
     # Core API
     "App",


### PR DESCRIPTION
Dummy PR to force rebuild timing for the gateway and notebook images with source-level comment changes.\n\nTouches files copied by both Docker images:\n- signalpilot/gateway/gateway/__init__.py\n- signalpilot/notebook-server/signalpilot/__init__.py\n\nNo functional changes intended.