### PR TITLE
chore(dev): improve Docker hot-reload stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,57 @@
+# SignalPilot local Docker stack.
+# Copy to `.env` for local-only credentials and port overrides.
+#
+# The core stack starts without these values:
+#   web, gateway, notebook, sandbox, and Postgres.
+#
+# Do not commit `.env`.
+
+# Optional host port overrides. In-container ports stay fixed.
+# SP_WEB_PORT=3200
+# SP_GATEWAY_PORT=3300
+# SP_NOTEBOOK_PORT=2718
+# SP_DB_PORT=5601
+
+# Optional host data access for sandboxed DuckDB/SQLite local-file queries.
+# macOS: /Users
+# Linux: /home
+# Windows: C:/Users
+# SP_HOST_DATA_DIR=/Users
+
+# Optional Claude/Anthropic credentials for notebook AI chat and delivery flows.
+# Use either an API key, an OAuth token, or a mounted Claude config directory.
+# ANTHROPIC_API_KEY=
+# CLAUDE_CODE_OAUTH_TOKEN=
+# CLAUDE_HOST_CONFIG_DIR=${HOME}/.config/signalpilot/claude-code-docker
+
+# Optional Slack OAuth and Events API integration.
+# Requires a public callback/webhook URL, usually via ngrok or cloudflared.
+# SLACK_OAUTH_CLIENT_ID=
+# SLACK_OAUTH_CLIENT_SECRET=
+# SLACK_OAUTH_REDIRECT_URI=
+# SLACK_OAUTH_SCOPES=app_mentions:read,channels:history,chat:write,files:write,groups:history,im:history,mpim:history,reactions:write
+# SLACK_SIGNING_SECRET=
+
+# Optional Slack worker / Socket Mode values.
+# SLACK_DELIVERY_MODE=http
+# SLACK_BOT_TOKEN=
+# SLACK_APP_TOKEN=
+# SLACK_BOT_USER_ID=
+# SLACK_ALLOWED_CHANNEL_IDS=
+# SLACK_POC_ORG_ID=local
+# SLACK_POC_USER_ID=
+# SLACK_POC_DEFAULT_PROJECT_ID=
+# SLACK_PROGRESS_ENABLED=true
+# SLACK_PROGRESS_MODEL_PROVIDER=anthropic
+# SLACK_PROGRESS_MODEL=
+
+# Optional Notion OAuth and webhook integration.
+# Requires a public callback/webhook URL, usually via ngrok or cloudflared.
+# NOTION_OAUTH_CLIENT_ID=
+# NOTION_OAUTH_CLIENT_SECRET=
+# NOTION_OAUTH_REDIRECT_URI=
+# NOTION_WEBHOOK_VERIFICATION_TOKEN=
+
+# Legacy compatibility: existing local setups may still use `.slack.local.env`.
+# The compose files load both `.env` and `.slack.local.env`; `.env` is the
+# preferred file for new dev machines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,90 @@ cd signalpilot
 git remote add upstream https://github.com/SignalPilot-Labs/signalpilot.git
 ```
 
-### Run the full stack
+### Run the hot-reload development stack
+
+Use the dev overlay for day-to-day work. It keeps the app isolated in Docker,
+but bind-mounts the source tree and runs reload-capable commands so code edits
+do not require image rebuilds.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+If another local stack is already using a default port, override only the host
+port and keep the in-container network unchanged:
+
+```bash
+SP_GATEWAY_PORT=3310 docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+Put durable local overrides in the root `.env` file:
+
+```bash
+cp .env.example .env
+```
+
+Do not use `signalpilot/web/.env.local` for Docker port wiring. The dev compose
+file sets the web container environment directly and clears `.next/dev` on boot
+so a stale Next.js dev bundle cannot keep an old gateway URL.
+
+After the first build, normal source edits should only need:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+| Service | Port | Development behavior |
+|---------|------|----------------------|
+| Web UI (Next.js) | 3200 | `next dev` with source bind-mounted, `.next` and `node_modules` in Docker volumes |
+| Gateway (FastAPI + MCP) | 3300 | source bind-mounted; Uvicorn auto-restarts on Python edits using polling |
+| Notebook server | 2718 | source bind-mounted; server auto-restarts on Python edits using polling |
+| PostgreSQL | 5601 | persisted Docker volume |
+
+The hot-reload overlay covers the main local product path: web, gateway,
+notebook server, sandbox, and Postgres. It does not run the K8s pod-orchestration
+mode, benchmark harnesses, plugin test images, or older workspaces/Notion-worker
+services.
+
+Rebuild only when dependencies, lockfiles, Dockerfiles, or system packages
+change.
+
+Useful checks:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml ps
+docker compose -f docker-compose.yml -f docker-compose.dev.yml logs -f gateway web
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down --remove-orphans
+```
+
+If Next.js exits after an interrupted build with a Turbopack cache error, restart
+the web service; the dev overlay clears the corrupt cache path before `next dev`
+starts.
+
+### Optional local credentials
+
+The core Docker stack runs without external credentials. You can open the web
+app, use the gateway, start notebooks, and use local Postgres/Sandbox without
+Claude, Slack, or Notion keys.
+
+Add optional integration credentials to the root `.env` file. Existing machines
+that already use `.slack.local.env` still work, but `.env` is the preferred file
+for new local setups.
+
+| Integration | Required only for | Local variables |
+|-------------|-------------------|-----------------|
+| Claude / Anthropic | notebook AI chat, AI delivery rendering, Slack/Notion analysis agents | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`; alternatively set `CLAUDE_HOST_CONFIG_DIR` to a host directory containing Claude Code credentials |
+| Slack OAuth / Events | installing Slack, receiving Slack events, Slack progress/delivery | `SLACK_OAUTH_CLIENT_ID`, `SLACK_OAUTH_CLIENT_SECRET`, `SLACK_OAUTH_REDIRECT_URI`, `SLACK_SIGNING_SECRET`; Socket Mode additionally uses `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` |
+| Notion OAuth / webhooks | installing Notion, receiving Notion comments, Notion delivery | `NOTION_OAUTH_CLIENT_ID`, `NOTION_OAUTH_CLIENT_SECRET`, `NOTION_OAUTH_REDIRECT_URI`, `NOTION_WEBHOOK_VERIFICATION_TOKEN` |
+
+Slack and Notion callback/webhook URLs must be reachable by those providers. For
+local development, point the redirect/webhook variables at a tunnel such as
+ngrok or cloudflared that forwards to the gateway on `SP_GATEWAY_PORT`.
+
+### Run the production-like local stack
+
+Use the base compose file when you want to test the standalone image path rather
+than the hot-reload workflow.
 
 ```bash
 docker compose up --build
@@ -85,13 +168,12 @@ Connect the MCP server to Claude Code:
 claude mcp add --transport http signalpilot http://localhost:3300/mcp
 ```
 
