### PR TITLE
Use org Anthropic secrets for analysis

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/__init__.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/__init__.py
@@ -1,6 +1,6 @@
 """Shared orchestration helpers for notebook-backed external analysis."""
 
-from .credentials import delivery_api_key_for_user
+from .credentials import delivery_api_key_for_org
 from .followups import DeliverableFollowupPlan, plan_deliverable_followup
 from .html_orchestrator import (
     HtmlDeliverableResult,
@@ -50,7 +50,7 @@ __all__ = [
     "WorkerPlan",
     "WorkerProgress",
     "classify_analysis_request",
-    "delivery_api_key_for_user",
+    "delivery_api_key_for_org",
     "delivery_result_to_status",
     "load_delivery_packet",
     "load_delivery_packet_from_events",

--- a/signalpilot/gateway/gateway/analysis_delivery/credentials.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/credentials.py
@@ -1,4 +1,4 @@
-"""Credential helpers for account-scoped analysis delivery."""
+"""Credential helpers for org-scoped analysis delivery."""
 
 from __future__ import annotations
 
@@ -6,25 +6,22 @@ import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.store import user_secrets as user_secrets_store
+from gateway.store import org_secrets as org_secrets_store
 
 LOGGER = logging.getLogger(__name__)
 
 
-async def delivery_api_key_for_user(
+async def delivery_api_key_for_org(
     session: AsyncSession,
     *,
     org_id: str,
-    user_id: str | None,
 ) -> str:
-    """Return the user's Anthropic key for delivery rendering, or disable model delivery."""
-    if not user_id:
-        return ""
+    """Return the org Anthropic key for delivery rendering, or disable model delivery."""
     try:
-        return await user_secrets_store.get_user_anthropic_key(session, org_id, user_id) or ""
+        return await org_secrets_store.resolve_anthropic_key(session, org_id) or ""
     except Exception as exc:
         LOGGER.info(
-            "Could not load user Anthropic key for analysis delivery; using fallback delivery: %s",
+            "Could not load org Anthropic key for analysis delivery; using fallback delivery: %s",
             exc,
         )
         return ""

--- a/signalpilot/gateway/gateway/api/__init__.py
+++ b/signalpilot/gateway/gateway/api/__init__.py
@@ -25,6 +25,7 @@ from .metrics import router as metrics_router
 from .notebook_sessions import router as notebook_sessions_router
 from .notion import router as notion_router
 from .notion import webhook_router as notion_webhook_router
+from .org_secrets import router as org_secrets_router
 from .projects import router as projects_router
 from .query import router as query_router
 from .reports import router as reports_router
@@ -63,6 +64,7 @@ def register_routers(app: FastAPI) -> None:
     app.include_router(reports_router)
     app.include_router(notion_router)
     app.include_router(notion_webhook_router)
+    app.include_router(org_secrets_router)
     app.include_router(slack_router)
     app.include_router(workspace_projects_router)
     app.include_router(chat_router)

--- a/signalpilot/gateway/gateway/api/org_secrets.py
+++ b/signalpilot/gateway/gateway/api/org_secrets.py
@@ -1,0 +1,76 @@
+"""Org secrets endpoints — encrypted org-scoped API keys."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from sqlalchemy import select
+
+from ..db.models import GatewayOrgSecrets
+from ..security.scope_guard import RequireScope
+from ..store import org_secrets as org_secrets_store
+from ..store.crypto import _decrypt_with_migration, _encrypt
+from .deps import StoreD
+
+router = APIRouter(prefix="/api/org")
+
+
+def _mask_preview(key: str) -> str:
+    """Return a safe prefix-only preview of an API key — never the trailing chars."""
+    return f"{key[:8]}..." if len(key) >= 8 else "****"
+
+
+class OrgSecretsUpdate(BaseModel):
+    anthropic_api_key: str | None = None
+
+
+class OrgSecretsResponse(BaseModel):
+    has_key: bool
+    key_preview: str | None = None
+    updated_at: float | None = None
+
+
+async def _get_org_secret_row(store: StoreD, org_id: str) -> GatewayOrgSecrets | None:
+    result = await store.session.execute(select(GatewayOrgSecrets).where(GatewayOrgSecrets.org_id == org_id))
+    return result.scalar_one_or_none()
+
+
+async def _response_for_row(store: StoreD, org_id: str) -> OrgSecretsResponse:
+    row = await _get_org_secret_row(store, org_id)
+    if not row or not row.anthropic_api_key_enc:
+        return OrgSecretsResponse(
+            has_key=False,
+            updated_at=row.updated_at if row else None,
+        )
+
+    try:
+        key, needs_migration = _decrypt_with_migration(row.anthropic_api_key_enc)
+        if needs_migration:
+            row.anthropic_api_key_enc = _encrypt(key)
+            await store.session.commit()
+        return OrgSecretsResponse(
+            has_key=True,
+            key_preview=_mask_preview(key),
+            updated_at=row.updated_at,
+        )
+    except Exception:
+        return OrgSecretsResponse(has_key=False, updated_at=row.updated_at)
+
+
+@router.get("/secrets", response_model=OrgSecretsResponse, dependencies=[RequireScope("read")])
+async def get_org_secrets(store: StoreD) -> OrgSecretsResponse:
+    """Get org-scoped secrets metadata, with secret values masked."""
+    org_id = store.org_id or "local"
+    return await _response_for_row(store, org_id)
+
+
+@router.put("/secrets", response_model=OrgSecretsResponse, dependencies=[RequireScope("write")])
+async def update_org_secrets(body: OrgSecretsUpdate, store: StoreD) -> OrgSecretsResponse:
+    """Store, rotate, or clear org-scoped secrets. Values are encrypted at rest."""
+    org_id = store.org_id or "local"
+    key = body.anthropic_api_key.strip() if body.anthropic_api_key is not None else ""
+    if key:
+        await org_secrets_store.set_org_anthropic_key(store.session, org_id, key)
+    else:
+        await org_secrets_store.clear_org_anthropic_key(store.session, org_id)
+    return await _response_for_row(store, org_id)

--- a/signalpilot/gateway/gateway/db/models.py
+++ b/signalpilot/gateway/gateway/db/models.py
@@ -958,6 +958,21 @@ class GatewayUserSecrets(GatewayBase):
     )
 
 
+class GatewayOrgSecrets(GatewayBase):
+    """Org-scoped secrets — encrypted at rest."""
+
+    __tablename__ = "gateway_org_secrets"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    org_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    anthropic_api_key_enc: Mapped[bytes | None] = mapped_column(LargeBinary)
+    updated_at: Mapped[float] = mapped_column(Float, nullable=False)
+
+    __table_args__ = (
+        Index("ix_gw_orgsecrets_org_id", "org_id"),
+    )
+
+
 class GatewayGitHubInstallation(GatewayBase):
     """GitHub App installation linked to an org."""
 

--- a/signalpilot/gateway/gateway/notebooks/session_service.py
+++ b/signalpilot/gateway/gateway/notebooks/session_service.py
@@ -18,12 +18,12 @@ from gateway.notebook_proxy.constants import POD_PORT
 from gateway.orchestrator import NotebookOrchestrator
 from gateway.orchestrator.jwt_secret_lifecycle import create_jwt_secret_with_owner_ref
 from gateway.store import notebook_sessions as ns
-from gateway.store import user_secrets as user_secrets_store
+from gateway.store import org_secrets as org_secrets_store
 
 logger = logging.getLogger(__name__)
 
 OrchestratorFactory = Callable[[], Awaitable[NotebookOrchestrator]]
-_AI_CREDENTIAL_ENV_NAMES = ("CLAUDE_CODE_OAUTH_TOKEN", "OAUTH_TOKEN", "ANTHROPIC_API_KEY")
+_AI_CREDENTIAL_ENV_NAMES = ("CLAUDE_CODE_OAUTH_TOKEN", "OAUTH_TOKEN")
 _NOTEBOOK_MODEL_ENV_NAMES = ("SIGNALPILOT_ANALYSIS_AGENT_MODEL", "SIGNALPILOT_WORKER_AGENT_MODEL")
 _DEFAULT_CLOUD_WEB_URL = "https://app.signalpilot.ai"
 
@@ -110,7 +110,6 @@ async def _pod_extra_env(
     session: AsyncSession,
     *,
     org_id: str,
-    user_id: str,
     extra_env: dict[str, str] | None,
 ) -> dict[str, str] | None:
     env: dict[str, str] = {
@@ -123,7 +122,7 @@ async def _pod_extra_env(
     if web_url:
         env["SP_WEB_URL"] = web_url
 
-    anthropic_key = await user_secrets_store.get_user_anthropic_key(session, org_id, user_id)
+    anthropic_key = await org_secrets_store.resolve_anthropic_key(session, org_id)
     if anthropic_key:
         env["ANTHROPIC_API_KEY"] = anthropic_key
 
@@ -297,7 +296,6 @@ async def ensure_notebook_session(
     pod_extra_env = await _pod_extra_env(
         session,
         org_id=org_id,
-        user_id=credential_user_id or user_id,
         extra_env=extra_env,
     )
     session_jwt = mint_session_jwt(

--- a/signalpilot/gateway/gateway/notion/analysis.py
+++ b/signalpilot/gateway/gateway/notion/analysis.py
@@ -23,7 +23,7 @@ from gateway.analysis_delivery import (
     AnalysisPreflightKind,
     DeliveryPacket,
     classify_analysis_request,
-    delivery_api_key_for_user,
+    delivery_api_key_for_org,
     delivery_result_to_status,
     load_delivery_packet,
     load_delivery_packet_from_events,
@@ -1611,10 +1611,9 @@ async def _process_deliverable_followup(
             if plan.requires_ephemeral_run
             else "Updating this dashboard/report.",
         )
-        delivery_api_key = await delivery_api_key_for_user(
+        delivery_api_key = await delivery_api_key_for_org(
             db,
             org_id=org_id,
-            user_id=user_id,
         )
         await _release_db_session(db)
         html_result = await render_followup(
@@ -1951,10 +1950,9 @@ async def process_routed_comment_event(
         public_status = _with_public_snapshot_urls(_with_public_chart_urls(final_status, runtime), runtime)
         public_trail_url = _public_signalpilot_url(public_status.get("trailUrl") or start_trail_url, runtime)
         delivery_user_id = routed.installation.user_id or route.analysis_user_id
-        delivery_api_key = await delivery_api_key_for_user(
+        delivery_api_key = await delivery_api_key_for_org(
             db,
             org_id=routed.installation.org_id,
-            user_id=delivery_user_id,
         )
         try:
             packet = await load_delivery_packet(

--- a/signalpilot/gateway/gateway/slack_poc/worker.py
+++ b/signalpilot/gateway/gateway/slack_poc/worker.py
@@ -29,7 +29,7 @@ from gateway.analysis_delivery import (
     AnalysisPreflightKind,
     SlackTraceProgressReporter,
     classify_analysis_request,
-    delivery_api_key_for_user,
+    delivery_api_key_for_org,
     delivery_result_to_status,
     load_delivery_packet,
     load_delivery_packet_from_events,
@@ -45,6 +45,7 @@ from gateway.slack_poc.progress import (
     INITIAL_PROGRESS_TEXT,
 )
 from gateway.store import slack as slack_store
+from gateway.store.org_secrets import resolve_anthropic_key
 from gateway.string_utils import string_value as _string
 
 LOGGER = logging.getLogger(__name__)
@@ -60,6 +61,11 @@ SLACK_POC_HTTP_DEFAULT_HOST = "127.0.0.1"
 _PLACEHOLDER_CHART_TITLE_RE = re.compile(
     r"(?:notebook\s+)?(?:chart|image|figure|visualization)(?:\s+\d+)?",
     flags=re.I,
+)
+_DEFAULT_WEB_URL = "https://app.signalpilot.ai"
+_MISSING_ANTHROPIC_KEY_TEMPLATE = (
+    "SignalPilot needs an Anthropic API key. "
+    "Ask your admin to add it on the integrations page: {url}"
 )
 
 
@@ -410,6 +416,20 @@ class SlackPoCWorker:
         progress_task: asyncio.Task[None] | None = None
         await self._add_request_reaction(request, SLACK_ACK_REACTION)
         try:
+            async with self.session_factory() as db:
+                has_org_anthropic_key = bool(await resolve_anthropic_key(db, self.config.org_id))
+        except Exception as exc:
+            LOGGER.info("Could not load org Anthropic key for Slack analysis: %s", exc, exc_info=True)
+            has_org_anthropic_key = False
+        if not has_org_anthropic_key:
+            await self.slack.post_message(
+                channel=request.channel_id,
+                thread_ts=request.thread_ts,
+                text=_missing_anthropic_key_text(),
+            )
+            await self._mark_request_failed(request)
+            return
+        try:
             progress_ts = await self.slack.post_message(
                 channel=request.channel_id,
                 thread_ts=request.thread_ts,
@@ -420,7 +440,7 @@ class SlackPoCWorker:
         try:
             previous_messages = await self._previous_thread_messages(request)
             async with self.session_factory() as db:
-                analysis_user_id = await self._analysis_user_id(db)
+                credential_user_id = await self._analysis_user_id(db)
                 discussion_id = _discussion_id(request)
                 request_id = notebook_analysis._analysis_request_id("slack", discussion_id)
                 defaults = self._analysis_defaults(request)
@@ -434,6 +454,7 @@ class SlackPoCWorker:
                     default_branch=defaults.default_branch,
                     analysis_branch_mode=defaults.analysis_branch_mode,
                 )
+                analysis_user_id = credential_user_id or route.analysis_user_id
                 runtime = await ensure_analysis_notebook_session(
                     db,
                     org_id=self.config.org_id,
@@ -441,7 +462,7 @@ class SlackPoCWorker:
                     request_id=route.request_id,
                     project_id=route.project_id,
                     branch=route.branch,
-                    credential_user_id=analysis_user_id,
+                    credential_user_id=credential_user_id,
                 )
                 await notebook_analysis.upsert_analysis_trail_seed(
                     db,
@@ -513,10 +534,9 @@ class SlackPoCWorker:
             delivery_api_key = ""
             try:
                 async with self.session_factory() as db:
-                    delivery_api_key = await delivery_api_key_for_user(
+                    delivery_api_key = await delivery_api_key_for_org(
                         db,
                         org_id=self.config.org_id,
-                        user_id=analysis_user_id,
                     )
                     packet = await load_delivery_packet(
                         db,
@@ -665,16 +685,11 @@ class SlackPoCWorker:
         except Exception as exc:
             LOGGER.info("Could not update Slack progress message: %s", exc, exc_info=True)
 
-    async def _analysis_user_id(self, db: AsyncSession) -> str:
+    async def _analysis_user_id(self, db: AsyncSession) -> str | None:
+        del db
         if self.config.user_id:
             return self.config.user_id
-        user_id = await _latest_notion_installation_user_id(db, self.config.org_id)
-        if user_id:
-            return user_id
-        raise RuntimeError(
-            "SLACK_POC_USER_ID is unset and no connected Notion installation user_id "
-            f"was found for org {self.config.org_id!r}."
-        )
+        return None
 
     def _analysis_defaults(self, request: SlackRequest) -> SlackAnalysisDefaults:
         defaults = self.config.channel_defaults.get(request.channel_id)
@@ -1101,25 +1116,6 @@ async def _dispatch_self_serve_payload(payload: dict[str, Any], base_config: Sla
         await slack.aclose()
 
 
-async def _latest_notion_installation_user_id(db: AsyncSession, org_id: str) -> str | None:
-    from sqlalchemy import select
-
-    from gateway.db.models import NotionInstallation
-
-    result = await db.execute(
-        select(NotionInstallation.user_id)
-        .where(
-            NotionInstallation.org_id == org_id,
-            NotionInstallation.status == "connected",
-            NotionInstallation.user_id.is_not(None),
-        )
-        .order_by(NotionInstallation.updated_at.desc())
-        .limit(1)
-    )
-    value = result.scalar_one_or_none()
-    return str(value) if value else None
-
-
 def load_config_from_env() -> SlackPoCConfig:
     _load_local_env()
     bot_token = _required_env("SLACK_BOT_TOKEN")
@@ -1266,6 +1262,15 @@ def _remove_bot_mention(text: str, bot_user_id: str | None) -> str:
     if bot_user_id:
         text = re.sub(rf"<@{re.escape(bot_user_id)}>\s*", "", text)
     return re.sub(r"<@[A-Z0-9]+>\s*", "", text).strip()
+
+
+def _integrations_url() -> str:
+    web_url = os.getenv("SIGNALPILOT_WEB_URL") or os.getenv("SP_WEB_URL") or _DEFAULT_WEB_URL
+    return f"{web_url.rstrip('/')}/integrations" if web_url else "/integrations"
+
+
+def _missing_anthropic_key_text() -> str:
+    return _MISSING_ANTHROPIC_KEY_TEMPLATE.format(url=_integrations_url())
 
 
 def _clip_text(text: str) -> str:

--- a/signalpilot/gateway/gateway/store/org_secrets.py
+++ b/signalpilot/gateway/gateway/store/org_secrets.py
@@ -1,0 +1,60 @@
+"""Store helpers for org-scoped secrets."""
+
+from __future__ import annotations
+
+import time
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.db.models import GatewayOrgSecrets
+from gateway.store.crypto import _decrypt_with_migration, _encrypt
+
+
+async def _org_secrets_row(session: AsyncSession, org_id: str) -> GatewayOrgSecrets | None:
+    result = await session.execute(select(GatewayOrgSecrets).where(GatewayOrgSecrets.org_id == org_id))
+    return result.scalar_one_or_none()
+
+
+async def get_org_anthropic_key(session: AsyncSession, org_id: str) -> str | None:
+    """Return the decrypted org Anthropic API key, if one is stored."""
+    row = await _org_secrets_row(session, org_id)
+    if not row or not row.anthropic_api_key_enc:
+        return None
+    try:
+        plaintext, needs_migration = _decrypt_with_migration(row.anthropic_api_key_enc)
+        if needs_migration:
+            row.anthropic_api_key_enc = _encrypt(plaintext)
+            await session.commit()
+        return plaintext
+    except Exception:
+        return None
+
+
+async def set_org_anthropic_key(session: AsyncSession, org_id: str, key: str) -> GatewayOrgSecrets:
+    """Store or rotate the org Anthropic API key."""
+    row = await _org_secrets_row(session, org_id)
+    now = time.time()
+    if row is None:
+        row = GatewayOrgSecrets(org_id=org_id, updated_at=now)
+        session.add(row)
+    row.anthropic_api_key_enc = _encrypt(key)
+    row.updated_at = now
+    await session.commit()
+    return row
+
+
+async def clear_org_anthropic_key(session: AsyncSession, org_id: str) -> GatewayOrgSecrets | None:
+    """Clear the org Anthropic API key if an org secret row exists."""
+    row = await _org_secrets_row(session, org_id)
+    if row is None:
+        return None
+    row.anthropic_api_key_enc = None
+    row.updated_at = time.time()
+    await session.commit()
+    return row
+
+
+async def resolve_anthropic_key(session: AsyncSession, org_id: str) -> str | None:
+    """Resolve the Anthropic key for analysis. Org secrets are the only source."""
+    return await get_org_anthropic_key(session, org_id)

--- a/signalpilot/gateway/tests/test_analysis_delivery.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery.py
@@ -10,7 +10,7 @@ from gateway.analysis_delivery import (
     AnalysisPreflightKind,
     DeliveryRenderer,
     classify_analysis_request,
-    delivery_api_key_for_user,
+    delivery_api_key_for_org,
     delivery_result_to_status,
     load_delivery_packet,
     load_delivery_packet_from_events,
@@ -378,25 +378,25 @@ def test_slack_progress_waits_for_worker_plan_then_uses_exact_steps() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delivery_api_key_for_user_reads_stored_account_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    get_user_anthropic_key = AsyncMock(return_value="sk-ant-user")
-    monkeypatch.setattr(credentials_module.user_secrets_store, "get_user_anthropic_key", get_user_anthropic_key)
+async def test_delivery_api_key_for_org_reads_stored_org_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve_anthropic_key = AsyncMock(return_value="sk-ant-org")
+    monkeypatch.setattr(credentials_module.org_secrets_store, "resolve_anthropic_key", resolve_anthropic_key)
 
-    api_key = await delivery_api_key_for_user(AsyncMock(), org_id="org-1", user_id="user-1")
+    api_key = await delivery_api_key_for_org(AsyncMock(), org_id="org-1")
 
-    assert api_key == "sk-ant-user"
-    get_user_anthropic_key.assert_awaited_once()
-    assert get_user_anthropic_key.await_args.args[1:] == ("org-1", "user-1")
+    assert api_key == "sk-ant-org"
+    resolve_anthropic_key.assert_awaited_once()
+    assert resolve_anthropic_key.await_args.args[1:] == ("org-1",)
 
 
 @pytest.mark.asyncio
-async def test_delivery_api_key_for_user_disables_model_delivery_without_account_key(
+async def test_delivery_api_key_for_org_disables_model_delivery_without_org_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    get_user_anthropic_key = AsyncMock(return_value=None)
-    monkeypatch.setattr(credentials_module.user_secrets_store, "get_user_anthropic_key", get_user_anthropic_key)
+    resolve_anthropic_key = AsyncMock(return_value=None)
+    monkeypatch.setattr(credentials_module.org_secrets_store, "resolve_anthropic_key", resolve_anthropic_key)
 
-    api_key = await delivery_api_key_for_user(AsyncMock(), org_id="org-1", user_id="user-1")
+    api_key = await delivery_api_key_for_org(AsyncMock(), org_id="org-1")
 
     assert api_key == ""
 

--- a/signalpilot/gateway/tests/test_notion_analysis.py
+++ b/signalpilot/gateway/tests/test_notion_analysis.py
@@ -481,10 +481,10 @@ async def test_process_routed_comment_event_uses_user_secret_for_delivery_render
         assert kwargs["user_id"] == "user-1"
         return DeliveryPacket(user_request="Analyze revenue by month", status="done")
 
-    async def delivery_api_key_for_user(*args, **kwargs):
+    async def delivery_api_key_for_org(*args, **kwargs):
         assert args == (db,)
-        assert kwargs == {"org_id": "org-1", "user_id": "user-1"}
-        return "sk-ant-user"
+        assert kwargs == {"org_id": "org-1"}
+        return "sk-ant-org"
 
     async def render_delivery(packet, *, api_key=None, renderer=None):
         del packet, renderer
@@ -520,7 +520,7 @@ async def test_process_routed_comment_event_uses_user_secret_for_delivery_render
     monkeypatch.setattr(notion_analysis, "_with_public_chart_urls", lambda status, runtime: status)
     monkeypatch.setattr(notion_analysis, "_upload_chart_images_to_notion", upload_chart_images_to_notion)
     monkeypatch.setattr(notion_analysis, "load_delivery_packet", load_delivery_packet)
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key_for_user)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key_for_org)
     monkeypatch.setattr(notion_analysis, "render_delivery", render_delivery)
 
     result = await notion_analysis.process_routed_comment_event(routed, payload, db=db)
@@ -528,7 +528,7 @@ async def test_process_routed_comment_event_uses_user_secret_for_delivery_render
     assert result.status == "processed"
     assert notebook_requests[0]["json"]["theme"]["chartSeries"][0] == "#087a3d"
     assert notebook_requests[0]["json"]["theme"]["bg"] == "#050505"
-    assert render_api_keys == ["sk-ant-user"]
+    assert render_api_keys == ["sk-ant-org"]
     confidence_updates = [update["Confidence score"] for update in property_updates if "Confidence score" in update]
     assert confidence_updates
     assert "number" not in confidence_updates[-1]
@@ -824,7 +824,7 @@ async def test_refresh_followup_bypasses_generic_preflight_and_replaces_same_blo
     monkeypatch.setattr(notion_analysis.notion_store, "create_deliverable_update", create_update)
     monkeypatch.setattr(notion_analysis.notion_store, "latest_deliverable_context_snapshot", latest_context)
     monkeypatch.setattr(notion_analysis, "_run_ephemeral_deliverable_refresh", run_refresh)
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key)
     monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
     monkeypatch.setattr(notion_analysis.notion_dashboards, "replace_html_deliverable", replace_html)
     monkeypatch.setattr(notion_analysis.reports_store, "update_report_html", update_report)
@@ -911,7 +911,7 @@ async def test_edit_only_followup_does_not_call_notebook_refresh(monkeypatch: py
         "_run_ephemeral_deliverable_refresh",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("refresh should not run")),
     )
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key)
     monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
     monkeypatch.setattr(notion_analysis.notion_dashboards, "replace_html_deliverable", replace_html)
     monkeypatch.setattr(notion_analysis.reports_store, "update_report_html", update_report)
@@ -1006,7 +1006,7 @@ async def test_followup_freezes_update_id_before_releasing_db_session(monkeypatc
         "_run_ephemeral_deliverable_refresh",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("refresh should not run")),
     )
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key)
     monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
     monkeypatch.setattr(notion_analysis.notion_dashboards, "replace_html_deliverable", replace_html)
     monkeypatch.setattr(notion_analysis.reports_store, "update_report_html", update_report)
@@ -1160,7 +1160,7 @@ async def test_followup_reply_routes_by_discussion_when_parent_is_not_embed(
         "_run_ephemeral_deliverable_refresh",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("refresh should not run")),
     )
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key)
     monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
     monkeypatch.setattr(notion_analysis.notion_dashboards, "replace_html_deliverable", replace_html)
     monkeypatch.setattr(notion_analysis.reports_store, "update_report_html", update_report)
@@ -1304,7 +1304,7 @@ async def test_patch_failure_does_not_update_report_or_success_pointers(
     monkeypatch.setattr(notion_analysis.notion_store, "find_deliverable_by_embed_block", find_deliverable)
     monkeypatch.setattr(notion_analysis.reports_store, "get_report", get_report)
     monkeypatch.setattr(notion_analysis.notion_store, "create_deliverable_update", create_update)
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key)
     monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
     monkeypatch.setattr(notion_analysis.notion_dashboards, "replace_html_deliverable", replace_html)
     monkeypatch.setattr(notion_analysis.reports_store, "update_report_html", fail_update_report)
@@ -1367,7 +1367,7 @@ async def test_followup_posts_original_failure_when_failed_status_write_loses_co
     monkeypatch.setattr(notion_analysis.notion_store, "find_deliverable_by_embed_block", find_deliverable)
     monkeypatch.setattr(notion_analysis.reports_store, "get_report", get_report)
     monkeypatch.setattr(notion_analysis.notion_store, "create_deliverable_update", create_update)
-    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_user", delivery_api_key)
+    monkeypatch.setattr(notion_analysis, "delivery_api_key_for_org", delivery_api_key)
     monkeypatch.setattr(notion_analysis, "render_followup", render_followup)
     monkeypatch.setattr(notion_analysis.notion_store, "mark_deliverable_update_failed", mark_failed)
 

--- a/signalpilot/gateway/tests/test_notion_notebook_session_service.py
+++ b/signalpilot/gateway/tests/test_notion_notebook_session_service.py
@@ -65,7 +65,7 @@ def _settings() -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
-async def test_pod_extra_env_includes_gateway_oauth_user_anthropic_key_and_web_url(
+async def test_pod_extra_env_includes_gateway_oauth_org_anthropic_key_and_web_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
@@ -75,21 +75,20 @@ async def test_pod_extra_env_includes_gateway_oauth_user_anthropic_key_and_web_u
     monkeypatch.delenv("SIGNALPILOT_WORKER_AGENT_MODEL", raising=False)
     monkeypatch.setenv("SIGNALPILOT_WEB_URL", "https://app.signalpilot.ai")
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
-        AsyncMock(return_value="user-ant-key"),
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
+        AsyncMock(return_value="org-ant-key"),
     )
 
     env = await session_service._pod_extra_env(
         AsyncMock(),
         org_id="org-1",
-        user_id="user-1",
         extra_env={"SP_AGENT_MODE": "true"},
     )
 
     assert env == {
         "CLAUDE_CODE_OAUTH_TOKEN": "oauth-token",
-        "ANTHROPIC_API_KEY": "user-ant-key",
+        "ANTHROPIC_API_KEY": "org-ant-key",
         "SP_WEB_URL": "https://app.signalpilot.ai",
         "SP_AGENT_MODE": "true",
     }
@@ -103,15 +102,14 @@ async def test_pod_extra_env_defaults_web_url_in_cloud_mode(monkeypatch: pytest.
     monkeypatch.delenv("SIGNALPILOT_WORKER_AGENT_MODEL", raising=False)
     monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
         AsyncMock(return_value=None),
     )
 
     env = await session_service._pod_extra_env(
         AsyncMock(),
         org_id="org-1",
-        user_id="user-1",
         extra_env=None,
     )
 
@@ -125,15 +123,14 @@ async def test_pod_extra_env_includes_analysis_agent_model(monkeypatch: pytest.M
     monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
     monkeypatch.setenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL", "claude-sonnet-4-5-20250929")
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
         AsyncMock(return_value=None),
     )
 
     env = await session_service._pod_extra_env(
         AsyncMock(),
         org_id="org-1",
-        user_id="user-1",
         extra_env=None,
     )
 
@@ -172,9 +169,9 @@ async def test_ensure_notion_session_spawns_without_static_notebook_url(monkeypa
     monkeypatch.setattr(session_service.ns, "update_session_status", AsyncMock())
     monkeypatch.setattr(session_service.ns, "get_session_internal", AsyncMock(return_value=_internal()))
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
-        AsyncMock(return_value="sk-ant-user"),
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
+        AsyncMock(return_value="sk-ant-org"),
     )
     monkeypatch.setattr(session_service, "_get_orchestrator", AsyncMock(return_value=orch))
     monkeypatch.setattr(session_service, "get_k8s_settings", lambda: _settings())
@@ -187,7 +184,7 @@ async def test_ensure_notion_session_spawns_without_static_notebook_url(monkeypa
     assert runtime.internal_base_url == "http://10.2.3.4:2718/notebook/session-1"
     assert runtime.public_base_url == "https://app.test/notebook/session-1"
     assert create_pod_calls[0]["image"] == _settings().sp_notebook_image
-    assert create_pod_calls[0]["extra_env"]["ANTHROPIC_API_KEY"] == "sk-ant-user"
+    assert create_pod_calls[0]["extra_env"]["ANTHROPIC_API_KEY"] == "sk-ant-org"
     assert create_pod_calls[0]["extra_env"]["SP_WEB_URL"] == "https://app.test"
 
 
@@ -226,14 +223,14 @@ async def test_analysis_session_owner_is_synthetic_but_jwt_uses_credential_user(
         jwt_calls.append(kwargs)
         return "jwt-1"
 
-    get_user_anthropic_key = AsyncMock(return_value="sk-ant-user")
+    resolve_anthropic_key = AsyncMock(return_value="sk-ant-org")
 
     monkeypatch.setattr(session_service.ns, "get_active_session", AsyncMock(return_value=None))
     monkeypatch.setattr(session_service.ns, "delete_stopped", AsyncMock())
     monkeypatch.setattr(session_service.ns, "create_session", AsyncMock(return_value=created))
     monkeypatch.setattr(session_service.ns, "update_session_status", AsyncMock())
     monkeypatch.setattr(session_service.ns, "get_session_internal", AsyncMock(return_value=_internal(user_id=created.user_id)))
-    monkeypatch.setattr(session_service.user_secrets_store, "get_user_anthropic_key", get_user_anthropic_key)
+    monkeypatch.setattr(session_service.org_secrets_store, "resolve_anthropic_key", resolve_anthropic_key)
     monkeypatch.setattr(session_service, "_get_orchestrator", AsyncMock(return_value=orch))
     monkeypatch.setattr(session_service, "get_k8s_settings", lambda: _settings())
     monkeypatch.setattr(session_service, "mint_session_jwt", mint_session_jwt)
@@ -252,8 +249,8 @@ async def test_analysis_session_owner_is_synthetic_but_jwt_uses_credential_user(
     assert runtime.session_id == "session-1"
     assert session_service.ns.create_session.await_args.kwargs["user_id"] == "analysis:notion:notion-req-1"
     assert jwt_calls[0]["user_id"] == "user-real"
-    get_user_anthropic_key.assert_awaited_once_with(ANY, "org-1", "user-real")
-    assert create_pod_calls[0]["extra_env"]["ANTHROPIC_API_KEY"] == "sk-ant-user"
+    resolve_anthropic_key.assert_awaited_once_with(ANY, "org-1")
+    assert create_pod_calls[0]["extra_env"]["ANTHROPIC_API_KEY"] == "sk-ant-org"
 
 
 @pytest.mark.asyncio
@@ -268,8 +265,8 @@ async def test_ensure_notion_session_reuses_matching_running_session(monkeypatch
     monkeypatch.setattr(session_service.ns, "get_active_session", AsyncMock(return_value=existing))
     monkeypatch.setattr(session_service.ns, "get_session_internal", AsyncMock(return_value=_internal()))
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
         AsyncMock(return_value=None),
     )
     monkeypatch.setattr(session_service.ns, "mark_stopped", AsyncMock())
@@ -296,8 +293,8 @@ async def test_ensure_notebook_session_recreates_when_branch_does_not_match(monk
     monkeypatch.setattr(session_service.ns, "create_session", AsyncMock(return_value=created))
     monkeypatch.setattr(session_service.ns, "update_session_status", AsyncMock())
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
         AsyncMock(return_value=None),
     )
 
@@ -333,8 +330,8 @@ async def test_ensure_notion_session_marks_error_on_pod_spawn_failure(monkeypatc
     monkeypatch.setattr(session_service.ns, "create_session", AsyncMock(return_value=created))
     monkeypatch.setattr(session_service.ns, "update_session_status", AsyncMock())
     monkeypatch.setattr(
-        session_service.user_secrets_store,
-        "get_user_anthropic_key",
+        session_service.org_secrets_store,
+        "resolve_anthropic_key",
         AsyncMock(return_value=None),
     )
     monkeypatch.setattr(session_service, "_get_orchestrator", AsyncMock(return_value=orch))

--- a/signalpilot/gateway/tests/test_org_secrets.py
+++ b/signalpilot/gateway/tests/test_org_secrets.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from gateway.db.models import GatewayBase, GatewayOrgSecrets
+from gateway.store import org_secrets
+
+
+async def _session_factory(tmp_path, monkeypatch):
+    monkeypatch.setenv("SP_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.delenv("SP_ENCRYPTION_KEY_OLD", raising=False)
+    monkeypatch.setenv("SP_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+
+    import gateway.store.crypto as crypto
+
+    monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(GatewayBase.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def test_org_secret_preview_is_prefix_only() -> None:
+    from gateway.api.org_secrets import _mask_preview
+
+    secret = "sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9"
+    preview = _mask_preview(secret)
+
+    assert preview == "sk-ant-a..."
+    assert "XYZ9" not in preview
+    assert _mask_preview("short") == "****"
+
+
+@pytest.mark.asyncio
+async def test_org_anthropic_key_set_rotate_and_clear(tmp_path, monkeypatch) -> None:
+    engine, Session = await _session_factory(tmp_path, monkeypatch)
+    try:
+        async with Session() as session:
+            await org_secrets.set_org_anthropic_key(session, "org-1", "sk-ant-org-1")
+            assert await org_secrets.get_org_anthropic_key(session, "org-1") == "sk-ant-org-1"
+
+            await org_secrets.set_org_anthropic_key(session, "org-1", "sk-ant-org-2")
+            assert await org_secrets.resolve_anthropic_key(session, "org-1") == "sk-ant-org-2"
+
+            row = await org_secrets.clear_org_anthropic_key(session, "org-1")
+            assert row is not None
+            assert await org_secrets.get_org_anthropic_key(session, "org-1") is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_org_anthropic_key_migrates_old_ciphertext_on_read(tmp_path, monkeypatch) -> None:
+    key_old = Fernet.generate_key()
+    key_primary = Fernet.generate_key()
+    monkeypatch.setenv("SP_ENCRYPTION_KEY", key_primary.decode())
+    monkeypatch.setenv("SP_ENCRYPTION_KEY_OLD", key_old.decode())
+    monkeypatch.setenv("SP_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+
+    import gateway.store.crypto as crypto
+
+    monkeypatch.setattr(crypto, "_CACHED_MULTIFERNET", None)
+
+    old_ciphertext = Fernet(key_old).encrypt(b"sk-ant-old-org-key")
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(GatewayBase.metadata.create_all)
+
+    try:
+        Session = async_sessionmaker(engine, expire_on_commit=False)
+        async with Session() as session:
+            row = GatewayOrgSecrets(
+                org_id="org-1",
+                anthropic_api_key_enc=old_ciphertext,
+                updated_at=time.time(),
+            )
+            session.add(row)
+            await session.commit()
+
+            assert await org_secrets.get_org_anthropic_key(session, "org-1") == "sk-ant-old-org-key"
+            assert row.anthropic_api_key_enc != old_ciphertext
+            assert Fernet(key_primary).decrypt(row.anthropic_api_key_enc).decode() == "sk-ant-old-org-key"
+            with pytest.raises(InvalidToken):
+                Fernet(key_old).decrypt(row.anthropic_api_key_enc)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_org_anthropic_key_corrupt_ciphertext_returns_none_without_leaking(
+    tmp_path,
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    engine, Session = await _session_factory(tmp_path, monkeypatch)
+    try:
+        async with Session() as session:
+            row = GatewayOrgSecrets(
+                org_id="org-1",
+                anthropic_api_key_enc=b"not-a-valid-fernet-token",
+                updated_at=time.time(),
+            )
+            session.add(row)
+            await session.commit()
+
+            with caplog.at_level(logging.INFO):
+                assert await org_secrets.get_org_anthropic_key(session, "org-1") is None
+            assert "not-a-valid-fernet-token" not in caplog.text
+    finally:
+        await engine.dispose()
+
+
+def test_org_secrets_api_get_put_rotate_clear_and_mask(tmp_path, monkeypatch) -> None:
+    from gateway.db.engine import get_db
+    from gateway.main import app
+    from gateway.store import get_local_api_key
+
+    async def run() -> tuple[object, object]:
+        return await _session_factory(tmp_path, monkeypatch)
+
+    import asyncio
+
+    engine, Session = asyncio.run(run())
+
+    async def _mock_db_session():
+        async with Session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _mock_db_session
+    try:
+        api_key = get_local_api_key()
+        client = TestClient(app, headers={"Authorization": f"Bearer {api_key}"})
+
+        unset = client.get("/api/org/secrets")
+        assert unset.status_code == 200
+        assert unset.json() == {"has_key": False, "key_preview": None, "updated_at": None}
+
+        secret = "sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9"
+        set_resp = client.put("/api/org/secrets", json={"anthropic_api_key": secret})
+        assert set_resp.status_code == 200
+        set_body = set_resp.json()
+        assert set_body["has_key"] is True
+        assert set_body["key_preview"] == "sk-ant-a..."
+        assert secret not in set_resp.text
+        assert "XYZ9" not in set_resp.text
+
+        rotate_resp = client.put("/api/org/secrets", json={"anthropic_api_key": "sk-ant-rotated-SECRET"})
+        assert rotate_resp.status_code == 200
+        assert rotate_resp.json()["key_preview"] == "sk-ant-r..."
+        assert "SECRET" not in rotate_resp.text
+
+        clear_resp = client.put("/api/org/secrets", json={"anthropic_api_key": None})
+        assert clear_resp.status_code == 200
+        assert clear_resp.json()["has_key"] is False
+
+        empty_clear_resp = client.put("/api/org/secrets", json={"anthropic_api_key": ""})
+        assert empty_clear_resp.status_code == 200
+        assert empty_clear_resp.json()["has_key"] is False
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        asyncio.run(engine.dispose())
+
+
+@pytest.mark.asyncio
+async def test_org_secrets_api_corrupt_ciphertext_returns_unset(tmp_path, monkeypatch) -> None:
+    engine, Session = await _session_factory(tmp_path, monkeypatch)
+    try:
+        async with Session() as session:
+            session.add(
+                GatewayOrgSecrets(
+                    org_id="local",
+                    anthropic_api_key_enc=b"bad-ciphertext",
+                    updated_at=time.time(),
+                )
+            )
+            await session.commit()
+
+        from gateway.db.engine import get_db
+        from gateway.main import app
+        from gateway.store import get_local_api_key
+
+        async def _mock_db_session():
+            async with Session() as session:
+                yield session
+
+        app.dependency_overrides[get_db] = _mock_db_session
+        try:
+            api_key = get_local_api_key()
+            client = TestClient(app, headers={"Authorization": f"Bearer {api_key}"})
+            resp = client.get("/api/org/secrets")
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["has_key"] is False
+        assert body["key_preview"] is None
+        assert "bad-ciphertext" not in resp.text
+    finally:
+        await engine.dispose()

--- a/signalpilot/gateway/tests/test_slack_poc_worker.py
+++ b/signalpilot/gateway/tests/test_slack_poc_worker.py
@@ -222,20 +222,15 @@ async def test_worker_uses_explicit_config_user_id_before_notion_installation() 
 
 
 @pytest.mark.asyncio
-async def test_worker_uses_notion_installation_user_when_user_id_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def latest_notion_user_id(db, org_id: str) -> str:
-        assert db == "db"
-        assert org_id == "org-1"
-        return "user-from-notion"
-
-    monkeypatch.setattr(worker_module, "_latest_notion_installation_user_id", latest_notion_user_id)
+async def test_worker_returns_none_when_user_id_unset() -> None:
     worker = SlackPoCWorker(
         SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", org_id="org-1"),
         AsyncMock(spec=SlackApiClient),
         AsyncMock(),
     )
 
-    assert await worker._analysis_user_id("db") == "user-from-notion"
+    assert await worker._analysis_user_id("db") is None
+    assert not hasattr(worker_module, "_latest_notion_installation_user_id")
 
 
 @pytest.mark.asyncio
@@ -276,7 +271,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
         request_id: str,
         project_id: str,
         branch: str,
-        credential_user_id: str,
+        credential_user_id: str | None,
     ):
         assert db == "db"
         assert org_id == "org-1"
@@ -284,7 +279,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
         assert request_id == "slack-req-1"
         assert project_id == "project-1"
         assert branch == "analysis/slack/slack-req-1-analyze-revenue"
-        assert credential_user_id == "user-1"
+        assert credential_user_id is None
         events.append("ensure_session")
         return worker_module.NotebookRuntime(
             session_id="session-1",
@@ -315,11 +310,12 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     monkeypatch.setattr(worker_module.notebook_analysis, "_poll_analysis", poll_analysis)
     monkeypatch.setattr(worker_module.notebook_analysis, "_public_signalpilot_url", lambda url, runtime: url)
     monkeypatch.setattr(worker_module.notebook_analysis, "_with_public_chart_urls", lambda status, runtime: status)
+    monkeypatch.setattr(worker_module, "resolve_anthropic_key", AsyncMock(return_value="sk-ant-org"))
 
-    async def delivery_api_key_for_user(*args, **kwargs):
+    async def delivery_api_key_for_org(*args, **kwargs):
         assert args == ("db",)
-        assert kwargs == {"org_id": "org-1", "user_id": "user-1"}
-        return "sk-ant-user"
+        assert kwargs == {"org_id": "org-1"}
+        return "sk-ant-org"
 
     async def render_delivery(packet, *, api_key=None, renderer=None):
         del packet, renderer
@@ -332,7 +328,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
             confidence_score="high",
         )
 
-    monkeypatch.setattr(worker_module, "delivery_api_key_for_user", delivery_api_key_for_user)
+    monkeypatch.setattr(worker_module, "delivery_api_key_for_org", delivery_api_key_for_org)
     monkeypatch.setattr(worker_module, "render_delivery", render_delivery)
 
     slack = AsyncMock(spec=SlackApiClient)
@@ -357,7 +353,6 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
             bot_token="xoxb-test",
             app_token="xapp-test",
             org_id="org-1",
-            user_id="user-1",
             default_project_id="project-1",
         ),
         slack,
@@ -376,7 +371,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
         assert source_prompt == "analyze revenue"
         assert channel_id == "C1"
         assert message_ts == "progress-ts"
-        assert user_id == "user-1"
+        assert user_id == "analysis:slack:slack-req-1"
         await slack.update_message(channel=channel_id, ts=message_ts, text="Querying database...")
         progress_seen.set()
         await stop_event.wait()
@@ -397,6 +392,8 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     )
 
     assert events == [
+        "db_enter",
+        "db_exit",
         "db_enter",
         "resolve_route",
         "ensure_session",
@@ -419,7 +416,7 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
     assert slack_events[-1][0] == "update"
     assert "*Analysis complete*" in slack_events[-1][1]
     assert slack.post_message.await_count == 1
-    assert render_api_keys == ["sk-ant-user"]
+    assert render_api_keys == ["sk-ant-org"]
     slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
     slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="white_check_mark")
     slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="eyes")
@@ -428,6 +425,13 @@ async def test_worker_releases_db_session_before_long_notebook_analysis(monkeypa
 
 @pytest.mark.asyncio
 async def test_worker_adds_error_reaction_when_analysis_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SessionContext:
+        async def __aenter__(self):
+            return "db"
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
     slack = AsyncMock(spec=SlackApiClient)
     slack.post_message.return_value = "progress-ts"
     slack.add_reaction.return_value = None
@@ -436,13 +440,14 @@ async def test_worker_adds_error_reaction_when_analysis_fails(monkeypatch: pytes
     worker = SlackPoCWorker(
         SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", org_id="org-1", user_id="user-1"),
         slack,
-        AsyncMock(),
+        lambda: SessionContext(),
     )
 
     async def fail_previous_messages(_request):
         raise RuntimeError("notebook auth missing")
 
     monkeypatch.setattr(worker, "_previous_thread_messages", fail_previous_messages)
+    monkeypatch.setattr(worker_module, "resolve_anthropic_key", AsyncMock(return_value="sk-ant-org"))
 
     await worker._process_request(
         SlackRequest(
@@ -465,6 +470,54 @@ async def test_worker_adds_error_reaction_when_analysis_fails(monkeypatch: pytes
     slack.remove_reaction.assert_any_await(channel="C1", timestamp="1.0", name="white_check_mark")
     slack.update_message.assert_awaited_once()
     assert "could not complete the analysis" in slack.update_message.call_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_worker_posts_admin_nudge_when_org_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SessionContext:
+        async def __aenter__(self):
+            return "db"
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    slack = AsyncMock(spec=SlackApiClient)
+    slack.post_message.return_value = "nudge-ts"
+    slack.add_reaction.return_value = None
+    slack.remove_reaction.return_value = None
+    monkeypatch.setenv("SP_WEB_URL", "https://app.test")
+    monkeypatch.setattr(worker_module, "resolve_anthropic_key", AsyncMock(return_value=None))
+
+    worker = SlackPoCWorker(
+        SlackPoCConfig(bot_token="xoxb-test", app_token="xapp-test", org_id="org-1"),
+        slack,
+        lambda: SessionContext(),
+    )
+    previous_messages = AsyncMock()
+    monkeypatch.setattr(worker, "_previous_thread_messages", previous_messages)
+
+    await worker._process_request(
+        SlackRequest(
+            event_id="Ev1",
+            team_id="T1",
+            channel_id="C1",
+            user_id="U1",
+            text="analyze revenue",
+            event_ts="1.0",
+            thread_ts="1.0",
+            source_url="https://slack.test/archives/C1/p10",
+        )
+    )
+
+    slack.post_message.assert_awaited_once()
+    message = slack.post_message.await_args.kwargs["text"]
+    assert message == (
+        "SignalPilot needs an Anthropic API key. "
+        "Ask your admin to add it on the integrations page: https://app.test/integrations"
+    )
+    assert "Notion" not in message
+    previous_messages.assert_not_awaited()
+    slack.add_reaction.assert_any_await(channel="C1", timestamp="1.0", name="x")
 
 
 @pytest.mark.asyncio

--- a/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
@@ -207,27 +207,31 @@ def _get_auth_config() -> dict[str, str]:
     if credentials_path.is_file() and credentials_path.stat().st_size > 0:
         return {"type": "config_dir", "token": ""}
 
-    # Try fetching from gateway user secrets
+    # Check gateway org secrets. The full key is never returned through GET;
+    # it should already be injected into ANTHROPIC_API_KEY by the gateway.
     try:
-        from signalpilot._server.gateway_client import gateway_headers, gateway_url
         import httpx
+
+        from signalpilot._server.gateway_client import (
+            gateway_headers,
+            gateway_url,
+        )
         resp = httpx.get(
-            f"{gateway_url()}/api/user/secrets",
+            f"{gateway_url()}/api/org/secrets",
             headers=gateway_headers(),
             timeout=5.0,
         )
         if resp.status_code == 200:
             data = resp.json()
-            if data.get("has_anthropic_key"):
-                # The full key isn't returned via GET for security.
-                # It should be injected as env var by the gateway.
+            if data.get("has_key"):
                 pass
     except Exception:
         pass
 
     raise ValueError(
         "No AI credentials configured. Set CLAUDE_CODE_OAUTH_TOKEN or "
-        "ANTHROPIC_API_KEY, or add your Anthropic API key in Settings."
+        "ANTHROPIC_API_KEY, or ask your admin to add the Anthropic API key "
+        "on the integrations page."
     )
 
 

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py
@@ -61,6 +61,7 @@ async def agent_auth_status(*, request: Request) -> Response:
     import os
     from pathlib import Path
 
+    del request
     has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("OAUTH_TOKEN"))
     has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
     config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
@@ -73,18 +74,24 @@ async def agent_auth_status(*, request: Request) -> Response:
         credentials_path.is_file() and credentials_path.stat().st_size > 0
     )
 
-    # Also check gateway user secrets
+    # Also check gateway org secrets. GET never returns the raw key; pod env
+    # injection is still responsible for providing ANTHROPIC_API_KEY.
     has_gateway_key = False
     try:
-        from signalpilot._server.gateway_client import gateway_headers, gateway_url
         import httpx
-        resp = httpx.get(
-            f"{gateway_url()}/api/user/secrets",
-            headers=gateway_headers(),
-            timeout=5.0,
+
+        from signalpilot._server.gateway_client import (
+            gateway_headers,
+            gateway_url,
         )
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{gateway_url()}/api/org/secrets",
+                headers=gateway_headers(),
+            )
         if resp.status_code == 200:
-            has_gateway_key = resp.json().get("has_anthropic_key", False)
+            has_gateway_key = resp.json().get("has_key", False)
     except Exception:
         pass
 
@@ -110,49 +117,6 @@ async def agent_auth_status(*, request: Request) -> Response:
         }),
         media_type="application/json",
     )
-
-
-@router.post("/save-api-key")
-async def save_api_key(*, request: Request) -> Response:
-    """Save Anthropic API key to gateway user secrets."""
-    body = await request.json()
-    api_key = body.get("api_key", "").strip()
-    if not api_key:
-        return Response(
-            content=json.dumps({"error": "API key required"}),
-            media_type="application/json",
-            status_code=400,
-        )
-
-    import os
-    try:
-        from signalpilot._server.gateway_client import gateway_headers, gateway_url
-        import httpx
-        resp = httpx.put(
-            f"{gateway_url()}/api/user/secrets",
-            headers={**gateway_headers(), "Content-Type": "application/json"},
-            json={"anthropic_api_key": api_key},
-            timeout=10.0,
-        )
-        if resp.status_code == 200:
-            # Also set it locally for immediate use
-            os.environ["ANTHROPIC_API_KEY"] = api_key
-            return Response(
-                content=json.dumps({"success": True}),
-                media_type="application/json",
-            )
-        return Response(
-            content=json.dumps({"error": f"Gateway error: {resp.status_code}"}),
-            media_type="application/json",
-            status_code=500,
-        )
-    except Exception as e:
-        # Fallback: just set locally
-        os.environ["ANTHROPIC_API_KEY"] = api_key
-        return Response(
-            content=json.dumps({"success": True, "local_only": True}),
-            media_type="application/json",
-        )
 
 
 @router.post("/create")

--- a/signalpilot/notebook-server/tests/_server/api/endpoints/test_agent_org_secrets.py
+++ b/signalpilot/notebook-server/tests/_server/api/endpoints/test_agent_org_secrets.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Self
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class _Response:
+    def __init__(self, payload: dict):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _clear_ai_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    for name in (
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OAUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "SP_API_KEY",
+        "SP_SESSION_JWT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    config_dir = tmp_path / "claude-config"
+    config_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("SP_GATEWAY_URL", "https://gateway.test")
+
+
+@pytest.mark.asyncio
+async def test_agent_auth_status_checks_gateway_org_secrets(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _clear_ai_env(monkeypatch, tmp_path)
+    calls: list[str] = []
+
+    class AsyncClient:
+        def __init__(self, *, timeout: float):
+            assert timeout == 5.0
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> bool:
+            return False
+
+        async def get(self, url: str, **kwargs: object) -> _Response:
+            calls.append(url)
+            assert "headers" in kwargs
+            return _Response({"has_key": True})
+
+    monkeypatch.setattr("httpx.AsyncClient", AsyncClient)
+
+    from signalpilot._server.api.endpoints.agent import agent_auth_status
+
+    response = await agent_auth_status(request=object())
+    body = json.loads(response.body)
+
+    assert calls == ["https://gateway.test/api/org/secrets"]
+    assert body == {"configured": True, "method": "gateway"}
+
+
+def test_claude_auth_config_checks_org_secrets_but_does_not_fetch_raw_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _clear_ai_env(monkeypatch, tmp_path)
+    calls: list[str] = []
+
+    def get(url: str, **kwargs: object):
+        calls.append(url)
+        assert kwargs["timeout"] == 5.0
+        return _Response({"has_key": True})
+
+    monkeypatch.setattr("httpx.get", get)
+
+    from signalpilot._server.ai.claude_agent import _get_auth_config
+
+    with pytest.raises(ValueError, match="integrations page"):
+        _get_auth_config()
+
+    assert calls == ["https://gateway.test/api/org/secrets"]

--- a/signalpilot/web/app/integrations/page.tsx
+++ b/signalpilot/web/app/integrations/page.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen,
   Database,
   ExternalLink,
+  KeyRound,
   Link,
   Loader2,
   MessageSquare,
@@ -16,6 +17,7 @@ import { useAppAuth } from "~/lib/auth-context";
 import {
   deleteNotionOAuthInstallation,
   deleteSlackOAuthInstallation,
+  getOrgSecrets,
   getWorkspaceProjects,
   getNotionOAuthInstallations,
   getSlackOAuthInstallations,
@@ -23,7 +25,9 @@ import {
   provisionSlackOAuthInstallation,
   startNotionOAuth,
   startSlackOAuth,
+  updateOrgSecrets,
   type NotionOAuthInstallation,
+  type OrgSecretsResponse,
   type SlackOAuthInstallation,
 } from "~/lib/api";
 import type { WorkspaceProjectInfo } from "~/lib/types";
@@ -72,6 +76,11 @@ function projectLabel(project: WorkspaceProjectInfo): string {
   return project.display_name || project.name || project.id;
 }
 
+function formatUpdatedAt(value: number | null): string {
+  if (!value) return "-";
+  return new Date(value * 1000).toLocaleString();
+}
+
 export default function IntegrationsPage() {
   const { isLoaded } = useAppAuth();
   const { planTier, isLoaded: subLoaded } = useSubscription();
@@ -100,6 +109,27 @@ function IntegrationsContent() {
   const [provisioningSlackId, setProvisioningSlackId] = useState<string | null>(null);
   const [deletingOauthId, setDeletingOauthId] = useState<string | null>(null);
   const [deletingSlackId, setDeletingSlackId] = useState<string | null>(null);
+  const [orgSecrets, setOrgSecrets] = useState<OrgSecretsResponse | null>(null);
+  const [orgSecretsLoading, setOrgSecretsLoading] = useState(true);
+  const [orgSecretsLoadError, setOrgSecretsLoadError] = useState(false);
+  const [orgSecretsReadOnly, setOrgSecretsReadOnly] = useState(false);
+  const [anthropicKey, setAnthropicKey] = useState("");
+  const [savingAnthropicKey, setSavingAnthropicKey] = useState(false);
+  const [confirmRemoveAnthropicKey, setConfirmRemoveAnthropicKey] = useState(false);
+
+  const fetchOrgSecrets = useCallback(async () => {
+    setOrgSecretsLoading(true);
+    try {
+      const secrets = await getOrgSecrets();
+      setOrgSecrets(secrets);
+      setOrgSecretsLoadError(false);
+    } catch {
+      setOrgSecrets(null);
+      setOrgSecretsLoadError(true);
+    } finally {
+      setOrgSecretsLoading(false);
+    }
+  }, []);
 
   const fetchIntegrations = useCallback(async () => {
     try {
@@ -151,6 +181,7 @@ function IntegrationsContent() {
   }, [toast]);
 
   useEffect(() => { fetchIntegrations(); }, [fetchIntegrations]);
+  useEffect(() => { fetchOrgSecrets(); }, [fetchOrgSecrets]);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -344,6 +375,49 @@ function IntegrationsContent() {
     }
   }
 
+  async function handleSaveAnthropicKey() {
+    const key = anthropicKey.trim();
+    if (!key || savingAnthropicKey) return;
+    setSavingAnthropicKey(true);
+    try {
+      const updated = await updateOrgSecrets({ anthropic_api_key: key });
+      setOrgSecrets(updated);
+      setAnthropicKey("");
+      setOrgSecretsReadOnly(false);
+      setOrgSecretsLoadError(false);
+      toast(orgSecrets?.has_key ? "anthropic key rotated" : "anthropic key saved", "success");
+    } catch (e) {
+      if (String(e).includes("403:")) {
+        setOrgSecretsReadOnly(true);
+        toast("you do not have permission to update org secrets", "error");
+      } else {
+        toast(`failed to save key: ${e}`, "error");
+      }
+    } finally {
+      setSavingAnthropicKey(false);
+    }
+  }
+
+  async function handleRemoveAnthropicKey() {
+    setSavingAnthropicKey(true);
+    try {
+      const updated = await updateOrgSecrets({ anthropic_api_key: null });
+      setOrgSecrets(updated);
+      setConfirmRemoveAnthropicKey(false);
+      setOrgSecretsReadOnly(false);
+      toast("anthropic key removed", "success");
+    } catch (e) {
+      if (String(e).includes("403:")) {
+        setOrgSecretsReadOnly(true);
+        toast("you do not have permission to update org secrets", "error");
+      } else {
+        toast(`failed to remove key: ${e}`, "error");
+      }
+    } finally {
+      setSavingAnthropicKey(false);
+    }
+  }
+
   if (loading) return <ApiKeysSkeleton />;
 
   const visibleInstallations = oauthInstallations.filter((installation) => installation.status !== "disconnected");
@@ -376,6 +450,121 @@ function IntegrationsContent() {
           </span>
         </div>
       </TerminalBar>
+
+      <section className="mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <SectionHeader icon={KeyRound} title="anthropic api key" />
+        </div>
+
+        <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5">
+          {orgSecretsLoading ? (
+            <div className="flex items-center gap-2 text-[12px] text-[var(--color-text-dim)] tracking-wider">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              checking key
+            </div>
+          ) : orgSecretsLoadError ? (
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <StatusDot status="error" size={4} />
+                <span className="text-[12px] text-[var(--color-text-dim)] tracking-wider">
+                  failed to load
+                </span>
+              </div>
+              <button
+                onClick={fetchOrgSecrets}
+                className="px-4 py-2 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
+              >
+                retry
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <StatusDot status={orgSecrets?.has_key ? "healthy" : "warning"} size={4} />
+                    <span className="text-[13px] text-[var(--color-text)] tracking-wider font-medium">
+                      {orgSecrets?.has_key ? "key set" : "no key"}
+                    </span>
+                  </div>
+                  <div className="space-y-1 text-[11px] text-[var(--color-text-dim)] tracking-wider">
+                    {orgSecrets?.key_preview && (
+                      <p>
+                        preview: <span className="text-[var(--color-text-muted)] font-mono">{orgSecrets.key_preview}</span>
+                      </p>
+                    )}
+                    <p>
+                      updated: <span className="text-[var(--color-text-muted)]">{formatUpdatedAt(orgSecrets?.updated_at ?? null)}</span>
+                    </p>
+                    {orgSecretsReadOnly && (
+                      <p className="text-[var(--color-warning)]">
+                        read-only: write permission required
+                      </p>
+                    )}
+                  </div>
+                </div>
+                {orgSecrets?.has_key && (
+                  <div className="flex items-center gap-1.5">
+                    {confirmRemoveAnthropicKey ? (
+                      <>
+                        <button
+                          onClick={handleRemoveAnthropicKey}
+                          disabled={savingAnthropicKey || orgSecretsReadOnly}
+                          className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-error)] border border-[var(--color-error)]/30 hover:border-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
+                        >
+                          {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
+                          confirm
+                        </button>
+                        <button
+                          onClick={() => setConfirmRemoveAnthropicKey(false)}
+                          className="p-1.5 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmRemoveAnthropicKey(true)}
+                        disabled={orgSecretsReadOnly}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-error)]/50 hover:text-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
+                      >
+                        <Trash2 className="w-3 h-3" />
+                        remove
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="border-t border-[var(--color-border)] pt-4">
+                <label htmlFor="anthropic-api-key" className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">
+                  {orgSecrets?.has_key ? "rotate key" : "set key"}
+                </label>
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <input
+                    id="anthropic-api-key"
+                    type="password"
+                    value={anthropicKey}
+                    onChange={(event) => setAnthropicKey(event.target.value)}
+                    onKeyDown={(event) => { if (event.key === "Enter") void handleSaveAnthropicKey(); }}
+                    disabled={savingAnthropicKey || orgSecretsReadOnly}
+                    placeholder="sk-ant-..."
+                    className="min-w-0 flex-1 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs font-mono focus:outline-none disabled:opacity-40"
+                  />
+                  <button
+                    onClick={handleSaveAnthropicKey}
+                    disabled={!anthropicKey.trim() || savingAnthropicKey || orgSecretsReadOnly}
+                    className="flex items-center justify-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-[12px] tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
+                  >
+                    {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : <KeyRound className="w-3 h-3" />}
+                    {orgSecrets?.has_key ? "rotate" : "save"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
 
       <section className="mb-8">
         <div className="flex items-center justify-between mb-4">

--- a/signalpilot/web/app/integrations/page.tsx
+++ b/signalpilot/web/app/integrations/page.tsx
@@ -433,7 +433,7 @@ function IntegrationsContent() {
   const projectsById = new Map(workspaceProjects.map((project) => [project.id, project]));
 
   return (
-    <div className="p-8 max-w-6xl animate-fade-in">
+    <div className="p-8 max-w-3xl animate-fade-in">
       <PageHeader
         title="integrations"
         subtitle="notion + slack"
@@ -450,121 +450,6 @@ function IntegrationsContent() {
           </span>
         </div>
       </TerminalBar>
-
-      <section className="mb-8">
-        <div className="flex items-center justify-between mb-4">
-          <SectionHeader icon={KeyRound} title="anthropic api key" />
-        </div>
-
-        <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5">
-          {orgSecretsLoading ? (
-            <div className="flex items-center gap-2 text-[12px] text-[var(--color-text-dim)] tracking-wider">
-              <Loader2 className="w-3 h-3 animate-spin" />
-              checking key
-            </div>
-          ) : orgSecretsLoadError ? (
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <StatusDot status="error" size={4} />
-                <span className="text-[12px] text-[var(--color-text-dim)] tracking-wider">
-                  failed to load
-                </span>
-              </div>
-              <button
-                onClick={fetchOrgSecrets}
-                className="px-4 py-2 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
-              >
-                retry
-              </button>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <StatusDot status={orgSecrets?.has_key ? "healthy" : "warning"} size={4} />
-                    <span className="text-[13px] text-[var(--color-text)] tracking-wider font-medium">
-                      {orgSecrets?.has_key ? "key set" : "no key"}
-                    </span>
-                  </div>
-                  <div className="space-y-1 text-[11px] text-[var(--color-text-dim)] tracking-wider">
-                    {orgSecrets?.key_preview && (
-                      <p>
-                        preview: <span className="text-[var(--color-text-muted)] font-mono">{orgSecrets.key_preview}</span>
-                      </p>
-                    )}
-                    <p>
-                      updated: <span className="text-[var(--color-text-muted)]">{formatUpdatedAt(orgSecrets?.updated_at ?? null)}</span>
-                    </p>
-                    {orgSecretsReadOnly && (
-                      <p className="text-[var(--color-warning)]">
-                        read-only: write permission required
-                      </p>
-                    )}
-                  </div>
-                </div>
-                {orgSecrets?.has_key && (
-                  <div className="flex items-center gap-1.5">
-                    {confirmRemoveAnthropicKey ? (
-                      <>
-                        <button
-                          onClick={handleRemoveAnthropicKey}
-                          disabled={savingAnthropicKey || orgSecretsReadOnly}
-                          className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-error)] border border-[var(--color-error)]/30 hover:border-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
-                        >
-                          {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
-                          confirm
-                        </button>
-                        <button
-                          onClick={() => setConfirmRemoveAnthropicKey(false)}
-                          className="p-1.5 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"
-                        >
-                          <X className="w-3 h-3" />
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        onClick={() => setConfirmRemoveAnthropicKey(true)}
-                        disabled={orgSecretsReadOnly}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-error)]/50 hover:text-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
-                      >
-                        <Trash2 className="w-3 h-3" />
-                        remove
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              <div className="border-t border-[var(--color-border)] pt-4">
-                <label htmlFor="anthropic-api-key" className="block text-[12px] text-[var(--color-text-dim)] mb-1.5 tracking-wider">
-                  {orgSecrets?.has_key ? "rotate key" : "set key"}
-                </label>
-                <div className="flex flex-col sm:flex-row gap-2">
-                  <input
-                    id="anthropic-api-key"
-                    type="password"
-                    value={anthropicKey}
-                    onChange={(event) => setAnthropicKey(event.target.value)}
-                    onKeyDown={(event) => { if (event.key === "Enter") void handleSaveAnthropicKey(); }}
-                    disabled={savingAnthropicKey || orgSecretsReadOnly}
-                    placeholder="sk-ant-..."
-                    className="min-w-0 flex-1 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs font-mono focus:outline-none disabled:opacity-40"
-                  />
-                  <button
-                    onClick={handleSaveAnthropicKey}
-                    disabled={!anthropicKey.trim() || savingAnthropicKey || orgSecretsReadOnly}
-                    className="flex items-center justify-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-[12px] tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
-                  >
-                    {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : <KeyRound className="w-3 h-3" />}
-                    {orgSecrets?.has_key ? "rotate" : "save"}
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
 
       <section className="mb-8">
         <div className="flex items-center justify-between mb-4">
@@ -913,7 +798,132 @@ function IntegrationsContent() {
 
       <section className="mb-8">
         <div className="flex items-center justify-between mb-4">
-          <SectionHeader icon={Palette} title="deliverable theme" />
+          <SectionHeader icon={KeyRound} title="anthropic api key" />
+        </div>
+
+        <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5">
+          {orgSecretsLoading ? (
+            <div className="flex items-center gap-2 text-[12px] text-[var(--color-text-dim)] tracking-wider">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              checking key
+            </div>
+          ) : orgSecretsLoadError ? (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-2">
+                <StatusDot status="error" size={4} />
+                <span className="text-[12px] text-[var(--color-text-dim)] tracking-wider">
+                  failed to load
+                </span>
+              </div>
+              <button
+                onClick={fetchOrgSecrets}
+                className="px-4 py-2 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
+              >
+                retry
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <StatusDot status={orgSecrets?.has_key ? "healthy" : "warning"} size={4} />
+                    <span className="text-[13px] text-[var(--color-text)] tracking-wider font-medium">
+                      {orgSecrets?.has_key ? "key set" : "no key"}
+                    </span>
+                  </div>
+                  <div className="space-y-1 text-[11px] text-[var(--color-text-dim)] tracking-wider">
+                    {orgSecrets?.key_preview && (
+                      <p>
+                        preview: <span className="text-[var(--color-text-muted)] font-mono">{orgSecrets.key_preview}</span>
+                      </p>
+                    )}
+                    <p>
+                      updated: <span className="text-[var(--color-text-muted)]">{formatUpdatedAt(orgSecrets?.updated_at ?? null)}</span>
+                    </p>
+                    {orgSecretsReadOnly && (
+                      <p className="text-[var(--color-warning)]">
+                        read-only: write permission required
+                      </p>
+                    )}
+                  </div>
+                </div>
+                {orgSecrets?.has_key && (
+                  <div className="flex items-center gap-1.5">
+                    {confirmRemoveAnthropicKey ? (
+                      <>
+                        <button
+                          onClick={handleRemoveAnthropicKey}
+                          disabled={savingAnthropicKey || orgSecretsReadOnly}
+                          className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-error)] border border-[var(--color-error)]/30 hover:border-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
+                        >
+                          {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
+                          confirm
+                        </button>
+                        <button
+                          onClick={() => setConfirmRemoveAnthropicKey(false)}
+                          className="p-1.5 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmRemoveAnthropicKey(true)}
+                        disabled={orgSecretsReadOnly}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-error)]/50 hover:text-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
+                      >
+                        <Trash2 className="w-3 h-3" />
+                        remove
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="border-t border-[var(--color-border)] pt-4">
+                <label htmlFor="anthropic-api-key" className="sr-only">Anthropic API key</label>
+                <p className="mb-3 text-[12px] leading-5 text-[var(--color-text-dim)] tracking-wider">
+                  Set your{" "}
+                  <a
+                    href="https://platform.claude.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[var(--color-text)] underline decoration-[var(--color-border-hover)] underline-offset-4 hover:decoration-[var(--color-text)]"
+                  >
+                    Anthropic API key
+                  </a>{" "}
+                  to enable SignalPilot Agents
+                </p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <input
+                    id="anthropic-api-key"
+                    type="password"
+                    value={anthropicKey}
+                    onChange={(event) => setAnthropicKey(event.target.value)}
+                    onKeyDown={(event) => { if (event.key === "Enter") void handleSaveAnthropicKey(); }}
+                    disabled={savingAnthropicKey || orgSecretsReadOnly}
+                    placeholder="sk-ant-..."
+                    className="min-w-0 flex-1 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs font-mono focus:outline-none disabled:opacity-40"
+                  />
+                  <button
+                    onClick={handleSaveAnthropicKey}
+                    disabled={!anthropicKey.trim() || savingAnthropicKey || orgSecretsReadOnly}
+                    className="flex items-center justify-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-[12px] tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
+                  >
+                    {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : <KeyRound className="w-3 h-3" />}
+                    {orgSecrets?.has_key ? "rotate" : "save"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <SectionHeader icon={Palette} title="AI generations theme" />
         </div>
         <ThemeEditor />
       </section>

--- a/signalpilot/web/components/integrations/theme-editor.tsx
+++ b/signalpilot/web/components/integrations/theme-editor.tsx
@@ -121,7 +121,7 @@ export function ThemeEditor() {
     <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-5">
         <div>
-          <p className="text-[13px] text-[var(--color-text)] tracking-wider">HTML deliverable theme</p>
+          <p className="text-[13px] text-[var(--color-text)] tracking-wider">AI generations theme</p>
           {adminLocked && <p className="mt-1 text-[11px] text-[var(--color-error)] tracking-wider">org admin required</p>}
         </div>
         <div className="flex items-center gap-2">
@@ -144,7 +144,7 @@ export function ThemeEditor() {
         </div>
       </div>
 
-      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_460px]">
+      <div className="flex flex-col gap-5">
         <div className="space-y-5">
           <label className="block max-w-md">
             <span className="block text-[11px] text-[var(--color-text-dim)] tracking-wider uppercase mb-1.5">main color</span>

--- a/signalpilot/web/e2e/agent-chat.spec.ts
+++ b/signalpilot/web/e2e/agent-chat.spec.ts
@@ -104,11 +104,10 @@ test("SignalPilot Agent — send message and receive response", async ({
   const hasInput = await chatInput.isVisible({ timeout: 10_000 }).catch(() => false);
 
   if (!hasInput) {
-    ts("Chat textarea not found — checking for API key input...");
-    // The agent panel might show an API key input first
-    const apiKeyInput = spRoot.locator('input[placeholder*="sk-ant"]');
-    if (await apiKeyInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-      ts("API key input found — agent requires API key configuration");
+    ts("Chat textarea not found — checking for org API key setup prompt...");
+    const integrationsLink = spRoot.locator('a[href="/integrations"]');
+    if (await integrationsLink.isVisible({ timeout: 3000 }).catch(() => false)) {
+      ts("Org API key setup prompt found — agent requires admin configuration");
       await page.screenshot({ path: "e2e-agent-apikey.png" });
     } else {
       await page.screenshot({ path: "e2e-agent-noinput.png" });

--- a/signalpilot/web/lib/api.ts
+++ b/signalpilot/web/lib/api.ts
@@ -800,6 +800,17 @@ export type NotionOAuthInstallation = {
   config: NotionOAuthInstallationConfig | null;
 };
 export type NotionPageOption = { id: string; title: string; url: string | null };
+export type OrgSecretsResponse = {
+  has_key: boolean;
+  key_preview: string | null;
+  updated_at: number | null;
+};
+export type OrgSecretsUpdate = {
+  anthropic_api_key: string | null;
+};
+export const getOrgSecrets = () => request<OrgSecretsResponse>("/api/org/secrets");
+export const updateOrgSecrets = (payload: OrgSecretsUpdate) =>
+  request<OrgSecretsResponse>("/api/org/secrets", { method: "PUT", body: JSON.stringify(payload) });
 export const getNotionIntegrations = () => request<NotionIntegration[]>("/api/integrations/notion");
 export const createNotionIntegration = (payload: { name: string; api_key: string; search_page_ids: string[]; report_parent_page_id?: string }) =>
   request<NotionIntegration>("/api/integrations/notion", { method: "POST", body: JSON.stringify(payload) });

--- a/signalpilot/web/notebook/components/chat/agent-chat-panel.tsx
+++ b/signalpilot/web/notebook/components/chat/agent-chat-panel.tsx
@@ -47,76 +47,27 @@ import {
 
 
 /* ── API Key Setup ── */
-const ApiKeySetup: React.FC<{ onConfigured: () => void }> = ({ onConfigured }) => {
-  const [apiKey, setApiKey] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
-  const runtimeManager = useRuntimeManager();
-
-  const handleSave = async () => {
-    if (!apiKey.trim()) {return;}
-    setSaving(true);
-    setError("");
-    try {
-      const resp = await fetch(
-        runtimeManager.getAgentURL("save-api-key").toString(),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...(await runtimeManager.headers()) },
-          body: JSON.stringify({ api_key: apiKey.trim() }),
-        },
-      );
-      const data = await resp.json() as { success?: boolean; error?: string };
-      if (data.success) {
-        onConfigured();
-      } else {
-        setError(data.error || "Failed to save");
-      }
-    } catch (e) {
-      setError(String(e));
-    }
-    setSaving(false);
-  };
-
+const ApiKeySetup: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center h-full p-6 text-center gap-4">
       <KeyRoundIcon className="h-10 w-10 text-muted-foreground opacity-30" />
       <div>
         <h3 className="text-sm font-semibold text-foreground mb-1">Set up AI Agent</h3>
         <p className="text-xs text-muted-foreground">
-          Enter your Anthropic API key to enable the AI agent.
+          Ask an admin to add the org Anthropic API key on the integrations page.
         </p>
       </div>
-      <div className="w-full max-w-xs space-y-2">
-        <input
-          type="password"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") {handleSave();} }}
-          placeholder="sk-ant-..."
-          className={cn(
-            "w-full rounded-md border border-border bg-background px-3 py-2 text-xs font-mono",
-            "placeholder:text-muted-foreground/50",
-            "focus:outline-none focus:ring-1 focus:ring-primary/40",
-          )}
-        />
-        {error && <p className="text-[11px] text-red-500">{error}</p>}
-        <Button
-          variant="default"
-          size="sm"
-          className="w-full"
-          onClick={handleSave}
-          disabled={!apiKey.trim() || saving}
-        >
-          {saving ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
-          Save API Key
-        </Button>
-      </div>
-      <p className="text-[10px] text-muted-foreground max-w-xs">
-        Your key is stored securely on the server. Get one at{" "}
-        <a href="https://console.anthropic.com" target="_blank" rel="noopener noreferrer"
-          className="text-primary hover:underline">console.anthropic.com</a>
-      </p>
+      <a
+        href="/integrations"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          "inline-flex h-8 items-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground",
+          "hover:bg-primary/90",
+        )}
+      >
+        Open integrations
+      </a>
     </div>
   );
 };
@@ -193,7 +144,7 @@ const AgentChatPanel: React.FC = () => {
   }
 
   if (!aiConfigured) {
-    return <ApiKeySetup onConfigured={() => setAiConfigured(true)} />;
+    return <ApiKeySetup />;
   }
 
   return <AgentChatPanelInner />;

--- a/signalpilot/web/notebook/core/runtime/runtime.ts
+++ b/signalpilot/web/notebook/core/runtime/runtime.ts
@@ -204,7 +204,7 @@ export class RuntimeManager {
     return this.formatHttpURL(`/api/ai/${path}`);
   }
 
-  getAgentURL(path: "auth-status" | "create" | "message" | "stop" | "status" | "list" | "events" | "save-api-key"): URL {
+  getAgentURL(path: "auth-status" | "create" | "message" | "stop" | "status" | "list" | "events"): URL {
     return this.formatHttpURL(`/api/agent/${path}`);
   }
 


### PR DESCRIPTION
## Summary
- add org-scoped encrypted Anthropic key storage, resolver, and `/api/org/secrets`
- route notebook pods, delivery rendering, notebook auth status, and Slack analysis through the org-only key path
- remove per-user Anthropic key setup from notebook UI paths and add the org key setup to integrations
- refine integrations layout: Slack before key setup, narrower page, and `AI generations theme` with stacked preview

## Validation
- `cd signalpilot/gateway && uv run pytest tests/test_org_secrets.py tests/test_analysis_delivery.py tests/test_notion_notebook_session_service.py tests/test_slack_poc_worker.py tests/test_notion_analysis.py -q`
- `cd signalpilot/gateway && uv run ruff check ...` on touched gateway files and tests
- `cd signalpilot/notebook-server && uv run pytest tests/_server/api/endpoints/test_agent_org_secrets.py -q`
- `cd signalpilot/notebook-server && uv run ruff check tests/_server/api/endpoints/test_agent_org_secrets.py`
- `python3 -m py_compile ...` on touched Python files
- `git diff --check`

## Notes
- Web full lint/typecheck still has existing repo-level tooling/debt issues: `next lint` is broken under the current Next setup, direct ESLint has no flat config, and broad `tsc --noEmit` reports unrelated existing errors.
