### PR TITLE
fix: continue notebook deploy when gateway rollout is not readable

### DIFF
--- a/scripts/deploy-gateway-notebook-eks.sh
+++ b/scripts/deploy-gateway-notebook-eks.sh
@@ -137,11 +137,22 @@ GATEWAY_DEPLOY_FILE="$(basename "$GATEWAY_DEPLOY_SCRIPT")"
 )
 
 if [[ "${SKIP_GATEWAY_ROLLOUT_WAIT:-0}" != "1" ]]; then
-  log "Waiting for gateway rollout: ${GATEWAY_NAMESPACE}/${GATEWAY_DEPLOYMENT}"
-  run kubectl rollout status \
-    -n "$GATEWAY_NAMESPACE" \
-    "deployment/${GATEWAY_DEPLOYMENT}" \
-    --timeout="${GATEWAY_ROLLOUT_TIMEOUT:-300s}"
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    log "DRY_RUN=1: would wait for gateway rollout: ${GATEWAY_NAMESPACE}/${GATEWAY_DEPLOYMENT}"
+    run kubectl rollout status \
+      -n "$GATEWAY_NAMESPACE" \
+      "deployment/${GATEWAY_DEPLOYMENT}" \
+      --timeout="${GATEWAY_ROLLOUT_TIMEOUT:-300s}"
+  elif kubectl auth can-i get deployments.apps -n "$GATEWAY_NAMESPACE" >/dev/null 2>&1 \
+    && kubectl get deployment -n "$GATEWAY_NAMESPACE" "$GATEWAY_DEPLOYMENT" >/dev/null 2>&1; then
+    log "Waiting for gateway rollout: ${GATEWAY_NAMESPACE}/${GATEWAY_DEPLOYMENT}"
+    run kubectl rollout status \
+      -n "$GATEWAY_NAMESPACE" \
+      "deployment/${GATEWAY_DEPLOYMENT}" \
+      --timeout="${GATEWAY_ROLLOUT_TIMEOUT:-300s}"
+  else
+    log "Skipping gateway rollout wait; current kube identity cannot read ${GATEWAY_NAMESPACE}/${GATEWAY_DEPLOYMENT} or it does not exist"
+  fi
 fi
 
 if [[ "${DRY_RUN:-0}" == "1" ]]; then
@@ -171,7 +182,13 @@ if [[ "${DELETE_SP_NB_NAMESPACES:-0}" == "1" ]]; then
 else
   log "Deleting notebook pods in namespaces: ${NOTEBOOK_NAMESPACES[*]}"
   for namespace in "${NOTEBOOK_NAMESPACES[@]}"; do
-    run kubectl delete pods -n "$namespace" --all --wait=false --ignore-not-found
+    mapfile -t NOTEBOOK_PODS < <(kubectl get pods -n "$namespace" -o name)
+    if [[ "${#NOTEBOOK_PODS[@]}" -eq 0 ]]; then
+      log "No notebook pods found in namespace: ${namespace}"
+      continue
+    fi
+    log "Deleting notebook pods in ${namespace}: ${NOTEBOOK_PODS[*]}"
+    run kubectl delete -n "$namespace" --wait=false --ignore-not-found "${NOTEBOOK_PODS[@]}"
   done
 fi
 

--- a/signalpilot/gateway/gateway/__init__.py
+++ b/signalpilot/gateway/gateway/__init__.py
@@ -1,5 +1,5 @@
 """SignalPilot Gateway — governed MCP server for AI database access."""
 
-# Deploy timing probe: source-level touch for gateway image rebuilds.
+# Deploy timing probe: gateway source touched for rollout RBAC fix validation.
 
 __version__ = "0.1.0"

--- a/signalpilot/notebook-server/signalpilot/__init__.py
+++ b/signalpilot/notebook-server/signalpilot/__init__.py
@@ -13,7 +13,7 @@ sp is designed to be:
     5. fun
 """
 
-# Deploy timing probe: source-level touch for notebook image rebuilds.
+# Deploy timing probe: notebook source touched for rollout RBAC fix validation.
 
 __all__ = [  # noqa: RUF022
     # Core API


### PR DESCRIPTION
Fixes the deploy script behavior seen on the EC2 deploy host.

Changes:
- Skip gateway rollout wait when the current kube identity cannot read the gateway Deployment or the Deployment does not exist.
- Continue to notebook pod recycling instead of failing before cleanup.
- Delete notebook pods individually instead of using kubectl delete pods --all, because the EC2 role has list pods and delete pods but not deletecollection pods.
- Touch source-level comments in gateway and notebook code so both image builds are triggered for validation.

Validation:
- bash -n scripts/deploy-gateway-notebook-eks.sh
- git diff --check -- scripts/deploy-gateway-notebook-eks.sh signalpilot/gateway/gateway/__init__.py signalpilot/notebook-server/signalpilot/__init__.py