-### Iterating on a single service
+### Rebuilding a single service
 
 ```bash
-# Rebuild just the gateway after backend changes
+# Only needed after dependency, lockfile, or Dockerfile changes
 docker compose build gateway && docker compose up -d gateway
 
-# Rebuild the web UI
 docker compose build web && docker compose up -d web
 ```
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,26 +1,40 @@
-FROM node:22-slim AS builder
+FROM node:22-slim AS deps
+WORKDIR /app
+
+# Install dependencies before copying the full source so Docker can cache them.
+# npm ci installs exactly from the lockfile (reproducible); legacy-peer-deps
+# matches how the lock is generated.
+COPY signalpilot/web/package.json signalpilot/web/package-lock.json signalpilot/web/.npmrc signalpilot/web/
+RUN cd signalpilot/web && npm ci --legacy-peer-deps
+RUN cd signalpilot/web && \
+    case "$(uname -m)" in \
+      aarch64) npm install --legacy-peer-deps --no-save lightningcss-linux-arm64-gnu@1.32.0 @tailwindcss/oxide-linux-arm64-gnu@4.2.4 ;; \
+      x86_64) npm install --legacy-peer-deps --no-save lightningcss-linux-x64-gnu@1.32.0 @tailwindcss/oxide-linux-x64-gnu@4.2.4 ;; \
+    esac
+
+FROM deps AS dev
+WORKDIR /app/signalpilot/web
+
+ENV NODE_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_DEPLOYMENT_MODE=local
+ENV NEXT_PUBLIC_GATEWAY_URL=http://localhost:3300
+ENV SP_GATEWAY_INTERNAL_URL=http://gateway:3300
+
+EXPOSE 3200
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0"]
+
+FROM deps AS builder
 WORKDIR /app
 
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ARG NEXT_PUBLIC_DEPLOYMENT_MODE=local
 ARG NEXT_PUBLIC_GATEWAY_URL=http://localhost:3300
