### PR TITLE
Split projects surface and lazy-load notebook runtime

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,6 +46,8 @@ services:
   web:
     build:
       target: dev
+    healthcheck:
+      disable: true
     environment:
       NODE_ENV: development
       NEXT_TELEMETRY_DISABLED: "1"
@@ -56,7 +58,11 @@ services:
       CHOKIDAR_USEPOLLING: "true"
     volumes:
       - ./signalpilot/web:/app/signalpilot/web:cached
-      - signalpilot-web-node-modules:/app/signalpilot/web/node_modules
+      - type: volume
+        source: signalpilot-web-node-modules
+        target: /app/signalpilot/web/node_modules
+        volume:
+          nocopy: true
       - signalpilot-web-next:/app/signalpilot/web/.next
       - signalpilot-shared:/shared:ro
     command: >
@@ -68,8 +74,35 @@ services:
              if [ -f /shared/local_api_key ]; then
                export SP_LOCAL_API_KEY="$$(cat /shared/local_api_key)";
              fi;
+             if [ ! -d node_modules/next ]; then
+               npm ci --legacy-peer-deps;
+             fi;
+             case "$$(uname -m)" in
+               aarch64)
+                 if [ ! -e node_modules/lightningcss-linux-arm64-gnu/lightningcss.linux-arm64-gnu.node ]; then
+                   npm install --legacy-peer-deps --no-save lightningcss-linux-arm64-gnu@1.32.0 @tailwindcss/oxide-linux-arm64-gnu@4.2.4;
+                 fi
+                 ;;
+               x86_64)
+                 if [ ! -e node_modules/lightningcss-linux-x64-gnu/lightningcss.linux-x64-gnu.node ]; then
+                   npm install --legacy-peer-deps --no-save lightningcss-linux-x64-gnu@1.32.0 @tailwindcss/oxide-linux-x64-gnu@4.2.4;
+                 fi
+                 ;;
+             esac;
+             bundler_flag="--webpack";
+             case "$${NEXT_DEV_BUNDLER:-webpack}" in
+               turbo|turbopack)
+                 bundler_flag="--turbopack";
+                 ;;
+               webpack|"")
+                 bundler_flag="--webpack";
+                 ;;
+               *)
+                 echo "Unknown NEXT_DEV_BUNDLER=$${NEXT_DEV_BUNDLER}; using webpack";
+                 ;;
+             esac;
              rm -rf .next/dev;
-             exec npm run dev -- --hostname 0.0.0.0'
+             exec npm run dev -- --hostname 0.0.0.0 "$$bundler_flag"'
 
 volumes:
   signalpilot-web-node-modules:

--- a/signalpilot/gateway/gateway/mcp/server.py
+++ b/signalpilot/gateway/gateway/mcp/server.py
@@ -7,6 +7,7 @@ import os as _os
 from mcp.server.fastmcp import FastMCP
 
 from ..config import get_mcp_settings
+from ..config.k8s import get_k8s_settings
 from ..runtime.mode import is_cloud_mode
 
 # Allowed hosts for MCP streamable-http transport (DNS rebinding protection)
@@ -14,10 +15,13 @@ _allowed_hosts = ["localhost", "127.0.0.1", "host.docker.internal", "0.0.0.0"]
 _extra_hosts = get_mcp_settings().sp_mcp_allowed_hosts
 if _extra_hosts:
     _allowed_hosts.extend(h.strip() for h in _extra_hosts.split(",") if h.strip())
-# Include hosts with port numbers
+# Include hosts with port numbers. SP_PUBLIC_GATEWAY_PORT reflects the port
+# clients actually connect on (e.g. compose's SP_GATEWAY_PORT override), so
+# a remapped host port doesn't get rejected as an invalid Host header.
+_gateway_port = get_k8s_settings().sp_public_gateway_port
 _allowed_hosts_with_ports = list(_allowed_hosts)
 for h in _allowed_hosts:
-    _allowed_hosts_with_ports.append(f"{h}:3300")
+    _allowed_hosts_with_ports.append(f"{h}:{_gateway_port}")
 
 # In cloud mode behind a reverse proxy (Caddy/nginx), disable host validation entirely
 # since the proxy already handles DNS rebinding protection via its own config

--- a/signalpilot/web/app/notebook/page.tsx
+++ b/signalpilot/web/app/notebook/page.tsx
@@ -1,7 +1,22 @@
-// Full-page notebook IDE. Same component as /projects, but the layout hides the
-// left navbar and goes full-width for "/notebook" (see sidebar.tsx
-// HIDDEN_SIDEBAR_PREFIXES and main-content.tsx FULL_WIDTH_PREFIXES). Used by the
-// IDE header's "External" / pop-out link so it stays inside the authenticated
-// app instead of hitting the gateway notebook URL directly (which lacks the
-// proxy session cookie).
-export { default } from "../projects/page";
+"use client";
+
+import dynamic from "next/dynamic";
+import { Loader2 } from "lucide-react";
+
+const NotebooksPage = dynamic(
+  () => import("~/components/notebook/notebooks-page"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-[var(--color-text-dim)]" />
+      </div>
+    ),
+  },
+);
+
+// Full-page notebook IDE. Keep this route as a tiny shell so the initial
+// /notebook request does not compile the notebook runtime graph in Docker.
+export default function NotebookPage() {
+  return <NotebooksPage />;
+}

--- a/signalpilot/web/app/projects/page.tsx
+++ b/signalpilot/web/app/projects/page.tsx
@@ -1,3 +1,85 @@
 "use client";
 
-export { default } from "~/components/notebook/notebooks-page";
+import dynamic from "next/dynamic";
+import { useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import ProjectsOverviewPage from "~/components/projects/projects-overview-page";
+
+const SPA_NAVIGATE_EVENT = "spa:navigate";
+
+const NotebookRuntimePage = dynamic(
+  () => import("~/components/notebook/notebooks-page"),
+  {
+    ssr: false,
+    loading: () => <NotebookRuntimeLoading />,
+  },
+);
+
+function searchRequiresRuntime(params: URLSearchParams): boolean {
+  return Boolean(
+    params.get("project") ||
+      params.get("file") ||
+      params.get("session_id"),
+  );
+}
+
+export default function ProjectsPage() {
+  const searchParams = useSearchParams();
+  const nextSearch = searchParams.toString();
+  const [browserSearch, setBrowserSearch] = useState(() =>
+    typeof window === "undefined" ? "" : window.location.search,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    setBrowserSearch(window.location.search);
+  }, [nextSearch]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const syncBrowserSearch = () => {
+      setBrowserSearch(window.location.search);
+    };
+
+    window.addEventListener("popstate", syncBrowserSearch);
+    window.addEventListener(SPA_NAVIGATE_EVENT, syncBrowserSearch);
+    return () => {
+      window.removeEventListener("popstate", syncBrowserSearch);
+      window.removeEventListener(SPA_NAVIGATE_EVENT, syncBrowserSearch);
+    };
+  }, []);
+
+  const effectiveSearchParams = useMemo(
+    () => new URLSearchParams(browserSearch || nextSearch),
+    [browserSearch, nextSearch],
+  );
+
+  if (searchRequiresRuntime(effectiveSearchParams)) {
+    return <NotebookRuntimePage />;
+  }
+
+  return <ProjectsOverviewPage />;
+}
+
+function NotebookRuntimeLoading() {
+  return (
+    <div className="flex h-screen flex-col">
+      <div className="flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2">
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--color-text-dim)]" />
+        <span className="text-[11px] uppercase tracking-wider text-[var(--color-text-dim)]">
+          opening notebook runtime...
+        </span>
+      </div>
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--color-text-dim)]" />
+      </div>
+    </div>
+  );
+}

--- a/signalpilot/web/components/notebook/boot-runtime.ts
+++ b/signalpilot/web/components/notebook/boot-runtime.ts
@@ -1,12 +1,6 @@
-import {
-  createSignalpilotClient,
-  type SignalpilotClient,
-} from "@/embed";
+import { createSignalpilotClient } from "@/embed/createSignalpilotClient";
+import type { SignalpilotClient } from "@/embed/types";
 import { Logger } from "@/utils/Logger";
-import {
-  isNotionTrailParams,
-  notionRequestIdFromSessionId,
-} from "@/core/notion/trail";
 import { isGeneratedAnalysisTrailNotebook } from "./analysis-trails";
 import type { NotebookConfig } from "./notebook-context";
 