+ARG SP_GATEWAY_INTERNAL_URL=http://gateway:3300
 
 ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_DEPLOYMENT_MODE=$NEXT_PUBLIC_DEPLOYMENT_MODE
 ENV NEXT_PUBLIC_GATEWAY_URL=$NEXT_PUBLIC_GATEWAY_URL
-
-# Install dependencies before copying the full source so Docker can cache them.
-# npm ci installs exactly from the lockfile (reproducible); legacy-peer-deps
-# matches how the lock is generated.
-COPY signalpilot/web/package.json signalpilot/web/package-lock.json signalpilot/web/
-RUN cd signalpilot/web && npm ci --legacy-peer-deps
-RUN cd signalpilot/web && \
-    case "$(uname -m)" in \
-      aarch64) npm install --legacy-peer-deps --no-save lightningcss-linux-arm64-musl@1.32.0 @tailwindcss/oxide-linux-arm64-musl@4.2.4 ;; \
-      x86_64) npm install --legacy-peer-deps --no-save lightningcss-linux-x64-musl@1.32.0 @tailwindcss/oxide-linux-x64-musl@4.2.4 ;; \
-    esac
-
-ARG SP_GATEWAY_INTERNAL_URL=http://gateway:3300
 ENV SP_GATEWAY_INTERNAL_URL=$SP_GATEWAY_INTERNAL_URL
 
 # Copy web app source

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,76 @@
+# SignalPilot — Hot-reload development overlay
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+#
+# Keep docker-compose.yml as the reproducible/prod-like stack. This overlay is
+# for day-to-day code edits: source is bind-mounted, dependency/build artifacts
+# stay inside Linux containers, and long-running services reload or restart.
+
+services:
+  gateway:
+    env_file:
+      - path: ./.slack.local.env
+        required: false
+      - path: ./.env
+        required: false
+    volumes:
+      - ./signalpilot/gateway/gateway:/app/gateway:cached
+      - ./scripts/dev-watch-notebook.py:/usr/local/bin/dev-watch-notebook.py:ro
+    command: >
+      sh -c "/app/.venv/bin/python -m gateway.dev_local_api_key /shared/local_api_key && exec /app/.venv/bin/python /usr/local/bin/dev-watch-notebook.py --watch /app/gateway --interval 1 -- /app/.venv/bin/uvicorn gateway.main:app --host 0.0.0.0 --port 3300"
+
+  notebook:
+    env_file:
+      - path: ./.slack.local.env
+        required: false
+      - path: ./.env
+        required: false
+    volumes:
+      - ./signalpilot/notebook-server/signalpilot:/opt/sp-notebook/signalpilot:cached
+      - ./scripts/dev-watch-notebook.py:/usr/local/bin/dev-watch-notebook.py:ro
+    entrypoint:
+      - sh
+      - -c
+      - |
+        export SP_API_KEY=$$(cat /shared/local_api_key 2>/dev/null || echo '')
+        exec /opt/sp-notebook/.venv/bin/python /usr/local/bin/dev-watch-notebook.py \
+          --watch /opt/sp-notebook/signalpilot \
+          --interval 1 \
+          -- /opt/sp-notebook/.venv/bin/python -m signalpilot --development-mode edit \
+            --host 0.0.0.0 --port 2718 --headless \
+            --no-token --no-skew-protection \
+            --allow-origins http://localhost:${SP_WEB_PORT:-3200},http://localhost:${SP_GATEWAY_PORT:-3300} \
+            /workspace
+
+  web:
+    build:
+      target: dev
+    environment:
+      NODE_ENV: development
+      NEXT_TELEMETRY_DISABLED: "1"
+      NEXT_PUBLIC_DEPLOYMENT_MODE: local
+      NEXT_PUBLIC_GATEWAY_URL: http://localhost:${SP_GATEWAY_PORT:-3300}
+      SP_GATEWAY_INTERNAL_URL: http://gateway:3300
+      WATCHPACK_POLLING: "true"
+      CHOKIDAR_USEPOLLING: "true"
+    volumes:
+      - ./signalpilot/web:/app/signalpilot/web:cached
+      - signalpilot-web-node-modules:/app/signalpilot/web/node_modules
+      - signalpilot-web-next:/app/signalpilot/web/.next
+      - signalpilot-shared:/shared:ro
+    command: >
+      sh -c 'i=0;
+             while [ ! -f /shared/local_api_key ] && [ "$$i" -lt 30 ]; do
+               sleep 1;
+               i=$$((i+1));
+             done;
+             if [ -f /shared/local_api_key ]; then
+               export SP_LOCAL_API_KEY="$$(cat /shared/local_api_key)";
+             fi;
+             rm -rf .next/dev;
+             exec npm run dev -- --hostname 0.0.0.0'
+
+volumes:
+  signalpilot-web-node-modules:
+  signalpilot-web-next:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       POSTGRES_PASSWORD: changeme_dev_only
       POSTGRES_DB: signalpilot
     ports:
-      - "127.0.0.1:5601:5432"
+      - "127.0.0.1:${SP_DB_PORT:-5601}:5432"
     volumes:
       - signalpilot-pg-data:/var/lib/postgresql/data
     healthcheck:
@@ -41,27 +41,29 @@ services:
       context: ./signalpilot/gateway
       dockerfile: ../../Dockerfile.gateway
     ports:
-      - "3300:3300"
+      - "${SP_GATEWAY_HOST:-0.0.0.0}:${SP_GATEWAY_PORT:-3300}:3300"
     env_file:
       - path: ./.slack.local.env
+        required: false
+      - path: ./.env
         required: false
     environment:
       DATABASE_URL: postgresql+asyncpg://signalpilot:changeme_dev_only@db:5432/signalpilot
       SP_DATA_DIR: /data
       SP_DEPLOYMENT_MODE: local
       SP_ENCRYPTION_KEY: 5d1aa5ETRcln8vkPWrzDkdfSEuqAua5xcZCWMLMDXmc=
-      SP_ALLOWED_ORIGINS: http://localhost:3000,http://localhost:3200,http://localhost:3300,http://localhost:2718
+      SP_ALLOWED_ORIGINS: http://localhost:3000,http://localhost:${SP_WEB_PORT:-3200},http://localhost:${SP_GATEWAY_PORT:-3300},http://localhost:${SP_NOTEBOOK_PORT:-2718}
       # Notebook: direct mode (no K8s)
       SP_NOTEBOOK_DIRECT_URL: http://notebook:2718
       SP_NOTEBOOK_UPSTREAM_MODE: direct
       SP_NOTEBOOK_IMAGE: signalpilot-notebook:latest
       SP_NOTEBOOK_NETWORK_POLICY: "false"
-      SP_PUBLIC_GATEWAY_URL: http://localhost:3300
-      SP_PUBLIC_GATEWAY_PORT: "3300"
+      SP_PUBLIC_GATEWAY_URL: http://localhost:${SP_GATEWAY_PORT:-3300}
+      SP_PUBLIC_GATEWAY_PORT: "${SP_GATEWAY_PORT:-3300}"
       SP_REPOS_DIR: /repos