@@ -33,6 +27,32 @@ export interface BootResult {
   client: SignalpilotClient;
   syncResult?: { localDir: string; fileCount: number };
   staticData: NotebookStaticData;
+}
+
+function isNotionTrailParams({
+  file,
+  sessionId,
+}: {
+  file?: string | null;
+  sessionId?: string | null;
+}): boolean {
+  return Boolean(
+    sessionId?.startsWith("session-notion-") ||
+      sessionId?.startsWith("session-slack-") ||
+      file?.startsWith("signalpilot-notion-analyses/"),
+  );
+}
+
+function notionRequestIdFromSessionId(
+  sessionId: string | null | undefined,
+): string | undefined {
+  if (
+    !sessionId?.startsWith("session-notion-") &&
+    !sessionId?.startsWith("session-slack-")
+  ) {
+    return undefined;
+  }
+  return sessionId.slice("session-".length);
 }
 
 function resolveRuntimeBase(config: NotebookConfig): string {

--- a/signalpilot/web/components/notebook/notebook-boot.tsx
+++ b/signalpilot/web/components/notebook/notebook-boot.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
-import { SignalpilotEditor, type SignalpilotClient } from "@/embed";
-import { spaNavigate } from "@/core/router/spa-navigate";
+import type { SignalpilotClient } from "@/embed/types";
 import { useNotebookConfig } from "./notebook-context";
 import {
   NotebookBootUserError,
@@ -22,7 +21,19 @@ const PHASE_LABELS: Record<string, string> = {
   syncing: "syncing project files...",
   sessions: "connecting kernel...",
   ready: "loading notebook...",
+  editor: "loading editor...",
 };
+
+type SignalpilotEditorComponent =
+  typeof import("@/embed/SignalpilotEditor").SignalpilotEditor;
+
+function spaNavigate(href: string): void {
+  if (!href) throw new Error("spaNavigate: empty href");
+  window.history.pushState({}, "", href);
+  window.dispatchEvent(
+    new CustomEvent("spa:navigate", { detail: { href } }),
+  );
+}
 
 function LoadingSpinner({ phase }: { phase: string }) {
   return (
@@ -51,6 +62,8 @@ export default function NotebookBoot({
   const staticDataRef = useRef<NotebookStaticData | null>(null);
   const [ready, setReady] = useState(false);
   const [phase, setPhase] = useState<string>("health");
+  const [EditorComponent, setEditorComponent] =
+    useState<SignalpilotEditorComponent | null>(null);
 
   const onReadyRef = useRef<(() => void) | undefined>(undefined);
   useEffect(() => {
@@ -92,6 +105,7 @@ export default function NotebookBoot({
         clientRef.current = result.client;
         staticDataRef.current = result.staticData ?? { filename: config.file };
         setReady(true);
+        handlePhase("editor");
         onReadyRef.current?.();
       })
       .catch((err) => {
@@ -116,6 +130,7 @@ export default function NotebookBoot({
       }
       staticDataRef.current = null;
       setReady(false);
+      setEditorComponent(null);
     };
   }, [
     config.sessionId,
@@ -130,6 +145,21 @@ export default function NotebookBoot({
     handlePhase,
   ]);
 
+  useEffect(() => {
+    if (!ready || EditorComponent) {
+      return;
+    }
+    let cancelled = false;
+    import("@/embed/SignalpilotEditor").then((module) => {
+      if (!cancelled) {
+        setEditorComponent(() => module.SignalpilotEditor);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, EditorComponent]);
+
   if (error) {
     return (
       <div className="flex-1 flex items-center justify-center text-[var(--color-error)] text-xs">
@@ -138,7 +168,7 @@ export default function NotebookBoot({
     );
   }
 
-  if (!ready || !clientRef.current || !staticDataRef.current) {
+  if (!ready || !clientRef.current || !staticDataRef.current || !EditorComponent) {
     return <LoadingSpinner phase={phase} />;
   }
 
@@ -151,7 +181,7 @@ export default function NotebookBoot({
 
   return (
     <>
-      <SignalpilotEditor
+      <EditorComponent
         client={clientRef.current}
         config={{
           gatewayUrl: config.gatewayUrl,

--- a/signalpilot/web/components/notebook/notebooks-page.tsx
+++ b/signalpilot/web/components/notebook/notebooks-page.tsx
@@ -7,22 +7,16 @@ import {
   Check,
   Code,
   ExternalLink,
-  Github,
   Loader2,
   Share2,
-  RefreshCw,
   Square,
 } from "lucide-react";
 import {
   createNotebookSession,
-  getGitHubInstallations,
   getNotebookSession,
-  getNotionOAuthInstallations,
-  getProjects,
   deleteNotebookSession,
   pingNotebookSession,
   getGatewayAuthToken,
-  getWorkspaceProjects,
   resolveAnalysisTrail,
   type AnalysisTrail,
   type NotebookSession,
@@ -34,28 +28,7 @@ import {
   type NotebookConfig,
 } from "~/components/notebook/notebook-context";
 import { NotebooksProjectsPaywall } from "~/components/billing/notebooks-projects-paywall";
-import { NotionIcon } from "~/components/branding/notion-icon";
 import { useSubscription } from "~/lib/subscription-context";
-import { DbtProjectActions } from "@/components/home/dbt-project-actions";
-import { DbtProjectList } from "@/components/home/dbt-project-list";
-import { Header } from "@/components/home/components";
-import { Button } from "@/components/ui/button";
-import { dbtProjectDirAtom } from "@/components/editor/dbt/use-dbt";
-import { gatewayBranchIdAtom as persistedGatewayBranchIdAtom } from "@/core/branch/branch-state";
-import { KnownQueryParams } from "@/core/constants";
-import {
-  GATEWAY_BRANCH_STORAGE_KEY,
-  GATEWAY_PROJECT_STORAGE_KEY,
-  gatewayBranchIdAtom,
-  gatewayProjectIdAtom,
-} from "@/core/network/gateway-state";
-import {
-  setGatewayBranchId,
-  setGatewayProjectId,
-} from "@/core/network/api";
-import { isNotionTrailParams } from "@/core/notion/trail";
-import { SPA_NAVIGATE_EVENT } from "@/core/router/spa-navigate";
-import { store } from "@/core/state/jotai";
 
 const PAID_TIERS = ["pro", "team", "enterprise", "unlimited"];
 
@@ -65,7 +38,7 @@ const NotebookBoot = dynamic(
     ssr: false,
     loading: () => (
       <div className="flex-1 flex items-center justify-center">
-        <Loader2 className="w-6 h-6 animate-spin text-[var(--color-text-dim)]" />
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
       </div>
     ),
   }
@@ -76,6 +49,15 @@ const NOTEBOOK_PROXY_URL = process.env.NEXT_PUBLIC_NOTEBOOK_PROXY_URL ?? "";
 const IS_CLOUD_MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE === "cloud";
 const NOTION_THREAD_EVENT = "sp:notion-thread-resolved";
 const NOTION_THREAD_STORAGE_PREFIX = "sp:notion-thread:";
+const SPA_NAVIGATE_EVENT = "spa:navigate";
+const GATEWAY_PROJECT_STORAGE_KEY = "sp:gateway-project-id";
+const GATEWAY_BRANCH_STORAGE_KEY = "sp:gateway-branch-id";
+const KnownQueryParams = {
+  project: "project",
+  branch: "branch",
+  filePath: "file",
+  sessionId: "session_id",
+} as const;
 
 type NotionThreadWindow = Window & {
   __signalPilotNotionThreadId?: string;
@@ -83,16 +65,6 @@ type NotionThreadWindow = Window & {
 };
 
 type AppState = "loading" | "no-session" | "booting" | "ready";
-
-type NotionConversation = {
-  id: string;
-  title: string;
-  source?: string;
-  status?: string;
-  notebook_path?: string;
-  created_at?: number;
-  updated_at?: number;
-};
 
 type ChatTraceThread = {
   thread_id: string;
@@ -109,14 +81,6 @@ type ResolvedTrail = Pick<AnalysisTrail, "project_id" | "branch" | "thread_id" |
 
 type RuntimeMode = "project" | "notion-trail" | "notebook";
 type RuntimeProduct = "projects" | "notebooks";
-
-type OverviewState = {
-  loading: boolean;
-  projectCount: number;
-  githubConnected: boolean;
-  notionConnected: boolean;
-  error: string | null;
-};
 
 const BOOT_PHASE_LABELS: Record<string, string> = {
   health: "connecting to runtime...",
@@ -140,23 +104,17 @@ function resolveRuntimeMode({
   return "notebook";
 }
 
-function hasUsableNotionInstallation(
-  installations: Array<{ status?: string; config?: { enabled?: boolean } | null }>,
-): boolean {
-  return installations.some(
-    (installation) => installation.status !== "disconnected" && installation.config?.enabled === true,
-  );
-}
-
-function hasUsableGitHubInstallation(data: unknown): boolean {
-  const installations = Array.isArray(data)
-    ? data
-    : (data as { installations?: unknown[] } | null)?.installations ?? [];
-  return installations.some(
-    (installation) =>
-      installation !== null &&
-      typeof installation === "object" &&
-      (installation as { status?: string }).status !== "disconnected",
+function isNotionTrailParams({
+  file,
+  sessionId,
+}: {
+  file?: string | null;
+  sessionId?: string | null;
+}): boolean {
+  return Boolean(
+    sessionId?.startsWith("session-notion-") ||
+      sessionId?.startsWith("session-slack-") ||
+      file?.startsWith("signalpilot-notion-analyses/"),
   );
 }
 
@@ -175,10 +133,10 @@ function IDEHeader({
   right?: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--color-border)] bg-[var(--color-bg)]">
+    <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-background">
       <div className="flex items-center gap-3">
-        <Code className="w-4 h-4 text-[var(--color-text)]" />
-        <span className="text-xs font-bold uppercase tracking-wider text-[var(--color-text)]">
+        <Code className="w-4 h-4 text-foreground" />
+        <span className="text-xs font-bold uppercase tracking-wider text-foreground">
           SignalPilot notebook
         </span>
         {children}
@@ -227,19 +185,7 @@ export default function NotebooksPage() {
   const [notebookConfig, setNotebookConfig] = useState<NotebookConfig | null>(null);
   const [, setActiveNotebookSession] =
     useState<NotebookSession | null>(null);
-  const [notionConversations, setNotionConversations] = useState<
-    NotionConversation[]
-  >([]);
-  const [overview, setOverview] = useState<OverviewState>({
-    loading: true,
-    projectCount: 0,
-    githubConnected: false,
-    notionConnected: false,
-    error: null,
-  });
-  const [overviewLoading, setOverviewLoading] = useState(false);
-  const [overviewError, setOverviewError] = useState<string | null>(null);
-  const [projectListRefreshNonce, setProjectListRefreshNonce] = useState(0);
+  const [notionConnected, setNotionConnected] = useState(false);
   const [copied, setCopied] = useState(false);
   const [bootPhase, setBootPhase] = useState<string>("health");
   const pingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -284,12 +230,6 @@ export default function NotebooksPage() {
       return;
     }
 
-    setGatewayProjectId(null);
-    setGatewayBranchId(null);
-    store.set(gatewayProjectIdAtom, null);
-    store.set(gatewayBranchIdAtom, null);
-    store.set(persistedGatewayBranchIdAtom, null);
-    store.set(dbtProjectDirAtom, null);
     window.localStorage.removeItem(GATEWAY_PROJECT_STORAGE_KEY);
     window.localStorage.removeItem(GATEWAY_BRANCH_STORAGE_KEY);
     window.localStorage.removeItem("sp:dbt-project-dir");
@@ -315,9 +255,6 @@ export default function NotebooksPage() {
     nextUrl.searchParams.set(KnownQueryParams.filePath, trail.notebook_path || urlFile);
     nextUrl.searchParams.delete(KnownQueryParams.sessionId);
 
-    store.set(gatewayProjectIdAtom, trail.project_id);
-    store.set(gatewayBranchIdAtom, trail.branch || "main");
-    store.set(persistedGatewayBranchIdAtom, trail.branch || "main");
     window.localStorage.setItem(GATEWAY_PROJECT_STORAGE_KEY, trail.project_id);
     window.localStorage.setItem(GATEWAY_BRANCH_STORAGE_KEY, trail.branch || "main");
 
@@ -459,18 +396,6 @@ export default function NotebooksPage() {
     };
   }, []);
 
-  function toNotionConversation(thread: ChatTraceThread): NotionConversation {
-    return {
-      id: thread.thread_id,
-      title: thread.title || "Notion request",
-      source: thread.source,
-      status: thread.status,
-      notebook_path: thread.notebook_path,
-      created_at: thread.created_at,
-      updated_at: thread.updated_at,
-    };
-  }
-
   async function fetchNotionTraceThreads() {
     const token = await getGatewayAuthToken();
     const headers: Record<string, string> = {};
@@ -481,9 +406,7 @@ export default function NotebooksPage() {
     });
   }
 
-  async function resolveNotionThreadId(
-    notionConnected = overview.notionConnected,
-  ): Promise<string | undefined> {
+  async function resolveNotionThreadId(): Promise<string | undefined> {
     if (isTrailSessionId(urlSessionId)) {
       return urlSessionId;
     }
@@ -494,13 +417,11 @@ export default function NotebooksPage() {
     if (remembered) {
       return remembered;
     }
-    if (!notionConnected) {
-      return undefined;
-    }
 
     try {
       const resp = await fetchNotionTraceThreads();
       if (!resp.ok) {return undefined;}
+      setNotionConnected(true);
       const data = (await resp.json()) as {
         threads?: ChatTraceThread[];
       };
@@ -562,12 +483,12 @@ export default function NotebooksPage() {
         project: urlProject || undefined,
         branch: urlProject ? activeBranch : undefined,
         file: urlFile || undefined,
-        notionConnected: overview.notionConnected,
+        notionConnected,
       };
     }
 
     const resolvedTrail = trail ?? await resolveTrailMetadata();
-    const kernelSessionId = resolvedTrail?.thread_id ?? await resolveNotionThreadId(overview.notionConnected);
+    const kernelSessionId = resolvedTrail?.thread_id ?? await resolveNotionThreadId();
     const trailFile = resolvedTrail?.notebook_path || urlFile;
     const isProjectBackedTrail = Boolean(resolvedTrail?.project_id);
     if (!isProjectBackedTrail && isNotionTrail(trailFile, kernelSessionId || urlSessionId)) {
@@ -590,79 +511,8 @@ export default function NotebooksPage() {
       project: resolvedTrail?.project_id,
       branch: resolvedTrail?.branch,
       file: trailFile || undefined,
-      notionConnected: overview.notionConnected,
+      notionConnected: notionConnected || Boolean(kernelSessionId),
     };
-  }
-
-  async function loadNotionConversations(
-    notionConnected = overview.notionConnected,
-  ) {
-    if (!notionConnected) {
-      setOverviewError(null);
-      setNotionConversations([]);
-      return;
-    }
-    setOverviewLoading(true);
-    setOverviewError(null);
-    try {
-      const resp = await fetchNotionTraceThreads();
-      if (!resp.ok) {
-        throw new Error(`HTTP ${resp.status}`);
-      }
-      const data = (await resp.json()) as {
-        threads?: ChatTraceThread[];
-      };
-      setNotionConversations(
-        (data.threads ?? []).map(toNotionConversation).filter(
-          (conversation) =>
-            conversation.source === "notion" ||
-            isTrailSessionId(conversation.id),
-        ),
-      );
-    } catch (err) {
-      setOverviewError(err instanceof Error ? err.message : String(err));
-      setNotionConversations([]);
-    } finally {
-      setOverviewLoading(false);
-    }
-  }
-
-  async function loadOverview() {
-    setOverview((prev) => ({ ...prev, loading: true, error: null }));
-
-    const [projectsResult, githubResult, notionResult] = await Promise.allSettled([
-      getWorkspaceProjects("active")
-        .then((result) => result.total)
-        .catch(() => getProjects().then((projects) => projects.length)),
-      getGitHubInstallations(),
-      getNotionOAuthInstallations(),
-    ]);
-
-    const nextOverview: OverviewState = {
-      loading: false,
-      projectCount:
-        projectsResult.status === "fulfilled" ? projectsResult.value : 0,
-      githubConnected:
-        githubResult.status === "fulfilled" &&
-        hasUsableGitHubInstallation(githubResult.value),
-      notionConnected:
-        notionResult.status === "fulfilled" &&
-        hasUsableNotionInstallation(notionResult.value),
-      error:
-        projectsResult.status === "rejected" &&
-        githubResult.status === "rejected" &&
-        notionResult.status === "rejected"
-          ? "Could not load workspace overview"
-          : null,
-    };
-
-    setOverview(nextOverview);
-    if (nextOverview.notionConnected) {
-      await loadNotionConversations(true);
-    } else {
-      setOverviewError(null);
-      setNotionConversations([]);
-    }
   }
 
   useEffect(() => {
@@ -733,7 +583,6 @@ export default function NotebooksPage() {
           } else {
             setActiveNotebookSession(session);
             setState("no-session");
-            void loadOverview();
             return;
           }
         }
@@ -745,7 +594,6 @@ export default function NotebooksPage() {
         await launch(apiKey);
       } else if (!cancelled) {
         setState("no-session");
-        void loadOverview();
       }
     }
 
@@ -788,7 +636,7 @@ export default function NotebooksPage() {
         newBranch !== notebookConfig.branch ||
         newFile !== notebookConfig.file ||
         newKernelSessionId !== notebookConfig.kernelSessionId ||
-        overview.notionConnected !== notebookConfig.notionConnected
+        notionConnected !== notebookConfig.notionConnected
       ) {
         setNotebookConfig((prev) =>
           prev
@@ -799,13 +647,13 @@ export default function NotebooksPage() {
                 branch: newBranch,
                 file: newFile,
                 kernelSessionId: newKernelSessionId,
-                notionConnected: overview.notionConnected,
+                notionConnected,
               }
             : prev,
         );
       }
     }
-  }, [urlProject, urlBranch, urlFile, urlSessionId, state, overview.notionConnected]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [urlProject, urlBranch, urlFile, urlSessionId, state, notionConnected]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const kernelSessionId = notebookConfig?.kernelSessionId;
@@ -873,8 +721,6 @@ export default function NotebooksPage() {
     setState("no-session");
     setNotebookConfig(null);
     setActiveNotebookSession(null);
-    setNotionConversations([]);
-    void loadOverview();
     if (pingRef.current) { clearInterval(pingRef.current); pingRef.current = null; }
   }
 
@@ -931,15 +777,6 @@ export default function NotebooksPage() {
     return `/notebook${qs ? `?${qs}` : ""}`;
   }
 
-  async function refreshOverview() {
-    await loadOverview();
-  }
-
-  async function refreshProjectsSurface() {
-    setProjectListRefreshNonce((nonce) => nonce + 1);
-    await loadOverview();
-  }
-
   // ─── Render: Paywall (free-tier cloud users) ──────────────────
   if (gated) {
     return <NotebooksProjectsPaywall />;
@@ -948,14 +785,14 @@ export default function NotebooksPage() {
   // ─── Render: Loading ──────────────────────────────────────────
   if (state === "loading") {
     return (
-      <div className="flex flex-col h-screen">
+      <div className="flex flex-col h-screen bg-background text-foreground">
         <IDEHeader>
-          <Loader2 className="w-3.5 h-3.5 animate-spin text-[var(--color-text-dim)]" />
-          <span className="text-[11px] text-[var(--color-text-dim)]">{launchStatus}</span>
+          <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
+          <span className="text-[11px] text-muted-foreground">{launchStatus}</span>
         </IDEHeader>
         <div className="flex-1 flex flex-col items-center justify-center gap-4">
-          <Loader2 className="w-8 h-8 animate-spin text-[var(--color-text-dim)]" />
-          <span className="text-xs text-[var(--color-text-dim)] tracking-wider uppercase">
+          <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+          <span className="text-xs text-muted-foreground tracking-wider uppercase">
             {launchStatus}
           </span>
         </div>
@@ -975,13 +812,13 @@ export default function NotebooksPage() {
       effectiveNotebookConfig.kernelSessionId ?? "",
     ].join(":");
     return (
-      <div className="flex flex-col h-screen">
+      <div className="flex flex-col h-screen bg-background text-foreground">
         <IDEHeader
           right={
             <>
               <button
                 onClick={handleShare}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground border border-border hover:border-muted-foreground hover:text-foreground transition-all tracking-wider uppercase"
               >
                 {copied ? <Check className="w-3 h-3" /> : <Share2 className="w-3 h-3" />}
                 {copied ? "copied" : "share"}
@@ -991,14 +828,14 @@ export default function NotebooksPage() {
                   href={notebookPopoutHref(effectiveNotebookConfig)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground border border-border hover:border-muted-foreground hover:text-foreground transition-all tracking-wider uppercase"
                 >
                   <ExternalLink className="w-3 h-3" /> external
                 </a>
               )}
               <button
                 onClick={stop}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-error)] hover:text-[var(--color-error)] transition-all tracking-wider uppercase"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground border border-border hover:border-destructive hover:text-destructive transition-all tracking-wider uppercase"
               >
                 <Square className="w-3 h-3" /> stop
               </button>
@@ -1007,15 +844,15 @@ export default function NotebooksPage() {
         >
           {state === "booting" ? (
             <>
-              <Loader2 className="w-3.5 h-3.5 animate-spin text-[var(--color-text-dim)]" />
-              <span className="text-[11px] text-[var(--color-text-dim)]">
+              <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
+              <span className="text-[11px] text-muted-foreground">
                 {BOOT_PHASE_LABELS[bootPhase] || bootPhase}
               </span>
             </>
           ) : (
             <>
               <StatusDot status="healthy" size={4} pulse />
-              <span className="text-[11px] text-[var(--color-success)]">running</span>
+              <span className="text-[11px] text-green-500">running</span>
             </>
           )}
         </IDEHeader>
@@ -1033,186 +870,28 @@ export default function NotebooksPage() {
     <div className="p-8 animate-fade-in">
       <div className="max-w-6xl mx-auto mt-16">
         <div className="flex items-center gap-3 mb-6">
-          <Code className="w-6 h-6 text-[var(--color-text)]" />
-          <h1 className="text-lg font-bold uppercase tracking-wider text-[var(--color-text)]">
+          <Code className="w-6 h-6 text-foreground" />
+          <h1 className="text-lg font-bold uppercase tracking-wider text-foreground">
             SignalPilot IDE
           </h1>
         </div>
         <div className="flex flex-wrap items-center gap-3 mb-8">
           <button
             onClick={() => launch(undefined, "notebooks")}
-            className="flex items-center gap-3 px-5 py-3 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90"
+            className="flex items-center gap-3 px-5 py-3 bg-primary text-primary-foreground text-xs font-medium tracking-wider uppercase transition-all hover:opacity-90"
           >
             <Code className="w-4 h-4" />
             <span>open notebook runtime</span>
           </button>
           <a
-            href="/settings/github"
-            className="flex items-center gap-3 px-5 py-3 text-xs text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
+            href="/projects"
+            className="flex items-center gap-3 px-5 py-3 text-xs text-muted-foreground border border-border hover:border-muted-foreground hover:text-foreground transition-all tracking-wider uppercase"
           >
-            <Github className="w-4 h-4" />
-            <span>connect github</span>
-          </a>
-          <a
-            href="/integrations"
-            className="flex items-center gap-3 px-5 py-3 text-xs text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
-          >
-            <NotionIcon className="w-4 h-4" />
-            <span>connect notion</span>
+            <ExternalLink className="w-4 h-4" />
+            <span>back to projects</span>
           </a>
         </div>
-
-        {overview.error && (
-          <div className="mb-4 border border-[var(--color-error)]/40 px-5 py-4 text-xs text-[var(--color-error)]">
-            {overview.error}
-          </div>
-        )}
-
-        <div className="mb-8">
-          <div className="mb-4">
-            <DbtProjectActions
-              onProjectCreated={refreshProjectsSurface}
-              openProjectOnComplete={false}
-            />
-          </div>
-          <DbtProjectList
-            key={projectListRefreshNonce}
-            onRefresh={refreshProjectsSurface}
-          />
-        </div>
-
-        {overview.loading ? (
-          <div className="border border-[var(--color-border)] px-5 py-10 flex items-center justify-center gap-3 text-xs text-[var(--color-text-dim)] uppercase tracking-wider">
-            <Loader2 className="w-4 h-4 animate-spin" />
-            checking integrations...
-          </div>
-        ) : overview.notionConnected ? (
-          <>
-            <div className="mb-3">
-              <Header
-                Icon={NotionIcon}
-                control={
-                  <Button
-                    variant="text"
-                    size="xs"
-                    onClick={refreshOverview}
-                    disabled={overviewLoading}
-                    title="Refresh Notion requests"
-                  >
-                    {overviewLoading ? (
-                      <Loader2 size={14} className="animate-spin" />
-                    ) : (
-                      <RefreshCw size={14} />
-                    )}
-                  </Button>
-                }
-              >
-                Notion requests
-              </Header>
-            </div>
-            <NotionConversationList
-              conversations={notionConversations}
-              loading={overviewLoading}
-              error={overviewError}
-            />
-          </>
-        ) : (
-          <div className="border border-[var(--color-border)] px-5 py-10 text-sm text-[var(--color-text-dim)]">
-            <p>Connect Notion to generate notebook-backed requests from Notion comments.</p>
-            <a
-              href="/integrations"
-              className="inline-flex items-center gap-2 mt-4 px-4 py-2 text-[12px] text-[var(--color-bg)] bg-[var(--color-text)] hover:opacity-90 transition-all tracking-wider uppercase"
-            >
-              <NotionIcon className="w-3.5 h-3.5" />
-              connect notion
-            </a>
-          </div>
-        )}
       </div>
     </div>
   );
-}
-
-function NotionConversationList({
-  conversations,
-  loading,
-  error,
-}: {
-  conversations: NotionConversation[];
-  loading: boolean;
-  error: string | null;
-}) {
-  if (loading && conversations.length === 0) {
-    return (
-      <div className="border border-[var(--color-border)] px-5 py-10 flex items-center justify-center gap-3 text-xs text-[var(--color-text-dim)] uppercase tracking-wider">
-        <Loader2 className="w-4 h-4 animate-spin" />
-        loading notion requests...
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="border border-[var(--color-error)]/40 px-5 py-4 text-xs text-[var(--color-error)]">
-        Could not load Notion requests: {error}
-      </div>
-    );
-  }
-
-  if (conversations.length === 0) {
-    return (
-      <div className="py-8 text-center text-muted-foreground text-sm">
-        <NotionIcon className="mx-auto mb-2 h-6 w-6 opacity-40" />
-        <p>No Notion requests found.</p>
-        <p className="text-xs mt-1">@ SignalPilot in your Notion workspace.</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="border border-[var(--color-border)] divide-y divide-[var(--color-border)]">
-      {conversations.map((conversation) => {
-        const file = conversation.notebook_path || "";
-        const href = file
-          ? `/projects?file=${encodeURIComponent(file)}&session_id=${encodeURIComponent(conversation.id)}`
-          : `/projects?session_id=${encodeURIComponent(conversation.id)}`;
-        const status = conversation.status || "saved";
-        return (
-          <a
-            key={conversation.id}
-            href={href}
-            className="flex items-center gap-4 px-5 py-4 hover:bg-[var(--color-bg-hover)] transition-colors"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="text-sm text-[var(--color-text)] truncate">
-                {conversation.title || "Notion request"}
-              </div>
-              <div className="text-[11px] text-[var(--color-text-dim)] font-mono truncate mt-1">
-                {file || conversation.id}
-              </div>
-            </div>
-            <div className="flex items-center gap-3 shrink-0">
-              <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-dim)] border border-[var(--color-border)] px-2 py-1">
-                {status}
-              </span>
-              <span className="text-[11px] text-[var(--color-text-dim)]">
-                {formatConversationTime(conversation.updated_at)}
-              </span>
-              <ExternalLink className="w-4 h-4 text-[var(--color-text-dim)]" />
-            </div>
-          </a>
-        );
-      })}
-    </div>
-  );
-}
-
-function formatConversationTime(value?: number): string {
-  if (!value) return "";
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(new Date(value * 1000));
 }

--- a/signalpilot/web/components/projects/projects-overview-page.tsx
+++ b/signalpilot/web/components/projects/projects-overview-page.tsx
@@ -1,0 +1,1381 @@
+"use client";
+
+import {
+  useRouter,
+} from "next/navigation";
+import {
+  AlertTriangle,
+  Cloud,
+  Code,
+  Database,
+  ExternalLink,
+  FolderPlus,
+  GitBranch,
+  Github,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Trash2,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+
+import { NotionIcon } from "~/components/branding/notion-icon";
+import { useToast } from "~/components/ui/toast";
+import {
+  createNotebookSession,
+  createWorkspaceProject,
+  deleteWorkspaceProject,
+  getGatewayAuthToken,
+  getGitHubInstallUrl,
+  getGitHubInstallations,
+  getGitHubRepos,
+  getNotionOAuthInstallations,
+  getProjects,
+  getWorkspaceProjects,
+  linkGitHubRepo,
+  request,
+} from "~/lib/api";
+import type {
+  GitHubInstallation,
+  GitHubRepo,
+  WorkspaceProjectInfo,
+} from "~/lib/types";
+
+const GATEWAY_URL =
+  process.env.NEXT_PUBLIC_GATEWAY_URL ?? "http://localhost:3300";
+const GATEWAY_PROJECT_STORAGE_KEY = "sp:gateway-project-id";
+const GATEWAY_BRANCH_STORAGE_KEY = "sp:gateway-branch-id";
+const DBT_PROJECT_DIR_STORAGE_KEY = "sp:dbt-project-dir";
+
+const OUTLINE_BUTTON =
+  "inline-flex items-center justify-center gap-2 border border-[var(--color-border)] px-4 py-2 text-xs uppercase tracking-wider text-[var(--color-text-dim)] transition-all hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-50";
+const PRIMARY_BUTTON =
+  "inline-flex items-center justify-center gap-2 bg-[var(--color-text)] px-4 py-2 text-xs uppercase tracking-wider text-[var(--color-bg)] transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60";
+const ICON_BUTTON =
+  "inline-flex h-8 w-8 items-center justify-center border border-transparent text-[var(--color-text-dim)] transition-colors hover:border-[var(--color-border)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-50";
+
+type OverviewState = {
+  loading: boolean;
+  projectCount: number;
+  githubConnected: boolean;
+  notionConnected: boolean;
+  error: string | null;
+};
+
+type NotionConversation = {
+  id: string;
+  title: string;
+  source?: string;
+  status?: string;
+  notebook_path?: string;
+  created_at?: number;
+  updated_at?: number;
+};
+
+type ChatTraceThread = {
+  thread_id: string;
+  session_id: string;
+  title?: string;
+  source?: string;
+  status?: string;
+  notebook_path?: string;
+  created_at?: number;
+  updated_at?: number;
+};
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isTrailSessionId(sessionId?: string): sessionId is string {
+  return Boolean(
+    sessionId?.startsWith("session-notion-") ||
+      sessionId?.startsWith("session-slack-"),
+  );
+}
+
+function hasUsableNotionInstallation(
+  installations: Array<{ status?: string; config?: { enabled?: boolean } | null }>,
+): boolean {
+  return installations.some(
+    (installation) =>
+      installation.status !== "disconnected" &&
+      installation.config?.enabled === true,
+  );
+}
+
+function hasUsableGitHubInstallation(data: unknown): boolean {
+  const installations = Array.isArray(data)
+    ? data
+    : (data as { installations?: unknown[] } | null)?.installations ?? [];
+  return installations.some(
+    (installation) =>
+      installation !== null &&
+      typeof installation === "object" &&
+      (installation as { status?: string }).status !== "disconnected",
+  );
+}
+
+function toNotionConversation(thread: ChatTraceThread): NotionConversation {
+  return {
+    id: thread.thread_id,
+    title: thread.title || "Notion request",
+    source: thread.source,
+    status: thread.status,
+    notebook_path: thread.notebook_path,
+    created_at: thread.created_at,
+    updated_at: thread.updated_at,
+  };
+}
+
+function clearRuntimeCaches() {
+  window.localStorage.removeItem("sp:file-tree-cache");
+  window.localStorage.removeItem("sp:file-tree-open-state");
+}
+
+function setProjectRuntimeStorage(projectId: string, branch: string) {
+  window.localStorage.setItem(GATEWAY_PROJECT_STORAGE_KEY, projectId);
+  window.localStorage.setItem(GATEWAY_BRANCH_STORAGE_KEY, branch);
+  window.localStorage.removeItem(DBT_PROJECT_DIR_STORAGE_KEY);
+  clearRuntimeCaches();
+}
+
+function clearProjectRuntimeStorage() {
+  window.localStorage.removeItem(GATEWAY_PROJECT_STORAGE_KEY);
+  window.localStorage.removeItem(GATEWAY_BRANCH_STORAGE_KEY);
+  clearRuntimeCaches();
+}
+
+function slugifyProjectName(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return "";
+  }
+  if (value < 1024) {
+    return `${value} B`;
+  }
+  if (value < 1024 * 1024) {
+    return `${Math.round(value / 1024)} KB`;
+  }
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatRelativeTime(value?: number | null): string {
+  if (!value) {
+    return "";
+  }
+  const diffMs = Date.now() - value * 1000;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diffMs < minute) {
+    return "just now";
+  }
+  if (diffMs < hour) {
+    return `${Math.floor(diffMs / minute)}m ago`;
+  }
+  if (diffMs < day) {
+    return `${Math.floor(diffMs / hour)}h ago`;
+  }
+  if (diffMs < 30 * day) {
+    return `${Math.floor(diffMs / day)}d ago`;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value * 1000));
+}
+
+function formatConversationTime(value?: number): string {
+  if (!value) {
+    return "";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value * 1000));
+}
+
+export default function ProjectsOverviewPage() {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [overview, setOverview] = useState<OverviewState>({
+    loading: true,
+    projectCount: 0,
+    githubConnected: false,
+    notionConnected: false,
+    error: null,
+  });
+  const [projects, setProjects] = useState<WorkspaceProjectInfo[]>([]);
+  const [projectsLoading, setProjectsLoading] = useState(true);
+  const [notionConversations, setNotionConversations] = useState<
+    NotionConversation[]
+  >([]);
+  const [notionLoading, setNotionLoading] = useState(false);
+  const [notionError, setNotionError] = useState<string | null>(null);
+  const [launchingNotebook, setLaunchingNotebook] = useState(false);
+  const [showLocalImport, setShowLocalImport] = useState(false);
+  const [openingLocalProject, setOpeningLocalProject] = useState(false);
+
+  const loadNotionConversations = useCallback(async (notionConnected: boolean) => {
+    if (!notionConnected) {
+      setNotionError(null);
+      setNotionConversations([]);
+      return;
+    }
+
+    setNotionLoading(true);
+    setNotionError(null);
+    try {
+      const token = await getGatewayAuthToken();
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+      const response = await fetch(`${GATEWAY_URL}/api/chat/traces/threads`, {
+        headers,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = (await response.json()) as { threads?: ChatTraceThread[] };
+      setNotionConversations(
+        (data.threads ?? [])
+          .map(toNotionConversation)
+          .filter(
+            (conversation) =>
+              conversation.source === "notion" ||
+              isTrailSessionId(conversation.id),
+          ),
+      );
+    } catch (error) {
+      setNotionError(getErrorMessage(error));
+      setNotionConversations([]);
+    } finally {
+      setNotionLoading(false);
+    }
+  }, []);
+
+  const loadOverview = useCallback(async () => {
+    setOverview((prev) => ({ ...prev, loading: true, error: null }));
+    setProjectsLoading(true);
+
+    const [projectsResult, githubResult, notionResult] =
+      await Promise.allSettled([
+        getWorkspaceProjects("active"),
+        getGitHubInstallations(),
+        getNotionOAuthInstallations(),
+      ]);
+
+    let projectCount = 0;
+    if (projectsResult.status === "fulfilled") {
+      setProjects(projectsResult.value.projects ?? []);
+      projectCount = projectsResult.value.total;
+    } else {
+      setProjects([]);
+      try {
+        projectCount = (await getProjects()).length;
+      } catch {
+        projectCount = 0;
+      }
+    }
+    setProjectsLoading(false);
+
+    const nextOverview: OverviewState = {
+      loading: false,
+      projectCount,
+      githubConnected:
+        githubResult.status === "fulfilled" &&
+        hasUsableGitHubInstallation(githubResult.value),
+      notionConnected:
+        notionResult.status === "fulfilled" &&
+        hasUsableNotionInstallation(notionResult.value),
+      error:
+        projectsResult.status === "rejected" &&
+        githubResult.status === "rejected" &&
+        notionResult.status === "rejected"
+          ? "Could not load workspace overview"
+          : null,
+    };
+
+    setOverview(nextOverview);
+    await loadNotionConversations(nextOverview.notionConnected);
+  }, [loadNotionConversations]);
+
+  useEffect(() => {
+    void loadOverview();
+  }, [loadOverview]);
+
+  const openNotebookRuntime = useCallback(async () => {
+    setLaunchingNotebook(true);
+    try {
+      clearProjectRuntimeStorage();
+      window.localStorage.removeItem(DBT_PROJECT_DIR_STORAGE_KEY);
+      const session = await createNotebookSession({ project_id: null });
+      if (!session.id) {
+        throw new Error("Session created but no ID returned");
+      }
+      const params = new URLSearchParams();
+      params.set("session_id", session.id);
+      router.push(`/projects?${params.toString()}`);
+    } catch (error) {
+      toast(getErrorMessage(error), "error");
+      setLaunchingNotebook(false);
+    }
+  }, [router, toast]);
+
+  const openProject = useCallback((project: WorkspaceProjectInfo) => {
+    const branch = project.default_branch || "main";
+    setProjectRuntimeStorage(project.id, branch);
+    const params = new URLSearchParams();
+    params.set("project", project.id);
+    params.set("branch", branch);
+    params.set("file", "__new__project");
+    router.push(`/projects?${params.toString()}`);
+  }, [router]);
+
+  const openLocalProject = useCallback(
+    async (projectPath: string) => {
+      const trimmed = projectPath.trim();
+      if (!trimmed) {
+        return;
+      }
+      setOpeningLocalProject(true);
+      try {
+        clearProjectRuntimeStorage();
+        window.localStorage.setItem(
+          DBT_PROJECT_DIR_STORAGE_KEY,
+          JSON.stringify(trimmed),
+        );
+        const session = await createNotebookSession({ project_id: null });
+        if (!session.id) {
+          throw new Error("Session created but no ID returned");
+        }
+        const params = new URLSearchParams();
+        params.set("file", "__new__project");
+        params.set("session_id", session.id);
+        router.push(`/projects?${params.toString()}`);
+      } catch (error) {
+        toast(getErrorMessage(error), "error");
+        setOpeningLocalProject(false);
+      }
+    },
+    [router, toast],
+  );
+
+  return (
+    <div className="animate-fade-in p-8">
+      <div className="mx-auto mt-16 max-w-6xl">
+        <div className="mb-6 flex items-center gap-3">
+          <Code className="h-6 w-6 text-[var(--color-text)]" />
+          <h1 className="text-lg font-bold uppercase tracking-wider text-[var(--color-text)]">
+            SignalPilot IDE
+          </h1>
+        </div>
+
+        <div className="mb-8 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={openNotebookRuntime}
+            disabled={launchingNotebook}
+            className="inline-flex items-center gap-3 bg-[var(--color-text)] px-5 py-3 text-xs font-medium uppercase tracking-wider text-[var(--color-bg)] transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {launchingNotebook ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Code className="h-4 w-4" />
+            )}
+            <span>open notebook runtime</span>
+          </button>
+          <a
+            href="/settings/github"
+            className="inline-flex items-center gap-3 border border-[var(--color-border)] px-5 py-3 text-xs uppercase tracking-wider text-[var(--color-text-dim)] transition-all hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+          >
+            <Github className="h-4 w-4" />
+            <span>connect github</span>
+          </a>
+          <a
+            href="/integrations"
+            className="inline-flex items-center gap-3 border border-[var(--color-border)] px-5 py-3 text-xs uppercase tracking-wider text-[var(--color-text-dim)] transition-all hover:border-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+          >
+            <NotionIcon className="h-4 w-4" />
+            <span>connect notion</span>
+          </a>
+        </div>
+
+        {overview.error && (
+          <div className="mb-4 border border-[var(--color-error)]/40 px-5 py-4 text-xs text-[var(--color-error)]">
+            {overview.error}
+          </div>
+        )}
+
+        <div className="mb-8 space-y-4">
+          <WorkspaceProjectActions onProjectChanged={loadOverview} />
+
+          <div className="space-y-3">
+            <SectionHeader
+              Icon={Database}
+              control={
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    className={ICON_BUTTON}
+                    onClick={() => setShowLocalImport((value) => !value)}
+                    title="Import local project"
+                  >
+                    <FolderPlus className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    className={ICON_BUTTON}
+                    onClick={() => void loadOverview()}
+                    disabled={projectsLoading}
+                    title="Refresh projects"
+                  >
+                    {projectsLoading ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
+              }
+            >
+              Projects
+            </SectionHeader>
+
+            {showLocalImport && (
+              <LocalProjectForm
+                loading={openingLocalProject}
+                onOpen={openLocalProject}
+                onCancel={() => setShowLocalImport(false)}
+              />
+            )}
+
+            <ProjectGrid
+              projects={projects}
+              loading={projectsLoading}
+              projectCount={overview.projectCount}
+              onProjectClick={openProject}
+              onProjectDeleted={loadOverview}
+            />
+          </div>
+        </div>
+
+        {overview.loading ? (
+          <div className="flex items-center justify-center gap-3 border border-[var(--color-border)] px-5 py-10 text-xs uppercase tracking-wider text-[var(--color-text-dim)]">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            checking integrations...
+          </div>
+        ) : overview.notionConnected ? (
+          <>
+            <div className="mb-3">
+              <SectionHeader
+                Icon={NotionIcon}
+                control={
+                  <button
+                    type="button"
+                    className={ICON_BUTTON}
+                    onClick={() =>
+                      void loadNotionConversations(overview.notionConnected)
+                    }
+                    disabled={notionLoading}
+                    title="Refresh Notion requests"
+                  >
+                    {notionLoading ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                }
+              >
+                Notion requests
+              </SectionHeader>
+            </div>
+            <NotionConversationList
+              conversations={notionConversations}
+              loading={notionLoading}
+              error={notionError}
+              onOpen={(href) => router.push(href)}
+            />
+          </>
+        ) : (
+          <div className="border border-[var(--color-border)] px-5 py-10 text-sm text-[var(--color-text-dim)]">
+            <p>
+              Connect Notion to generate notebook-backed requests from Notion
+              comments.
+            </p>
+            <a
+              href="/integrations"
+              className="mt-4 inline-flex items-center gap-2 bg-[var(--color-text)] px-4 py-2 text-[12px] uppercase tracking-wider text-[var(--color-bg)] transition-all hover:opacity-90"
+            >
+              <NotionIcon className="h-3.5 w-3.5" />
+              connect notion
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({
+  Icon,
+  control,
+  children,
+}: {
+  Icon: LucideIcon | ComponentType<{ className?: string }>;
+  control?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <h2 className="flex select-none items-center gap-2 text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        {children}
+      </h2>
+      {control}
+    </div>
+  );
+}
+
+function WorkspaceProjectActions({
+  onProjectChanged,
+}: {
+  onProjectChanged: () => void | Promise<void>;
+}) {
+  const [showCreate, setShowCreate] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className={OUTLINE_BUTTON}
+          onClick={() => setShowCreate((value) => !value)}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Create new project
+        </button>
+        <button
+          type="button"
+          className={OUTLINE_BUTTON}
+          onClick={() => setShowImport((value) => !value)}
+        >
+          <GitBranch className="h-3.5 w-3.5" />
+          Import from GitHub
+        </button>
+      </div>
+
+      {showCreate && (
+        <CreateProjectForm
+          onClose={() => setShowCreate(false)}
+          onCreated={onProjectChanged}
+        />
+      )}
+      {showImport && (
+        <GitHubImportForm
+          onClose={() => setShowImport(false)}
+          onImported={onProjectChanged}
+        />
+      )}
+    </div>
+  );
+}
+
+function CreateProjectForm({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: () => void | Promise<void>;
+}) {
+  const { toast } = useToast();
+  const [name, setName] = useState("");
+  const [adapter, setAdapter] = useState("duckdb");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast("Project name is required", "error");
+      return;
+    }
+    const slug = slugifyProjectName(trimmed);
+    if (!slug) {
+      toast("Project name needs at least one letter or number", "error");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await createWorkspaceProject({
+        name: slug,
+        display_name: trimmed,
+        description: `${trimmed} dbt project (${adapter})`,
+        source: "managed",
+        tags: ["dbt", adapter],
+      });
+      toast(`Created ${trimmed}`, "success");
+      await onCreated();
+      onClose();
+    } catch (error) {
+      toast(getErrorMessage(error), "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-3 rounded-lg border border-[var(--color-border)] bg-muted/30 p-4"
+    >
+      <div className="flex items-center gap-2 text-sm font-semibold text-[var(--color-text)]">
+        <Database className="h-3.5 w-3.5" />
+        Create new dbt project
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="space-y-1">
+          <span className="block text-xs font-medium text-[var(--color-text-dim)]">
+            Project name
+          </span>
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-text-dim)]"
+            placeholder="my_dbt_project"
+            autoFocus
+          />
+        </label>
+        <label className="space-y-1">
+          <span className="block text-xs font-medium text-[var(--color-text-dim)]">
+            Adapter
+          </span>
+          <select
+            value={adapter}
+            onChange={(event) => setAdapter(event.target.value)}
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-text-dim)]"
+          >
+            <option value="duckdb">DuckDB</option>
+            <option value="postgres">PostgreSQL</option>
+            <option value="snowflake">Snowflake</option>
+            <option value="bigquery">BigQuery</option>
+            <option value="redshift">Redshift</option>
+          </select>
+        </label>
+      </div>
+      <div className="flex justify-end gap-2">
+        <button type="button" className={OUTLINE_BUTTON} onClick={onClose}>
+          Cancel
+        </button>
+        <button type="submit" className={PRIMARY_BUTTON} disabled={loading}>
+          {loading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          Create
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function GitHubImportForm({
+  onClose,
+  onImported,
+}: {
+  onClose: () => void;
+  onImported: () => void | Promise<void>;
+}) {
+  const { toast } = useToast();
+  const [installations, setInstallations] = useState<GitHubInstallation[]>([]);
+  const [repos, setRepos] = useState<GitHubRepo[]>([]);
+  const [loadingInstallations, setLoadingInstallations] = useState(true);
+  const [loadingRepos, setLoadingRepos] = useState(false);
+  const [selectedInstall, setSelectedInstall] =
+    useState<GitHubInstallation | null>(null);
+  const [importingRepo, setImportingRepo] = useState<string | null>(null);
+  const [connectingGitHub, setConnectingGitHub] = useState(false);
+
+  const loadInstallations = useCallback(async () => {
+    setLoadingInstallations(true);
+    try {
+      const data = await getGitHubInstallations();
+      setInstallations(data);
+      if (data.length >= 1) {
+        setSelectedInstall(data[0]);
+      }
+    } catch (error) {
+      toast(getErrorMessage(error), "error");
+      setInstallations([]);
+    } finally {
+      setLoadingInstallations(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void loadInstallations();
+  }, [loadInstallations]);
+
+  useEffect(() => {
+    if (!selectedInstall) {
+      setRepos([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingRepos(true);
+    getGitHubRepos(selectedInstall.id)
+      .then((nextRepos) => {
+        if (!cancelled) {
+          setRepos(nextRepos);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRepos([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingRepos(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedInstall]);
+
+  const connectGitHub = async () => {
+    setConnectingGitHub(true);
+    try {
+      const { install_url } = await getGitHubInstallUrl();
+      window.location.href = install_url;
+    } catch (error) {
+      toast(getErrorMessage(error), "error");
+      setConnectingGitHub(false);
+    }
+  };
+
+  const importRepo = async (repo: GitHubRepo) => {
+    if (!selectedInstall) {
+      return;
+    }
+
+    setImportingRepo(repo.full_name);
+    try {
+      const project = await createWorkspaceProject({
+        name: repo.name,
+        display_name: repo.name,
+        description: repo.description || "",
+        source: "github",
+        tags: ["github"],
+      });
+
+      await linkGitHubRepo({
+        project_id: project.id,
+        installation_id: selectedInstall.id,
+        repo_full_name: repo.full_name,
+        repo_id: repo.id,
+        default_branch: repo.default_branch,
+      });
+
+      toast("Mirroring repository from GitHub...", "info");
+      try {
+        await request<unknown>(`/api/github/sync/${project.id}`, {
+          method: "POST",
+        });
+      } catch (error) {
+        console.warn("[Projects] Gateway GitHub sync failed:", error);
+      }
+
+      toast(`Imported ${repo.full_name}`, "success");
+      await onImported();
+      onClose();
+    } catch (error) {
+      toast(getErrorMessage(error), "error");
+    } finally {
+      setImportingRepo(null);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-[var(--color-border)] bg-muted/30 p-4">
+      <div className="flex items-center gap-2 text-sm font-semibold text-[var(--color-text)]">
+        <GitBranch className="h-3.5 w-3.5" />
+        Import from GitHub
+      </div>
+
+      {loadingInstallations ? (
+        <div className="flex items-center justify-center gap-2 py-6 text-xs text-[var(--color-text-dim)]">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Loading GitHub connections...
+        </div>
+      ) : installations.length === 0 ? (
+        <div className="space-y-3 py-4 text-center">
+          <p className="text-sm text-[var(--color-text-dim)]">
+            No GitHub account connected.
+          </p>
+          <button
+            type="button"
+            onClick={connectGitHub}
+            disabled={connectingGitHub}
+            className={OUTLINE_BUTTON}
+          >
+            {connectingGitHub && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            )}
+            Connect GitHub
+            <ExternalLink className="h-3 w-3" />
+          </button>
+        </div>
+      ) : (
+        <>
+          {installations.length > 1 && (
+            <div className="flex flex-wrap gap-2">
+              {installations.map((installation) => (
+                <button
+                  key={installation.id}
+                  type="button"
+                  className={
+                    selectedInstall?.id === installation.id
+                      ? PRIMARY_BUTTON
+                      : OUTLINE_BUTTON
+                  }
+                  onClick={() => setSelectedInstall(installation)}
+                >
+                  {installation.github_account_login}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {loadingRepos ? (
+            <div className="flex items-center justify-center gap-2 py-4 text-xs text-[var(--color-text-dim)]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading repositories...
+            </div>
+          ) : repos.length === 0 ? (
+            <div className="py-4 text-center text-sm text-[var(--color-text-dim)]">
+              <p>No repositories found.</p>
+              <button
+                type="button"
+                onClick={connectGitHub}
+                disabled={connectingGitHub}
+                className="mt-2 inline-flex items-center gap-1.5 text-xs text-[var(--color-text)] hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {connectingGitHub && (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                )}
+                Add more repositories
+                <ExternalLink className="h-3 w-3" />
+              </button>
+            </div>
+          ) : (
+            <div className="max-h-[240px] space-y-1 overflow-y-auto">
+              {repos.map((repo) => (
+                <div
+                  key={repo.id}
+                  className="flex items-center gap-3 rounded-md border border-[var(--color-border)] px-3 py-2 transition-colors hover:border-[var(--color-text-dim)] hover:bg-muted/30"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium text-[var(--color-text)]">
+                      {repo.full_name}
+                    </div>
+                    {repo.description && (
+                      <div className="truncate text-xs text-[var(--color-text-dim)]">
+                        {repo.description}
+                      </div>
+                    )}
+                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-[var(--color-text-dim)]">
+                      <span>{repo.default_branch}</span>
+                      {repo.private && (
+                        <span className="border border-[var(--color-border)] px-1">
+                          private
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className={OUTLINE_BUTTON}
+                    onClick={() => void importRepo(repo)}
+                    disabled={importingRepo !== null}
+                  >
+                    {importingRepo === repo.full_name && (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    )}
+                    Import
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between border-t border-[var(--color-border)]/50 pt-2">
+            <button
+              type="button"
+              className={OUTLINE_BUTTON}
+              onClick={connectGitHub}
+              disabled={connectingGitHub}
+            >
+              {connectingGitHub ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Plus className="h-3.5 w-3.5" />
+              )}
+              Add Repository
+              <ExternalLink className="h-3 w-3 opacity-60" />
+            </button>
+            <button type="button" className={OUTLINE_BUTTON} onClick={onClose}>
+              Cancel
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function LocalProjectForm({
+  loading,
+  onOpen,
+  onCancel,
+}: {
+  loading: boolean;
+  onOpen: (projectPath: string) => void | Promise<void>;
+  onCancel: () => void;
+}) {
+  const [projectPath, setProjectPath] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    await onOpen(projectPath);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-2 px-1 sm:flex-row sm:items-center"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={projectPath}
+        onChange={(event) => setProjectPath(event.target.value)}
+        placeholder="Paste path to local dbt project folder..."
+        className="min-w-0 flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-dim)]/60 outline-none focus:border-[var(--color-text-dim)]"
+      />
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          className={PRIMARY_BUTTON}
+          disabled={!projectPath.trim() || loading}
+        >
+          {loading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          Open
+        </button>
+        <button type="button" className={OUTLINE_BUTTON} onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ProjectGrid({
+  projects,
+  loading,
+  projectCount,
+  onProjectClick,
+  onProjectDeleted,
+}: {
+  projects: WorkspaceProjectInfo[];
+  loading: boolean;
+  projectCount: number;
+  onProjectClick: (project: WorkspaceProjectInfo) => void;
+  onProjectDeleted: () => void | Promise<void>;
+}) {
+  if (loading && projects.length === 0) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-12 text-sm text-[var(--color-text-dim)]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading projects...
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-[var(--color-text-dim)]">
+        <Cloud className="mx-auto mb-2 h-6 w-6 opacity-40" />
+        <p>No projects found.</p>
+        {projectCount > 0 && (
+          <p className="mt-1 text-xs">
+            Workspace projects could not be listed, but legacy projects were
+            detected.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {projects.map((project) => (
+        <ProjectCard
+          key={project.id}
+          project={project}
+          onClick={onProjectClick}
+          onDeleted={onProjectDeleted}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ProjectCard({
+  project,
+  onClick,
+  onDeleted,
+}: {
+  project: WorkspaceProjectInfo;
+  onClick: (project: WorkspaceProjectInfo) => void;
+  onDeleted: () => void | Promise<void>;
+}) {
+  const [showDelete, setShowDelete] = useState(false);
+  const tags = project.tags ?? [];
+  const projectName = project.display_name || project.name;
+  const details = [
+    project.file_count > 0 ? `${project.file_count} files` : "",
+    formatBytes(project.total_bytes),
+    formatRelativeTime(project.updated_at),
+  ].filter(Boolean);
+
+  return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        className="group relative w-full rounded-lg border border-[var(--color-border)] p-4 text-left transition-all duration-150 hover:border-[var(--color-text-dim)] hover:bg-muted/50"
+        onClick={() => onClick(project)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onClick(project);
+          }
+        }}
+      >
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-md bg-primary/10 p-2 text-primary">
+            <Cloud className="h-[18px] w-[18px]" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-[var(--color-text)]">
+              {projectName}
+            </div>
+            {project.description && (
+              <div className="mt-0.5 truncate text-xs text-[var(--color-text-dim)]">
+                {project.description}
+              </div>
+            )}
+            {project.connection_name && (
+              <div className="mt-0.5 text-xs text-[var(--color-text-dim)]">
+                <Database className="mr-1 inline h-2.5 w-2.5" />
+                {project.connection_name}
+              </div>
+            )}
+            {details.length > 0 && (
+              <div className="mt-1.5 flex items-center gap-3 text-[10px] text-[var(--color-text-dim)]">
+                {details.map((detail) => (
+                  <span key={detail}>{detail}</span>
+                ))}
+              </div>
+            )}
+            {tags.length > 0 && (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-[var(--color-text-dim)]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="absolute right-2 top-2 rounded-md p-1.5 text-[var(--color-text-dim)] opacity-0 transition-opacity hover:bg-[var(--color-error)]/10 hover:text-[var(--color-error)] group-hover:opacity-100"
+          onClick={(event) => {
+            event.stopPropagation();
+            setShowDelete(true);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              event.stopPropagation();
+              setShowDelete(true);
+            }
+          }}
+          aria-label={`Delete ${projectName}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {showDelete && (
+        <DeleteProjectModal
+          project={project}
+          onClose={() => setShowDelete(false)}
+          onDeleted={async () => {
+            setShowDelete(false);
+            await onDeleted();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function DeleteProjectModal({
+  project,
+  onClose,
+  onDeleted,
+}: {
+  project: WorkspaceProjectInfo;
+  onClose: () => void;
+  onDeleted: () => void | Promise<void>;
+}) {
+  const { toast } = useToast();
+  const [confirmText, setConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const projectName = project.display_name || project.name;
+  const confirmPhrase = `delete ${projectName}`;
+  const isConfirmed =
+    confirmText.trim().toLowerCase() === confirmPhrase.toLowerCase();
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const deleteProject = async () => {
+    if (!isConfirmed) {
+      return;
+    }
+    setDeleting(true);
+    setError("");
+    try {
+      await deleteWorkspaceProject(project.id);
+      toast(`${projectName} has been deleted`, "success");
+      await onDeleted();
+    } catch (nextError) {
+      setError(getErrorMessage(nextError));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="mx-4 w-full max-w-md overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 border-b border-[var(--color-error)]/20 bg-[var(--color-error)]/5 px-5 py-4">
+          <div className="rounded-full bg-[var(--color-error)]/10 p-2">
+            <AlertTriangle className="h-5 w-5 text-[var(--color-error)]" />
+          </div>
+          <div className="flex-1">
+            <h3 className="text-sm font-semibold text-[var(--color-text)]">
+              Delete Project
+            </h3>
+            <p className="text-xs text-[var(--color-text-dim)]">
+              This action cannot be undone
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className={ICON_BUTTON}
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-5 py-4">
+          <div className="text-sm text-[var(--color-text-dim)]">
+            This will permanently delete{" "}
+            <span className="font-semibold text-[var(--color-text)]">
+              {projectName}
+            </span>
+            , including all branches, files, and commit history.
+          </div>
+
+          <label className="block space-y-2">
+            <span className="block text-xs font-medium text-[var(--color-text-dim)]">
+              To confirm, type{" "}
+              <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[var(--color-text)]">
+                {confirmPhrase}
+              </span>
+            </span>
+            <input
+              ref={inputRef}
+              type="text"
+              value={confirmText}
+              onChange={(event) => setConfirmText(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && isConfirmed) {
+                  void deleteProject();
+                }
+              }}
+              placeholder={confirmPhrase}
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 font-mono text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-text-dim)]"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+
+          {error && (
+            <div className="rounded-md border border-[var(--color-error)]/20 bg-[var(--color-error)]/5 px-3 py-2 text-xs text-[var(--color-error)]">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-[var(--color-border)] bg-muted/30 px-5 py-3">
+          <button type="button" className={OUTLINE_BUTTON} onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center gap-2 border border-[var(--color-error)] px-4 py-2 text-xs uppercase tracking-wider text-[var(--color-error)] transition-all hover:bg-[var(--color-error)]/10 disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={() => void deleteProject()}
+            disabled={!isConfirmed || deleting}
+          >
+            {deleting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" />
+            )}
+            Delete project
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NotionConversationList({
+  conversations,
+  loading,
+  error,
+  onOpen,
+}: {
+  conversations: NotionConversation[];
+  loading: boolean;
+  error: string | null;
+  onOpen: (href: string) => void;
+}) {
+  if (loading && conversations.length === 0) {
+    return (
+      <div className="flex items-center justify-center gap-3 border border-[var(--color-border)] px-5 py-10 text-xs uppercase tracking-wider text-[var(--color-text-dim)]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        loading notion requests...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="border border-[var(--color-error)]/40 px-5 py-4 text-xs text-[var(--color-error)]">
+        Could not load Notion requests: {error}
+      </div>
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-[var(--color-text-dim)]">
+        <NotionIcon className="mx-auto mb-2 h-6 w-6 opacity-40" />
+        <p>No Notion requests found.</p>
+        <p className="mt-1 text-xs">@ SignalPilot in your Notion workspace.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-[var(--color-border)] border border-[var(--color-border)]">
+      {conversations.map((conversation) => {
+        const file = conversation.notebook_path || "";
+        const params = new URLSearchParams();
+        if (file) {
+          params.set("file", file);
+        }
+        params.set("session_id", conversation.id);
+        const href = `/projects?${params.toString()}`;
+        const status = conversation.status || "saved";
+        return (
+          <a
+            key={conversation.id}
+            href={href}
+            onClick={(event) => {
+              event.preventDefault();
+              onOpen(href);
+            }}
+            className="flex items-center gap-4 px-5 py-4 transition-colors hover:bg-[var(--color-bg-hover)]"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm text-[var(--color-text)]">
+                {conversation.title || "Notion request"}
+              </div>
+              <div className="mt-1 truncate font-mono text-[11px] text-[var(--color-text-dim)]">
+                {file || conversation.id}
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+              <span className="border border-[var(--color-border)] px-2 py-1 text-[10px] uppercase tracking-wider text-[var(--color-text-dim)]">
+                {status}
+              </span>
+              <span className="text-[11px] text-[var(--color-text-dim)]">
+                {formatConversationTime(conversation.updated_at)}
+              </span>
+              <ExternalLink className="h-4 w-4 text-[var(--color-text-dim)]" />
+            </div>
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/signalpilot/web/notebook/components/chat/agent-chat-panel.tsx
+++ b/signalpilot/web/notebook/components/chat/agent-chat-panel.tsx
@@ -49,7 +49,7 @@ import {
 /* ── API Key Setup ── */
 const ApiKeySetup: React.FC = () => {
   return (
-    <div className="flex flex-col items-center justify-center h-full p-6 text-center gap-4">
+    <div className="flex flex-col items-center justify-center h-full bg-background p-6 text-center gap-4">
       <KeyRoundIcon className="h-10 w-10 text-muted-foreground opacity-30" />
       <div>
         <h3 className="text-sm font-semibold text-foreground mb-1">Set up AI Agent</h3>
@@ -136,7 +136,7 @@ const AgentChatPanel: React.FC = () => {
 
   if (aiConfigured === null) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+      <div className="flex items-center justify-center h-full bg-background text-muted-foreground text-sm">
         <Loader2 className="h-4 w-4 animate-spin mr-2" />
         Checking AI configuration...
       </div>
@@ -341,7 +341,7 @@ const AgentChatPanelInner: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col h-[calc(100%-53px)]">
+    <div className="flex flex-col h-[calc(100%-53px)] bg-background text-foreground">
       {/* Header */}
       <div className="flex border-b px-3 py-2 justify-between shrink-0 items-center">
         <div className="flex items-center gap-2">

--- a/signalpilot/web/notebook/components/editor/Output.tsx
+++ b/signalpilot/web/notebook/components/editor/Output.tsx
@@ -18,30 +18,30 @@ import {
   ChevronsUpDownIcon,
   ExpandIcon,
 } from "lucide-react";
-import { tooltipHandler } from "@/components/charts/tooltip";
 import { useExpandedOutput } from "@/core/cells/outputs";
 import { viewStateAtom } from "@/core/mode";
 import { useIframeCapabilities } from "@/hooks/useIframeCapabilities";
 import { useOverflowDetection } from "@/hooks/useOverflowDetection";
 import { renderHTML } from "@/plugins/core/RenderHTML";
 import { Banner } from "@/plugins/impl/common/error-banner";
-import type { TopLevelFacetedUnitSpec } from "@/plugins/impl/data-explorer/queries/types";
-import { getContainerWidth } from "@/plugins/impl/vega/utils";
-import { useTheme } from "@/theme/useTheme";
 import { Events } from "@/utils/events";
 import { invariant } from "@/utils/invariant";
 import { processMimeBundle } from "@/utils/mime-types";
 import { Objects } from "@/utils/objects";
-import { LazyVegaEmbed } from "../charts/lazy";
-import { ChartLoadingState } from "../data-table/charts/components/chart-states";
 import { Button } from "../ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Tooltip } from "../ui/tooltip";
-import { CsvViewer } from "./file-tree/renderers";
 import { SpTracebackOutput } from "./output/SpTracebackOutput";
 import { renderMimeIcon } from "./renderMimeIcon";
 
 const METADATA_KEY = "__metadata__";
+
+const LazyCsvViewer = React.lazy(() =>
+  import("./file-tree/renderers").then((module) => ({
+    default: module.CsvViewer,
+  })),
+);
+const LazyVegaOutput = React.lazy(() => import("./output/VegaOutput"));
 
 export type MimeType = OutputMessage["mimetype"];
 
@@ -69,7 +69,6 @@ export const OutputRenderer: React.FC<{
     metadata,
     renderFallback,
   } = props;
-  const { theme } = useTheme();
 
   // Memoize parsing the json data
   const parsedJsonData = useMemo(() => {
@@ -179,7 +178,11 @@ export const OutputRenderer: React.FC<{
         typeof data === "string",
         `Expected string data for mime=${mimetype}. Got ${typeof data}`,
       );
-      return <CsvViewer contents={data} />;
+      return (
+        <Suspense fallback={<TextOutput channel={channel} text="Loading CSV..." />}>
+          <LazyCsvViewer contents={data} />
+        </Suspense>
+      );
     case "text/latex":
     case "text/markdown":
       invariant(
@@ -194,17 +197,8 @@ export const OutputRenderer: React.FC<{
     case "application/vnd.vegalite.v6+json":
     case "application/vnd.vega.v6+json":
       return (
-        <Suspense fallback={<ChartLoadingState />}>
-          <LazyVegaEmbed
-            spec={parsedJsonData as TopLevelFacetedUnitSpec}
-            data-container-width={getContainerWidth(parsedJsonData)}
-            options={{
-              theme: theme === "dark" ? "dark" : undefined,
-              mode: "vega-lite",
-              tooltip: tooltipHandler.call,
-              renderer: "canvas",
-            }}
-          />
+        <Suspense fallback={<TextOutput channel={channel} text="Loading chart..." />}>
+          <LazyVegaOutput spec={parsedJsonData} />
         </Suspense>
       );
     case "application/vnd.sp+mimebundle":

--- a/signalpilot/web/notebook/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/signalpilot/web/notebook/components/editor/chrome/wrapper/app-chrome.tsx
@@ -400,8 +400,8 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsedSize={0}
       collapsible={true}
       className={cn(
-        "dark:bg-(--slate-1) print:hidden hide-on-fullscreen",
-        isSidebarOpen && "border-r border-l border-(--slate-7)",
+        "bg-background print:hidden hide-on-fullscreen",
+        isSidebarOpen && "border-r border-l border-border",
       )}
       minSize={10}
       // We can't make the default size greater than 0, otherwise it will start open
@@ -445,8 +445,8 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsedSize={0}
       collapsible={true}
       className={cn(
-        "dark:bg-(--slate-1) print:hidden hide-on-fullscreen",
-        isDeveloperPanelOpen && "border-t",
+        "bg-background print:hidden hide-on-fullscreen",
+        isDeveloperPanelOpen && "border-t border-border",
       )}
       minSize={10}
       // We can't make the default size greater than 0, otherwise it will start open

--- a/signalpilot/web/notebook/components/editor/output/VegaOutput.tsx
+++ b/signalpilot/web/notebook/components/editor/output/VegaOutput.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from "react";
+import type { VisualizationSpec } from "vega-embed";
+import { LazyVegaEmbed } from "@/components/charts/lazy";
+import { tooltipHandler } from "@/components/charts/tooltip";
+import { useTheme } from "@/theme/useTheme";
+import { ChartLoadingState } from "../../data-table/charts/components/chart-states";
+
+type ContainerWidth = number | "container";
+
+interface VegaOutputProps {
+  spec: unknown;
+}
+
+export default function VegaOutput({ spec }: VegaOutputProps) {
+  const { theme } = useTheme();
+
+  return (
+    <Suspense fallback={<ChartLoadingState />}>
+      <LazyVegaEmbed
+        spec={spec as VisualizationSpec | string}
+        data-container-width={getContainerWidth(spec)}
+        options={{
+          theme: theme === "dark" ? "dark" : undefined,
+          mode: "vega-lite",
+          tooltip: tooltipHandler.call,
+          renderer: "canvas",
+        }}
+      />
+    </Suspense>
+  );
+}
+
+function getContainerWidth(spec: unknown): ContainerWidth | undefined {
+  if (typeof spec !== "object" || spec === null) {
+    return undefined;
+  }
+  if ("width" in spec) {
+    return spec.width as ContainerWidth | undefined;
+  }
+  if ("spec" in spec) {
+    return getContainerWidth(spec.spec);
+  }
+  return undefined;
+}

--- a/signalpilot/web/notebook/core/bootstrap/mount-store.ts
+++ b/signalpilot/web/notebook/core/bootstrap/mount-store.ts
@@ -1,0 +1,238 @@
+import type * as api from "@/packages/sp-api";
+import { z } from "zod";
+import {
+  appConfigAtom,
+  configOverridesAtom,
+  userConfigAtom,
+} from "@/core/config/config";
+import {
+  parseAppConfig,
+  parseConfigOverrides,
+  parseUserConfig,
+} from "@/core/config/config-schema";
+import { KnownQueryParams } from "@/core/constants";
+import { getSpCode } from "@/core/meta/globals";
+import {
+  gatewayApiKeyAtom,
+  gatewayUrlAtom,
+  rawFallbackAtom,
+  serverTokenAtom,
+  showCodeInRunModeAtom,
+  spVersionAtom,
+} from "@/core/meta/state";
+import { type AppMode, initModeRouter, viewStateAtom } from "@/core/mode";
+import { connectionAtom } from "@/core/network/connection";
+import { requestClientAtom } from "@/core/network/requests";
+import { resolveRequestClient } from "@/core/network/resolve";
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  runtimeConfigAtom,
+} from "@/core/runtime/config";
+import {
+  codeAtom,
+  cwdAtom,
+  filenameAtom,
+  lspWorkspaceAtom,
+} from "@/core/saving/file-state";
+import { store, type JotaiStore } from "@/core/state/jotai";
+import { isStaticNotebook } from "@/core/static/static-state";
+import { WebSocketState } from "@/core/websocket/types";
+import { Logger } from "@/utils/Logger";
+
+const passthroughObject = z
+  .looseObject({})
+  .nullish()
+  .default({})
+  .transform((val) => {
+    if (val) {
+      return val;
+    }
+    if (typeof val === "string") {
+      Logger.warn(
+        "[sp] received JSON string instead of object. Parsing...",
+      );
+      return JSON.parse(val);
+    }
+    Logger.warn("[sp] missing config data");
+    return {};
+  });
+
+// This should be extremely backwards compatible and require no options.
+export const mountOptionsSchema = z.object({
+  filename: z
+    .string()
+    .nullish()
+    .transform((val) => val ?? null),
+  cwd: z.string().nullish().default(null),
+  lspWorkspace: z
+    .object({
+      rootUri: z.string(),
+      documentUri: z.string(),
+    })
+    .nullish()
+    .default(null),
+  code: z
+    .string()
+    .nullish()
+    .transform((val) => val ?? getSpCode() ?? ""),
+  rawFallback: z.boolean().nullish().default(false),
+  gatewayUrl: z.string().nullish().default(""),
+  gatewayApiKey: z.string().nullish().default(""),
+  version: z
+    .string()
+    .nullish()
+    .transform((val) => val ?? "unknown"),
+  mode: z
+    .enum(["edit", "read", "home", "run", "gallery"])
+    .transform((val): AppMode => {
+      if (val === "run") {
+        return "read";
+      }
+      return val;
+    }),
+  config: passthroughObject,
+  configOverrides: passthroughObject,
+  appConfig: passthroughObject,
+  view: z
+    .object({
+      showAppCode: z.boolean().default(true),
+    })
+    .nullish()
+    .transform((val) => val ?? { showAppCode: true }),
+  serverToken: z
+    .string()
+    .nullish()
+    .transform((val) => val ?? ""),
+  session: z.union([
+    z.null().optional(),
+    z
+      .looseObject({
+        version: z.literal("1"),
+        metadata: z.any(),
+        cells: z.array(z.any()),
+      })
+      .transform((val) => val as api.Session["NotebookSessionV1"]),
+  ]),
+  notebook: z.union([
+    z.null().optional(),
+    z
+      .looseObject({
+        version: z.literal("1"),
+        metadata: z.any(),
+        cells: z.array(z.any()),
+      })
+      .transform((val) => val as api.Notebook["NotebookV1"]),
+  ]),
+  runtimeConfig: z
+    .array(
+      z.looseObject({
+        url: z.string(),
+        lazy: z.boolean().default(true),
+        authToken: z
+          .custom<string | (() => string | Promise<string>)>(
+            (v) => v == null || typeof v === "string" || typeof v === "function",
+          )
+          .nullish(),
+      }),
+    )
+    .nullish()
+    .transform((val) => val ?? []),
+});
+
+export type ParsedMountOptions = z.infer<typeof mountOptionsSchema>;
+
+export type InitStoreResult = {
+  mode: AppMode;
+  parsed: ParsedMountOptions;
+};
+
+interface InitStoreOptions {
+  preloadPage?: (mode: AppMode) => void;
+}
+
+/**
+ * Applies the branch-variant subset of mount-config atoms.
+ */
+export function applyMountConfigDeltas(
+  parsed: ParsedMountOptions,
+  targetStore?: JotaiStore,
+): void {
+  const s = targetStore ?? store;
+
+  s.set(filenameAtom, parsed.filename);
+  s.set(cwdAtom, parsed.cwd ?? null);
+  s.set(lspWorkspaceAtom, parsed.lspWorkspace);
+  s.set(codeAtom, parsed.code);
+  s.set(serverTokenAtom, parsed.serverToken);
+
+  if (parsed.runtimeConfig.length > 0) {
+    const firstRuntimeConfig = parsed.runtimeConfig[0];
+    Logger.debug("Runtime URL", firstRuntimeConfig.url);
+    s.set(runtimeConfigAtom, {
+      ...firstRuntimeConfig,
+      serverToken: parsed.serverToken,
+    });
+  } else {
+    s.set(runtimeConfigAtom, {
+      ...DEFAULT_RUNTIME_CONFIG,
+      serverToken: parsed.serverToken,
+    });
+  }
+}
+
+/**
+ * Parse mount options and set all non-notebook atoms.
+ */
+export function initStore(
+  options: unknown,
+  targetStore?: JotaiStore,
+  initOptions: InitStoreOptions = {},
+): InitStoreResult {
+  const parsedOptions = mountOptionsSchema.safeParse(options);
+  if (!parsedOptions.success) {
+    Logger.error("Invalid SignalPilot mount options", parsedOptions.error);
+    throw new Error("Invalid SignalPilot mount options");
+  }
+
+  const mode = parsedOptions.data.mode;
+  initOptions.preloadPage?.(mode);
+
+  const s = targetStore ?? store;
+
+  s.set(requestClientAtom, resolveRequestClient());
+  initModeRouter();
+
+  s.set(spVersionAtom, parsedOptions.data.version);
+  s.set(showCodeInRunModeAtom, parsedOptions.data.view.showAppCode);
+  s.set(rawFallbackAtom, parsedOptions.data.rawFallback ?? false);
+  s.set(gatewayUrlAtom, parsedOptions.data.gatewayUrl ?? "");
+  s.set(gatewayApiKeyAtom, parsedOptions.data.gatewayApiKey ?? "");
+
+  const shouldStartInPresentMode = (() => {
+    const url = new URL(window.location.href);
+    return url.searchParams.get(KnownQueryParams.viewAs) === "present";
+  })();
+
+  const initialViewMode =
+    mode === "edit" && shouldStartInPresentMode ? "present" : mode;
+  s.set(viewStateAtom, { mode: initialViewMode, cellAnchor: null });
+
+  s.set(
+    configOverridesAtom,
+    parseConfigOverrides(parsedOptions.data.configOverrides),
+  );
+  s.set(userConfigAtom, parseUserConfig(parsedOptions.data.config));
+  s.set(appConfigAtom, parseAppConfig(parsedOptions.data.appConfig));
+
+  applyMountConfigDeltas(parsedOptions.data, targetStore);
+
+  if (
+    parsedOptions.data.runtimeConfig.length > 0 &&
+    !parsedOptions.data.runtimeConfig[0].lazy &&
+    !isStaticNotebook()
+  ) {
+    s.set(connectionAtom, { state: WebSocketState.CONNECTING });
+  }
+
+  return { mode, parsed: parsedOptions.data };
+}

--- a/signalpilot/web/notebook/core/bootstrap/reboot-mount.ts
+++ b/signalpilot/web/notebook/core/bootstrap/reboot-mount.ts
@@ -1,4 +1,7 @@
-import { mountOptionsSchema, applyMountConfigDeltas } from "@/mount";
+import {
+  applyMountConfigDeltas,
+  mountOptionsSchema,
+} from "@/core/bootstrap/mount-store";
 import { fetchMountConfig, MountConfigError } from "./fetch-mount-config";
 import { SPA_NAVIGATE_EVENT } from "@/core/router/spa-navigate";
 import { Logger } from "@/utils/Logger";

--- a/signalpilot/web/notebook/embed/SignalpilotEditor.tsx
+++ b/signalpilot/web/notebook/embed/SignalpilotEditor.tsx
@@ -1,7 +1,11 @@
-import { SpApp } from "@/core/SpApp";
+import { lazy, Suspense } from "react";
 import { adaptMountConfig } from "./adaptMountConfig";
 import { SpEmbedProviders } from "./SpEmbedProviders";
 import type { SignalpilotEditorProps } from "./types";
+
+const LazySpApp = lazy(() =>
+  import("@/core/SpApp").then((module) => ({ default: module.SpApp })),
+);
 
 /**
  * Embeddable editor component.
@@ -28,10 +32,12 @@ export function SignalpilotEditor({
 
   return (
     <div
-      className={`sp-root${className ? ` ${className}` : ""}`}
+      className={`sp-root relative h-full min-h-0 overflow-hidden${className ? ` ${className}` : ""}`}
     >
       <SpEmbedProviders client={client} options={options}>
-        <SpApp />
+        <Suspense fallback={null}>
+          <LazySpApp />
+        </Suspense>
       </SpEmbedProviders>
     </div>
   );

--- a/signalpilot/web/notebook/embed/SignalpilotHome.tsx
+++ b/signalpilot/web/notebook/embed/SignalpilotHome.tsx
@@ -1,7 +1,11 @@
-import { SpApp } from "@/core/SpApp";
+import { lazy, Suspense } from "react";
 import { adaptMountConfig } from "./adaptMountConfig";
 import { SpEmbedProviders } from "./SpEmbedProviders";
 import type { SignalpilotHomeProps } from "./types";
+
+const LazySpApp = lazy(() =>
+  import("@/core/SpApp").then((module) => ({ default: module.SpApp })),
+);
 
 /**
  * Embeddable home-page component.
@@ -31,7 +35,9 @@ export function SignalpilotHome({
       className={`sp-root${className ? ` ${className}` : ""}`}
     >
       <SpEmbedProviders client={client} options={options}>
-        <SpApp />
+        <Suspense fallback={null}>
+          <LazySpApp />
+        </Suspense>
       </SpEmbedProviders>
     </div>
   );

--- a/signalpilot/web/notebook/embed/SpEmbedProviders.tsx
+++ b/signalpilot/web/notebook/embed/SpEmbedProviders.tsx
@@ -1,5 +1,5 @@
 import { Provider } from "jotai";
-import { useEffect, useRef, type PropsWithChildren } from "react";
+import { useEffect, useRef, useState, type PropsWithChildren } from "react";
 import {
   bindStore,
   unbindStore,
@@ -11,12 +11,15 @@ import {
   ensureModuleRegistries,
   bindClient,
   unbindClient,
+  type ClientRegistries,
 } from "./client-binding";
-import { createClientRegistries } from "./registries-factory";
+import { ensureSignalpilotClientRegistries } from "./createSignalpilotClient";
 import { EmbedPortalProvider } from "./portal-container";
 import { SpEmbedConfigContext } from "./SpEmbedConfigContext";
 import { initStoreOnce } from "./initStoreOnce";
 import type { SignalpilotClient } from "./types";
+
+type RegistryFactory = () => ClientRegistries;
 
 export interface SpEmbedProvidersProps extends PropsWithChildren {
   client: SignalpilotClient;
@@ -29,20 +32,37 @@ export function SpEmbedProviders({
   children,
 }: SpEmbedProvidersProps): React.ReactElement {
   const initDone = useRef(false);
+  const pluginsRegistered = useRef(false);
+  const [registries, setRegistries] = useState<ClientRegistries | null>(null);
 
-  ensureModuleRegistries(createClientRegistries);
+  useEffect(() => {
+    let cancelled = false;
+    initDone.current = false;
+    pluginsRegistered.current = false;
+    setRegistries(null);
+    import("./registries-factory").then((module) => {
+      if (!cancelled) {
+        const factory: RegistryFactory = module.createClientRegistries;
+        ensureModuleRegistries(factory);
+        setRegistries(ensureSignalpilotClientRegistries(client, factory));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
 
   // Synchronously bind the client store during render so that non-hook code
   // (getRuntimeManager, API headers) can read from it immediately.
   // Re-bind on every render to handle React Strict Mode's unmount/remount
   // (cleanup effect pops the stack; next render must re-push).
-  if (getCurrentStore() !== client.store) {
+  if (registries && getCurrentStore() !== client.store) {
     bindStore(client.store);
-    bindRegistries(client.registries);
+    bindRegistries(registries);
     bindClient(client);
   }
 
-  if (!initDone.current) {
+  if (registries && !initDone.current) {
     initDone.current = true;
     initStoreOnce(client.store, options);
   }
@@ -50,22 +70,49 @@ export function SpEmbedProviders({
   // Cleanup: pop the bind stack when unmounting. On Strict Mode remount,
   // the render-phase check above re-pushes before children see stale state.
   useEffect(() => {
+    if (!registries) {
+      return;
+    }
     // Re-bind in effect too, in case the render-phase bind was for a
     // previous render that got discarded (concurrent mode).
     if (getCurrentStore() !== client.store) {
       bindStore(client.store);
-      bindRegistries(client.registries);
+      bindRegistries(registries);
       bindClient(client);
     }
 
     return () => {
       if (getCurrentStore() === client.store) {
         unbindClient(client);
-        unbindRegistries(client.registries);
+        unbindRegistries(registries);
         unbindStore(client.store);
       }
     };
-  }, [client, client.store, client.registries]);
+  }, [client, client.store, registries]);
+
+  useEffect(() => {
+    if (!registries || pluginsRegistered.current) {
+      return;
+    }
+    pluginsRegistered.current = true;
+    void import("@/plugins/plugins-react").then((module) =>
+      module.initializeReactPlugins(),
+    );
+  }, [registries]);
+
+  if (!registries) {
+    return (
+      <Provider store={client.store}>
+        <EmbedPortalProvider>
+          <SpEmbedConfigContext.Provider value={client}>
+            <div className="flex h-full flex-1 items-center justify-center text-xs text-muted-foreground">
+              loading runtime...
+            </div>
+          </SpEmbedConfigContext.Provider>
+        </EmbedPortalProvider>
+      </Provider>
+    );
+  }
 
   return (
     <Provider store={client.store}>

--- a/signalpilot/web/notebook/embed/createSignalpilotClient.ts
+++ b/signalpilot/web/notebook/embed/createSignalpilotClient.ts
@@ -1,7 +1,13 @@
 import { createStore } from "jotai";
 import { generateUUID } from "@/utils/uuid";
-import { createClientRegistries } from "./registries-factory";
+import type { ClientRegistries } from "./client-binding";
 import type { SignalpilotClient, SignalpilotClientOptions } from "./types";
+
+const CLIENT_REGISTRIES = Symbol("SignalpilotClient.registries");
+
+type MutableSignalpilotClient = SignalpilotClient & {
+  [CLIENT_REGISTRIES]?: ClientRegistries;
+};
 
 export function createSignalpilotClient(
   options?: SignalpilotClientOptions,
@@ -13,17 +19,31 @@ export function createSignalpilotClient(
     instanceId,
   });
 
-  const registries = createClientRegistries();
-
-  return {
+  const client: MutableSignalpilotClient = {
     instanceId,
     options: frozenOptions,
     store: createStore(),
-    registries,
+    get registries() {
+      const registries = this[CLIENT_REGISTRIES];
+      if (!registries) {
+        throw new Error("SignalPilot client registries are not initialized");
+      }
+      return registries;
+    },
     dispose(): void {
-      registries.runtimeState.stop();
+      this[CLIENT_REGISTRIES]?.runtimeState.stop();
       // UIElementRegistry / VirtualFileTracker / ModelManager have no native
       // teardown; their refs drop when the client object is GC'd.
     },
   };
+  return client;
+}
+
+export function ensureSignalpilotClientRegistries(
+  client: SignalpilotClient,
+  factory: () => ClientRegistries,
+): ClientRegistries {
+  const mutableClient = client as MutableSignalpilotClient;
+  mutableClient[CLIENT_REGISTRIES] ??= factory();
+  return mutableClient[CLIENT_REGISTRIES];
 }

--- a/signalpilot/web/notebook/embed/initStoreOnce.ts
+++ b/signalpilot/web/notebook/embed/initStoreOnce.ts
@@ -1,4 +1,4 @@
-import { initStore } from "@/mount";
+import { initStore } from "@/core/bootstrap/mount-store";
 import type { JotaiStore } from "@/core/state/jotai";
 
 const _initialized = new WeakSet<JotaiStore>();
@@ -23,11 +23,4 @@ export function initStoreOnce(store: JotaiStore, options: unknown): void {
   }
   _initialized.add(store);
   initStore(options, store);
-
-  // Register web component plugins (sp-table, sp-stat, sp-dropdown, etc.)
-  // so cell outputs with custom elements render correctly.
-  // The standalone mount path does this in mount.tsx; the embed path needs it here.
-  void import("@/plugins/plugins-react").then((m) =>
-    m.initializeReactPlugins(),
-  );
 }

--- a/signalpilot/web/notebook/mount.tsx
+++ b/signalpilot/web/notebook/mount.tsx
@@ -1,46 +1,16 @@
-import type * as api from "@/packages/sp-api";
 import { Provider } from "jotai";
 import { createRoot } from "react-dom/client";
-import { z } from "zod";
-import {
-  appConfigAtom,
-  configOverridesAtom,
-  userConfigAtom,
-} from "@/core/config/config";
-import { KnownQueryParams } from "@/core/constants";
-import { getSpCode } from "@/core/meta/globals";
-import {
-  spVersionAtom,
-  serverTokenAtom,
-  showCodeInRunModeAtom,
-  rawFallbackAtom,
-  gatewayUrlAtom,
-  gatewayApiKeyAtom,
-} from "@/core/meta/state";
 import { Logger } from "@/utils/Logger";
 import { ErrorBoundary } from "./components/editor/boundary/ErrorBoundary";
 import {
-  parseAppConfig,
-  parseConfigOverrides,
-  parseUserConfig,
-} from "./core/config/config-schema";
+  initStore,
+  type InitStoreResult,
+  type ParsedMountOptions,
+} from "./core/bootstrap/mount-store";
 import { SpApp, preloadPage } from "./core/SpApp";
-import { type AppMode, initModeRouter, viewStateAtom } from "./core/mode";
+import type { AppMode } from "./core/mode";
 import { cleanupAuthQueryParams } from "./core/network/auth";
-import { connectionAtom } from "./core/network/connection";
-import { requestClientAtom } from "./core/network/requests";
-import { resolveRequestClient } from "./core/network/resolve";
-import {
-  DEFAULT_RUNTIME_CONFIG,
-  runtimeConfigAtom,
-} from "./core/runtime/config";
-import {
-  codeAtom,
-  cwdAtom,
-  filenameAtom,
-  lspWorkspaceAtom,
-} from "./core/saving/file-state";
-import { store, type JotaiStore } from "./core/state/jotai";
+import { store } from "./core/state/jotai";
 import { _moduleSingleton, bindStore } from "./core/state/store-binding";
 import { initModuleRegistries } from "./embed/client-binding";
 import { createClientRegistries } from "./embed/registries-factory";
@@ -52,7 +22,6 @@ import {
 } from "./core/static/static-state";
 import { maybeRegisterVSCodeBindings } from "./core/vscode/vscode-bindings";
 
-import { WebSocketState } from "./core/websocket/types";
 import {
   handleWidgetMessage,
   MODEL_MANAGER,
@@ -61,15 +30,6 @@ import { vegaLoader } from "./plugins/impl/vega/loader";
 import { initializeCustomElements } from "./plugins/plugins";
 
 let hasMounted = false;
-
-/**
- * The parsed mount options plus the resolved mode.
- * Returned by initStore() so initEditState() doesn't re-parse.
- */
-type InitStoreResult = {
-  mode: AppMode;
-  parsed: z.infer<typeof mountOptionsSchema>;
-};
 
 /**
  * Main entry point for the sp app.
@@ -119,7 +79,7 @@ export async function mount(
     // call needed for the standalone path.
     bindStore(_moduleSingleton);
     // Init store — sync parse, all atom sets, networking
-    initResult = initStore(options);
+    initResult = initStore(options, undefined, { preloadPage });
   } catch (error) {
     // Most likely, configuration failed to parse.
     const root = createRoot(el);
@@ -164,7 +124,7 @@ export async function mount(
  * Rejections propagate to mount() → main.tsx catch → renderBootError (fail-fast).
  */
 async function initEditState(
-  parsed: z.infer<typeof mountOptionsSchema>,
+  parsed: ParsedMountOptions,
   mode: AppMode,
 ): Promise<void> {
   const [cellsModule, sessionModule] = await Promise.all([
@@ -181,307 +141,6 @@ async function initEditState(
     store.set(notebookAtom, notebook);
   }
 
-}
-
-const passthroughObject = z
-  .looseObject({})
-  .nullish()
-  .default({}) // Default to empty object
-  .transform((val) => {
-    if (val) {
-      return val;
-    }
-    if (typeof val === "string") {
-      Logger.warn(
-        "[sp] received JSON string instead of object. Parsing...",
-      );
-      return JSON.parse(val);
-    }
-    Logger.warn("[sp] missing config data");
-    return {};
-  });
-
-// This should be extremely backwards compatible and require no options
-export const mountOptionsSchema = z.object({
-  /**
-   * filename of the notebook to open
-   */
-  filename: z
-    .string()
-    .nullish()
-    .transform((val) => val ?? null),
-  /**
-   * absolute working directory of the notebook
-   */
-  cwd: z.string().nullish().default(null),
-  /**
-   * LSP workspace information
-   */
-  lspWorkspace: z
-    .object({
-      rootUri: z.string(),
-      documentUri: z.string(),
-    })
-    .nullish()
-    .default(null),
-  /**
-   * notebook code
-   */
-  code: z
-    .string()
-    .nullish()
-    .transform((val) => val ?? getSpCode() ?? ""),
-  /**
-   * True when the backend opened a non-notebook file in raw-editor fallback mode.
-   */
-  rawFallback: z.boolean().nullish().default(false),
-  /**
-   * Base URL for the SignalPilot data gateway API.
-   */
-  gatewayUrl: z.string().nullish().default(""),
-  /**
-   * API key for the SignalPilot gateway.
-   */
-  gatewayApiKey: z.string().nullish().default(""),
-  /**
-   * sp version
-   */
-  version: z
-    .string()
-    .nullish()
-    .transform((val) => val ?? "unknown"),
-  /**
-   * 'edit' or 'read'/'run' or 'home' or 'gallery'
-   */
-  mode: z
-    .enum(["edit", "read", "home", "run", "gallery"])
-    .transform((val): AppMode => {
-      if (val === "run") {
-        return "read";
-      }
-      return val;
-    }),
-  /**
-   * sp config
-   */
-  config: passthroughObject,
-  /**
-   * sp config overrides
-   */
-  configOverrides: passthroughObject,
-  /**
-   * sp app config
-   */
-  appConfig: passthroughObject,
-  /**
-   * show code in run mode
-   */
-  view: z
-    .object({
-      showAppCode: z.boolean().default(true),
-    })
-    .nullish()
-    .transform((val) => val ?? { showAppCode: true }),
-
-  /**
-   * server token
-   */
-  serverToken: z
-    .string()
-    .nullish()
-    .transform((val) => val ?? ""),
-
-  /**
-   * Serialized Session["NotebookSessionV1"] snapshot
-   */
-  session: z.union([
-    z.null().optional(),
-    z
-      .looseObject({
-        // Rough shape, we don't need to validate the full schema
-        version: z.literal("1"),
-        metadata: z.any(),
-        cells: z.array(z.any()),
-      })
-      .transform((val) => val as api.Session["NotebookSessionV1"]),
-  ]),
-
-  /**
-   * Serialized Notebook["NotebookV1"] snapshot
-   */
-  notebook: z.union([
-    z.null().optional(),
-    z
-      .looseObject({
-        // Rough shape, we don't need to validate the full schema
-        version: z.literal("1"),
-        metadata: z.any(),
-        cells: z.array(z.any()),
-      })
-      .transform((val) => val as api.Notebook["NotebookV1"]),
-  ]),
-
-  /**
-   * Runtime configs
-   */
-  runtimeConfig: z
-    .array(
-      z.looseObject({
-        url: z.string(),
-        // Lazy by default, but can be overridden by the runtime config
-        lazy: z.boolean().default(true),
-        // string | (() => string | Promise<string>) — the embed passes a thunk
-        // that resolves a fresh Clerk JWT per request. z.custom passes functions
-        // through unchanged (z.string() would strip them, dropping auth).
-        authToken: z
-          .custom<string | (() => string | Promise<string>)>(
-            (v) => v == null || typeof v === "string" || typeof v === "function",
-          )
-          .nullish(),
-      }),
-    )
-    .nullish()
-    .transform((val) => val ?? []),
-});
-
-/**
- * The parsed mount options type. Used by `applyMountConfigDeltas` and
- * `reboot-mount.ts` so they share the same schema-derived type.
- */
-export type ParsedMountOptions = z.infer<typeof mountOptionsSchema>;
-
-/**
- * Applies the branch-variant subset of mount-config atoms.
- *
- * Called by both `initStore()` (cold boot) and `rebootMountConfig()` (warm
- * reboot on branch switch). Keeping one source of truth avoids drift between
- * the two paths.
- *
- * Atoms written (branch-variant or session-variant):
- *   - filenameAtom       — branch may have a different active file
- *   - cwdAtom            — branch may change working directory
- *   - lspWorkspaceAtom   — branch-scoped LSP workspace
- *   - codeAtom           — file content differs per branch
- *   - serverTokenAtom    — backend may rotate the token
- *   - runtimeConfigAtom  — backend may regenerate session token / lazy flag
- *
- * Atoms deliberately SKIPPED (with one-line justification):
- *   - requestClientAtom      — networking layer, branch-invariant
- *   - spVersionAtom          — server version, doesn't change mid-session
- *   - showCodeInRunModeAtom  — view setting from initial URL only
- *   - rawFallbackAtom        — boot-time only
- *   - gatewayUrlAtom         — gateway is branch-invariant
- *   - gatewayApiKeyAtom      — gateway is branch-invariant
- *   - viewStateAtom          — preserve current view on branch switch
- *   - configOverridesAtom    — global config, not per-branch
- *   - userConfigAtom         — global config, not per-branch
- *   - appConfigAtom          — global config, not per-branch
- *   - connectionAtom         — managed by WS layer; reconnect effect handles state
- *   - initModeRouter()       — already wired on cold boot; re-init would double-register popstate
- *   - preloadPage(mode)      — boot-only
- */
-export function applyMountConfigDeltas(
-  parsed: ParsedMountOptions,
-  targetStore?: JotaiStore,
-): void {
-  // When an explicit targetStore is provided (embed path), write directly to it
-  // instead of going through the proxy. This avoids a class of bugs where the
-  // proxy's getCurrentStore() returns the wrong store due to bind-stack timing.
-  const s = targetStore ?? store;
-
-  // Files (branch-variant)
-  s.set(filenameAtom, parsed.filename);
-  s.set(cwdAtom, parsed.cwd ?? null);
-  s.set(lspWorkspaceAtom, parsed.lspWorkspace);
-  s.set(codeAtom, parsed.code);
-
-  // Server token (may rotate on reboot)
-  s.set(serverTokenAtom, parsed.serverToken);
-
-  // Runtime config (may regenerate session token / lazy flag)
-  if (parsed.runtimeConfig.length > 0) {
-    const firstRuntimeConfig = parsed.runtimeConfig[0];
-    Logger.debug("⚡ Runtime URL", firstRuntimeConfig.url);
-    s.set(runtimeConfigAtom, {
-      ...firstRuntimeConfig,
-      serverToken: parsed.serverToken,
-    });
-  } else {
-    s.set(runtimeConfigAtom, {
-      ...DEFAULT_RUNTIME_CONFIG,
-      serverToken: parsed.serverToken,
-    });
-  }
-}
-
-/**
- * Parse mount options and set all non-notebook atoms. Returns the parsed mode
- * and the full parsed data so callers don't re-parse.
- *
- * @param targetStore - When provided (embed path), all atom writes go directly
- *   to this store instead of through the proxy. This eliminates the class of
- *   bugs where getCurrentStore() might return the wrong store.
- */
-export function initStore(
-  options: unknown,
-  targetStore?: JotaiStore,
-): InitStoreResult {
-  const parsedOptions = mountOptionsSchema.safeParse(options);
-  if (!parsedOptions.success) {
-    Logger.error("Invalid SignalPilot mount options", parsedOptions.error);
-    throw new Error("Invalid SignalPilot mount options");
-  }
-  const mode = parsedOptions.data.mode;
-  preloadPage(mode);
-
-  // Use the explicit target store if provided; otherwise fall back to the proxy.
-  const s = targetStore ?? store;
-
-  // Configure networking layer (boot-only, branch-invariant)
-  s.set(requestClientAtom, resolveRequestClient());
-
-  // currentModeAtom is now URL-derived; initModeRouter() wires popstate/spa:navigate.
-  // Boot-only — do NOT re-call on warm reboot (would double-register popstate).
-  initModeRouter();
-
-  // Meta (boot-only, branch-invariant)
-  s.set(spVersionAtom, parsedOptions.data.version);
-  s.set(showCodeInRunModeAtom, parsedOptions.data.view.showAppCode);
-  s.set(rawFallbackAtom, parsedOptions.data.rawFallback ?? false);
-  s.set(gatewayUrlAtom, parsedOptions.data.gatewayUrl ?? "");
-  s.set(gatewayApiKeyAtom, parsedOptions.data.gatewayApiKey ?? "");
-
-  // Check for view-as parameter to start in present mode (boot-only)
-  const shouldStartInPresentMode = (() => {
-    const url = new URL(window.location.href);
-    return url.searchParams.get(KnownQueryParams.viewAs) === "present";
-  })();
-
-  const initialViewMode =
-    mode === "edit" && shouldStartInPresentMode ? "present" : mode;
-  s.set(viewStateAtom, { mode: initialViewMode, cellAnchor: null });
-
-  // Config (global, not per-branch)
-  s.set(
-    configOverridesAtom,
-    parseConfigOverrides(parsedOptions.data.configOverrides),
-  );
-  s.set(userConfigAtom, parseUserConfig(parsedOptions.data.config));
-  s.set(appConfigAtom, parseAppConfig(parsedOptions.data.appConfig));
-
-  // Runtime config atoms shared with the warm reboot path.
-  applyMountConfigDeltas(parsedOptions.data, targetStore);
-
-  // connectionAtom: only on cold boot, when the runtime is eager
-  if (
-    parsedOptions.data.runtimeConfig.length > 0 &&
-    !parsedOptions.data.runtimeConfig[0].lazy &&
-    !isStaticNotebook()
-  ) {
-    s.set(connectionAtom, { state: WebSocketState.CONNECTING });
-  }
-
-  return { mode, parsed: parsedOptions.data };
 }
 
 /**


### PR DESCRIPTION
## Summary
- split `/projects` so the overview surface loads separately from notebook runtime routes
- lazy-load notebook editor/runtime registries and move mount-store bootstrap logic out of `mount.tsx`
- split heavy output rendering paths like CSV/Vega into lazy-loaded components
- add Slack-first/org-key planning docs
- update dev compose startup and MCP allowed-host port handling

## Validation
- `git diff --cached --check`
- `python3 -m py_compile signalpilot/gateway/gateway/mcp/server.py`
- `cd signalpilot/web && pnpm build`

## Note
- Direct push to `main` was blocked by repository rules, so this is published through a PR.