-      SP_WEB_URL: http://localhost:3200
+      SP_WEB_URL: http://localhost:${SP_WEB_PORT:-3200}
       SIGNALPILOT_NOTEBOOK_INTERNAL_URL: http://notebook:2718
-      SIGNALPILOT_NOTEBOOK_PUBLIC_URL: http://localhost:3200/notebook
+      SIGNALPILOT_NOTEBOOK_PUBLIC_URL: http://localhost:${SP_WEB_PORT:-3200}/notebook
       SIGNALPILOT_DELIVERY_MODEL: ${SIGNALPILOT_DELIVERY_MODEL:-claude-sonnet-4-5-20250929}
       # Sandbox
       SP_SANDBOX_MANAGER_URL: http://sandbox:8080
@@ -78,7 +80,7 @@ services:
       - signalpilot-gateway-secrets:/gateway-secrets
       - signalpilot-repos:/repos
     command: >
-      sh -c "python3 -c 'from gateway.store import get_local_api_key; k=get_local_api_key(); open(\"/shared/local_api_key\",\"w\").write(k) if k else None' &&
+      sh -c "python3 -m gateway.dev_local_api_key /shared/local_api_key &&
              uvicorn gateway.main:app --host 0.0.0.0 --port 3300"
     depends_on:
       db:
@@ -87,6 +89,12 @@ services:
         condition: service_healthy
       sandbox:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:3300/health', timeout=2).read()"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
     restart: unless-stopped
 
   # ─── Notebook Server ──────────────────────────────────────────
@@ -95,9 +103,11 @@ services:
       context: ./signalpilot/notebook-server
       dockerfile: Dockerfile
     ports:
-      - "127.0.0.1:2718:2718"
+      - "127.0.0.1:${SP_NOTEBOOK_PORT:-2718}:2718"
     env_file:
       - path: ./.slack.local.env
+        required: false
+      - path: ./.env
         required: false
     entrypoint:
       - sh
@@ -107,14 +117,14 @@ services:
         exec python -m signalpilot edit \
           --host 0.0.0.0 --port 2718 --headless \
           --no-token --no-skew-protection \
-          --allow-origins http://localhost:3200,http://localhost:3300 \
+          --allow-origins http://localhost:${SP_WEB_PORT:-3200},http://localhost:${SP_GATEWAY_PORT:-3300} \
           /workspace
     environment:
       SP_LOG_DIR: /tmp/sp-logs
       SP_LOG_LEVEL: "10"
       SP_GATEWAY_URL: http://gateway:3300
       SP_GATEWAY_INTERNAL_URL: http://gateway:3300
-      SP_WEB_URL: ${SP_WEB_URL:-http://localhost:3200}
+      SP_WEB_URL: http://localhost:${SP_WEB_PORT:-3200}
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/home/notebook/.claude}
       SIGNALPILOT_ANALYSIS_AGENT_MODEL: ${SIGNALPILOT_ANALYSIS_AGENT_MODEL:-claude-sonnet-4-5-20250929}
     volumes:
@@ -135,13 +145,20 @@ services:
       context: .
       dockerfile: Dockerfile.web
     ports:
-      - "3200:3200"
+      - "${SP_WEB_HOST:-0.0.0.0}:${SP_WEB_PORT:-3200}:3200"
     environment:
       SP_GATEWAY_INTERNAL_URL: http://gateway:3300
     volumes:
       - signalpilot-shared:/shared:ro
     depends_on:
-      - gateway
+      gateway:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:3200').then(r=>process.exit(r.status < 500 ? 0 : 1)).catch(()=>process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     restart: unless-stopped
 
   # ─── Sandbox (gVisor code execution) ──────────────────────────

--- a/scripts/dev-watch-notebook.py
+++ b/scripts/dev-watch-notebook.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Poll source files and restart a development process on changes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+WATCH_SUFFIXES = {".py", ".toml"}
+IGNORED_DIRS = {"__pycache__", ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
+
+
+def snapshot(root: Path) -> dict[str, int]:
+    files: dict[str, int] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in IGNORED_DIRS]
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if path.suffix not in WATCH_SUFFIXES:
+                continue
+            try:
+                files[str(path)] = path.stat().st_mtime_ns
+            except FileNotFoundError:
+                continue
+    return files
+
+
+def stop_process(process: subprocess.Popen[object], timeout: float = 10.0) -> None:
+    if process.poll() is not None:
+        return
+    process.send_signal(signal.SIGTERM)
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--watch", required=True)
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("missing command after --")
+
+    watch_root = Path(args.watch)
+    process: subprocess.Popen[object] | None = None
+
+    def start() -> subprocess.Popen[object]:
+        print(f"[dev-watch] starting: {' '.join(command)}", flush=True)
+        return subprocess.Popen(command)
+
+    def shutdown(signum: int, _frame: object) -> None:
+        del signum
+        if process is not None:
+            stop_process(process)
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    process = start()
+    previous = snapshot(watch_root)
+    while True:
+        time.sleep(args.interval)
+        current = snapshot(watch_root)
+        changed = current != previous
+        exited = process.poll() is not None
+
+        if changed or exited:
+            reason = "source change" if changed else f"exit {process.returncode}"
+            print(f"[dev-watch] restarting after {reason}", flush=True)
+            stop_process(process)
+            previous = current
+            process = start()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/signalpilot/gateway/gateway/dev_local_api_key.py
+++ b/signalpilot/gateway/gateway/dev_local_api_key.py
@@ -1,0 +1,66 @@
+"""Prepare the local API key file for Docker development.
+
+This module intentionally avoids importing gateway.store. The store package
+pulls in database-backed modules at import time, which can block gateway
+startup before Uvicorn has a chance to serve health checks.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+from pathlib import Path
+
+from gateway.runtime.mode import is_cloud_mode
+
+
+def _atomic_create_file(path: Path, content: bytes, mode: int = 0o600) -> bytes:
+    try:
+        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode)
+        try:
+            os.write(fd, content)
+        finally:
+            os.close(fd)
+        return content
+    except FileExistsError:
+        return path.read_bytes()
+
+
+def _write_shared_key(path: Path, key: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path.write_text(key, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def get_or_create_local_api_key() -> str | None:
+    if is_cloud_mode():
+        return None
+
+    data_dir = Path(os.environ.get("SP_DATA_DIR", str(Path.home() / ".signalpilot")))
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    key_file = data_dir / "local_api_key"
+    new_key = "sp_local_" + secrets.token_hex(16)
+    key = _atomic_create_file(key_file, new_key.encode()).decode().strip()
+    if key:
+        return key
+
+    key_file.unlink(missing_ok=True)
+    new_key = "sp_local_" + secrets.token_hex(16)
+    return _atomic_create_file(key_file, new_key.encode()).decode().strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    shared_path = Path(args[0]) if args else None
+
+    key = get_or_create_local_api_key()
+    if key and shared_path is not None:
+        _write_shared_key(shared_path, key)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a committed hot-reload Docker overlay for web, gateway, and notebook dev loops.
- Add `.env.example` and document root `.env` setup for Claude, Slack, and Notion local credentials.
- Parameterize local compose ports and keep Docker dev gateway URLs consistent even when `signalpilot/web/.env.local` exists.
- Start the gateway with a lightweight local-key helper and polling watcher so Docker dev startup does not block on the store package before Uvicorn.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python3 -m py_compile scripts/dev-watch-notebook.py signalpilot/gateway/gateway/dev_local_api_key.py`
- `SP_GATEWAY_PORT=3310 SP_WEB_PORT=3210 SP_NOTEBOOK_PORT=2719 SP_DB_PORT=5602 docker compose -f docker-compose.yml -f docker-compose.dev.yml config`
- Runtime verified locally: web, gateway, notebook, db, and sandbox healthy on alternate ports; hot reload checked for web, gateway, and notebook.