### PR TITLE
security: audit branch for secrets, vulnerabilities, and private docs

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,102 @@
+# Security Audit — Branch `autofyn/run-a-security-a-880618` vs `main`
+
+Date: 2026-07-29
+Scope: all files added or modified on the current branch relative to `main`
+(~272 files, ~19.8k insertions, ~14.6k deletions).
+
+The audit was split into three parallel passes. Each pass produced its own
+detailed report; this document is the index and executive summary.
+
+## Reports
+
+| File | Focus |
+|------|-------|
+| [`secrets-and-private-docs.md`](./secrets-and-private-docs.md) | Credential/API-key leaks in the diff, glance at `main`, and private/internal markdown that shouldn't ship in a public OSS repo. |
+| [`backend-audit.md`](./backend-audit.md) | Python / FastAPI gateway, sandbox, connectors, Docker/compose, scripts. Injection, authz, SSRF, uploads, sandbox escape, GitHub webhook. |
+| [`frontend-audit.md`](./frontend-audit.md) | Next.js / React notebook UI, embed code, plugin. XSS, postMessage, CSP, secrets in bundle, dependency changes. |
+
+## Combined severity tally
+
+| Severity | Secrets/Docs | Backend | Frontend | Total |
+|----------|-------------:|--------:|---------:|------:|
+| CRITICAL |            2 |       0 |        0 |     2 |
+| HIGH     |            8 |       2 |        0 |    10 |
+| MEDIUM   |            3 |       4 |        2 |     9 |
+| LOW      |            1 |       3 |        4 |     8 |
+| INFO     |            0 |       5 |        3 |     8 |
+
+## Top priorities before public release
+
+Read the linked reports for full context, excerpts, file/line references, and
+recommended fixes. Highlights, ranked:
+
+1. **CRITICAL — Private writeups.** `writeups/HUMAN-TASKS.md` and
+   `writeups/research-metric-sources-and-connectors.md` contain internal
+   roadmap, unshipped-feature specs, a private repo path
+   (`kiwi0401/sp-pipelineproof-test`), customer/warehouse names (AKASA, NALA,
+   `perf_nala_pg`), acknowledged security holes still open in the code,
+   partnership economics with Xata, licensing/legal strategy, and internal
+   stakeholder names. These must not ship to a public OSS repo.
+   See `secrets-and-private-docs.md` §Private Docs.
+
+2. **HIGH — 11 more `writeups/*.md`** with similar (but less severe) internal
+   content: sprint summary, feature-1..7 writeups, UX overhaul plan, KB test
+   suite plan, and `signalpilot/web/UX.md`. Recommend moving `writeups/` to a
+   private repo and adding it to `.gitignore`.
+
+3. **HIGH — Unauthenticated `POST /save-api-key`** in the notebook server
+   (`signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py`
+   :115-160) accepts a secret from the request body, mutates `os.environ`
+   process-wide, and has no auth. See `backend-audit.md`.
+
+4. **HIGH — Eval runner → host-root RCE.** `gateway/evals/runner.py:553`
+   selects a Docker image from an admin-supplied eval-set manifest while
+   `docker-compose.yml:105` mounts `/var/run/docker.sock` into the gateway
+   container. An admin who can point `repo_url` at a hostile repo can escape
+   to host root. See `backend-audit.md`.
+
+5. **MEDIUM cluster (backend).** GitHub-webhook local-mode signature-check
+   fallback (`api/github_bot.py:44-48`); `git clone` of admin-supplied
+   `repo_url` with shell-quoted `script_rel`/`state`
+   (`evals/runner.py:287, 553-560`); legacy upload spool sizing
+   (`api/uploads.py:318-338`); Notion `verification_token` short-circuit
+   bypassing auth. See `backend-audit.md`.
+
+6. **MEDIUM (frontend).** Next.js was downgraded (`^16.2.11` → `^16.2.9`),
+   along with `sharp` and `brace-expansion`. Confirm no security patches were
+   reverted. A new client-side Anthropic API-key input in
+   `agent-chat-panel.tsx` keeps the key in React state after save. See
+   `frontend-audit.md`.
+
+7. **LOW (frontend).** CSP still allows `unsafe-inline` / `unsafe-eval`;
+   `base-uri` should be `'self'`; `vscode-bindings.ts` uses `postMessage("*",
+   ...)` (unchanged, but flagged for hardening). See `frontend-audit.md`.
+
+## What is NOT a finding
+
+- **No live secrets in the diff.** Every hit resolved to a placeholder, an
+  AWS-documented example (`AKIAIOSFODNN7EXAMPLE`), a test fake
+  (`sk-ant-...XYZ9`, `xoxb-test`), or an env-var reference (`${XATA_KEY:-}`).
+- **No live secrets in `main`** either. One low-severity note: the same
+  AWS-documented example appears in `tests/test_iam_auth.py` — not a real key.
+- **No exploitable frontend XSS.** HTML rendering paths use DOMPurify with a
+  strict allowlist, `react-markdown` is used without `rehype-raw`, and the KB
+  document view emits React children with a `^https?://` URL allowlist.
+- **PostMessage refactor introduces no new sinks.** Existing
+  `postMessage("*", ...)` in `vscode-bindings.ts` is pre-existing and
+  unchanged.
+
+## Hardening recommendations (not code changes)
+
+Even though no live secrets leaked in the diff, the writeups themselves
+document the *purpose* of several tokens
+(`XATA_KEY`, `SP_GITHUB_BOT_TOKEN`, `SP_GITHUB_WEBHOOK_SECRET`,
+`CLAUDE_CODE_OAUTH_TOKEN`). If any of those tokens ever ended up in the
+reflog on a personal machine, rotation is cheap insurance. Also flagged:
+MinIO dev defaults in `docker-compose.yml` are fine for local dev but should
+carry a comment warning against production use.
+
+---
+
+*Per the user's request, no code was changed. Fix work will be done by the
+user directly.*

--- a/security/backend-audit.md
+++ b/security/backend-audit.md
@@ -1,0 +1,340 @@
+# Backend Security Audit
+
+Scope: `git diff main..HEAD` restricted to Python files and Docker/YAML on
+branch `autofyn/run-a-security-a-880618`. Credential-scanning is handled by a
+sibling reviewer and is excluded here.
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | 0     |
+| HIGH     | 2     |
+| MEDIUM   | 4     |
+| LOW      | 3     |
+| INFO     | 5     |
+
+Overall posture is defensible. The new attack surface is well-scoped:
+identifiers are validated before being interpolated into SQL, the /demo route
+never persists the shared org key, connection pinning stops it from being
+misused, and CSRF/CORS is on in cloud mode with an explicit allow-list. The
+findings below are concentrated around (a) admin-scope features that
+delegate execution to attacker-controlled inputs (eval runner + repo_url,
+setup manifest picking Docker image), (b) an unauthenticated notebook-server
+endpoint that mutates process-wide env and forwards a key to the gateway on
+behalf of the caller, and (c) local-mode fallbacks in webhook receivers that
+open a door if the gateway is ever exposed unprotected.
+
+---
+
+## Findings
+
+### [HIGH] Notebook-server `/save-api-key` has no auth check and mutates process env
+
+- File: `signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py:115-160`
+- Category: authz / secrets
+- Description: `save_api_key` accepts an arbitrary `api_key` from the request
+  body, forwards it to the gateway `PUT /api/user/secrets` using the
+  server-side `gateway_headers()` (i.e. the notebook server's own gateway
+  credentials — not the caller's), and unconditionally sets
+  `os.environ["ANTHROPIC_API_KEY"] = api_key`. There is no session check on
+  this router, and the fallback path (line ~155) does the `os.environ` write
+  even when the gateway call fails. Setting `os.environ` mutates
+  process-global state that every kernel / subsequent request in the same
+  notebook-server process inherits.
+- Impact: A caller who can reach the notebook server (e.g. via the notebook
+  proxy path) can (1) overwrite the current user's gateway-stored Anthropic
+  key (or write one for a user who had none), and (2) poison the
+  notebook-server process's `ANTHROPIC_API_KEY` env for every subsequent
+  request routed to that pod — a form of stored key confusion across kernel
+  sessions in the same worker.
+- Recommendation: Require an authenticated notebook session on this route
+  (use the same session-cookie / SP session dep the other agent endpoints
+  rely on). Do not mutate `os.environ` at request time; store the key on the
+  session/kernel scope instead. Reject the request entirely if the gateway
+  call fails rather than silently "local_only".
+- Confidence: high
+
+### [HIGH] Eval-set manifest chooses the Docker image executed on the gateway host
+
+- File: `signalpilot/gateway/gateway/evals/runner.py:553` (`_run_setup_container`),
+  compose reference: `docker-compose.yml:105` (`/var/run/docker.sock:/var/run/docker.sock`)
+- Category: sandbox escape / RCE-via-config
+- Description: The gateway mounts the host Docker socket. The eval runner
+  invokes containers based on the eval-set manifest fetched by
+  `fetch_eval_repo(repo_url, …)`. Line 553:
+  `image = eval_set.setup.get("image") or settings.runner_image` — the
+  image name is taken straight from the manifest. `_run_setup_container`
+  also feeds `cmd` (from `runner_cmd`) into `sh -lc`, and honors
+  `eval_set.setup.get("mounts")` for bind mounts under
+  `SP_EVAL_SETUP_HOST_ROOT`. `repo_url` is set through the admin
+  `PUT /api/evals/config` endpoint, and once set, the manifest inside that
+  repo is fully attacker-controlled.
+- Impact: An admin (or anyone who reaches the admin scope, e.g. via a stolen
+  admin key) can point `repo_url` at a repo whose `manifest` names an
+  arbitrary image and arbitrary bind mounts under `SP_EVAL_SETUP_HOST_ROOT`.
+  Combined with the mounted docker socket, this is effectively RCE-as-root
+  on the gateway host (container escape via docker.sock is trivial: run a
+  container with `--privileged` / mount `/`).
+- Recommendation: Do not let the manifest choose the image — restrict to a
+  server-side allow-list (or force `settings.runner_image` / a small set of
+  known images). Reject bind-mount entries that resolve outside a fixed
+  read-only path even before the `..` check. Reconsider mounting
+  `/var/run/docker.sock` into the same container that runs application HTTP
+  logic; a dedicated docker-runner sidecar with a narrower socket proxy
+  (e.g. `docker-socket-proxy`) is the standard pattern.
+- Confidence: high
+
+### [MEDIUM] Eval-config `repo_url` cloned via `git clone` with attacker-controlled URL
+
+- File: `signalpilot/gateway/gateway/evals/runner.py:287-306` (`fetch_eval_repo`),
+  and repeated at line 560 inside the setup container script.
+- Category: injection (git remote / SSRF-adjacent)
+- Description: `fetch_eval_repo` does
+  `git clone --depth 1 <repo_url> <dest>` when the URL starts with
+  `http://`, `https://`, or `git@`. There's a leading-`-` argument-splitting
+  guard (via the prefix check), but the URL itself is otherwise unfiltered.
+  While CVE-2017-1000117-class `ssh://…-oProxyCommand=…` is largely mitigated
+  in modern git, this still lets an admin-scoped caller pull arbitrary code
+  onto the gateway host (and later the setup container script does
+  `git clone --depth 1 "$SP_EVAL_REPO_URL" /repo && … {runner_cmd}` where
+  `runner_cmd` is built from manifest-controlled `script_rel` and `state`
+  values interpolated into a double-quoted shell string — shell-quote
+  breakout is possible with a `"` in `script_rel`).
+- Impact: With admin scope: repo-driven code arriving on the gateway host,
+  and shell-quote breakout inside the setup container (further amplified by
+  the previous finding).
+- Recommendation: Validate `repo_url` against an allow-list of hosts (or
+  only accept https URLs to a known-good host set). Do not interpolate
+  `script_rel`/`state` into a shell command; instead pass them as
+  positional args (`sh /repo/script.sh state`) via `Cmd: ["sh", "/repo/…", state]`.
+  Reject any `script_rel` containing shell metacharacters or `..`.
+- Confidence: medium
+
+### [MEDIUM] GitHub webhook accepts unsigned events in non-cloud mode
+
+- File: `signalpilot/gateway/gateway/api/github_bot.py:44-48`
+- Category: auth (webhook trust)
+- Description: If `SP_GITHUB_WEBHOOK_SECRET` is unset and the process is
+  *not* in cloud mode, `github_webhook` accepts any body without an HMAC
+  signature check (only `is_cloud_mode()` triggers the 503). In cloud mode
+  the behavior is correct. If a self-hosted / on-prem gateway is ever
+  exposed to the internet without setting the secret, any caller can
+  trigger arbitrary PR scans against configured connections.
+- Impact: Data exfil / DoS potential: the scan runs warehouse queries
+  (`COUNT(*)`, `information_schema` reads, per-column null aggregates) and
+  the bot's GitHub token posts a comment + status. In cloud-mode
+  deployments this is fine; the risk lives at the "self-hoster exposes
+  local mode" boundary.
+- Recommendation: Require the webhook secret unconditionally (or only
+  accept the webhook from `127.0.0.1` / an internal network when the secret
+  is unset). Log a startup warning when the receiver is enabled without a
+  secret.
+- Confidence: medium
+
+### [MEDIUM] Legacy `/api/evals/upload` skips the multipart flow's size preflight
+
+- File: `signalpilot/gateway/gateway/api/uploads.py:318-338`
+- Category: DoS / resource
+- Description: The legacy single-POST upload path (kept for small files /
+  older clients) writes the whole body to a spool before size is checked
+  (`file.file.seek(0, 2)`), then rejects at `cfg.max_bytes`. The body-size
+  middleware is configured for the `/api/evals/upload` prefix with
+  `_eval_uploads_settings().max_bytes + 1_048_576` — i.e. up to
+  ~500 MB (default max_mb=500 in compose) is buffered into the spool and
+  streamed onto disk before the endpoint gets to enforce the cap. This
+  applies to the multipart routes too, but they only carry small JSON.
+- Impact: A single POST can burn up to the large per-path limit worth of
+  disk/tmpfs even when the size will be rejected. With a naive attacker
+  script this is a cheap disk-exhaustion primitive.
+- Recommendation: Reject early in the endpoint using the `Content-Length`
+  header before letting FastAPI consume the body (or lower the legacy
+  endpoint's per-path body cap and route it through a small-file endpoint
+  distinct from the multipart prefix).
+- Confidence: medium
+
+### [MEDIUM] `/api/notion/webhooks/events` returns 200 to any body containing `verification_token`
+
+- File: `signalpilot/gateway/gateway/api/notion.py:612-614`
+- Category: hardening / logging DoS
+- Description: The verification-token branch is checked *before* signature
+  verification, and returns 200 unconditionally with a WARNING log line. An
+  unauthenticated caller can send `{"verification_token": "..."}` to
+  generate warnings and 200 replies indefinitely.
+- Impact: Log flooding and observability noise. Not exploitable for data.
+- Recommendation: Once the integration has completed subscription
+  verification, ignore or 401 further verification-token payloads that
+  don't match a stored value; or rate-limit this path.
+- Confidence: high
+
+### [LOW] `schema_watch` PR body includes truncated markdown built from server-fetched schemas
+
+- File: `signalpilot/gateway/gateway/schema_watch/runner.py:212-225`
+- Category: injection (into GitHub PR)
+- Description: The PR body embeds table/column names from the target
+  warehouse verbatim in markdown. If those names contain markdown/HTML
+  fragments, they end up in a GitHub PR body — cosmetic, but on issues
+  triggered by an org's own warehouse it can render as an image / link
+  chosen by the DB owner. Not exploitable across orgs; the watch is
+  org-scoped.
+- Recommendation: Escape backticks / pipes in table/column names when
+  rendering markdown (`f"`{name.replace('`','\'')}`"`).
+- Confidence: low
+
+### [LOW] `github_repo` pattern permits `..` in either segment
+
+- File: `signalpilot/gateway/gateway/api/github_bot.py:94` and
+  `signalpilot/gateway/gateway/api/schema_watches.py:24`
+- Category: input validation
+- Description: `pattern=r"^[\w.-]+/[\w.-]+$"` accepts values like
+  `foo/../bar` (the two segments are already split by `/`, so the
+  attacker can put `..` in either half). GitHub's API rejects those as
+  404, but the value is also interpolated into git branch names and file
+  paths in `schema_watch.runner.report_drift_pr`. `connection_name` in
+  those file paths is safe (constrained by the connection's own
+  `[a-zA-Z0-9_-]` pattern), but the repo half only affects the outgoing
+  GitHub URL. Practical exposure is low.
+- Recommendation: Tighten the pattern to disallow `..` per-segment and
+  `.` / `-` at segment boundaries.
+- Confidence: medium
+
+### [LOW] MCP failed-auth rate limiter keys by rightmost `X-Forwarded-For`
+
+- File: `signalpilot/gateway/gateway/auth/mcp_api_key.py:324-341, 268-269`
+- Category: rate limiting
+- Description: `_extract_client_ip` uses the rightmost XFF value, which is
+  the correct anti-spoof choice only when the request went through exactly
+  the trusted proxy set that appends. When the gateway is behind a single
+  trusted reverse proxy this is correct; behind multiple untrusted hops or
+  no proxy, the rightmost IP is the last hop and every failed attempt
+  shares a bucket. Notes call this out already.
+- Recommendation: Make the trust depth configurable
+  (`SP_TRUSTED_PROXY_DEPTH`) and skip that many rightmost hops when the
+  headers are trusted; otherwise fall back to `scope["client"][0]`.
+- Confidence: medium
+
+### [INFO] Eval runner mints a `read,write`-scoped API key and passes it into an
+attacker-controlled container
+
+- File: `signalpilot/gateway/gateway/api/eval_runs.py:113-118`,
+  `signalpilot/gateway/gateway/evals/runner.py:724-729`
+- Category: least privilege
+- Description: The runner mints an API key with `["read", "write"]`
+  scopes and injects it into the eval container via `X-API-Key`. The
+  container executes `claude -p` with `--dangerously-skip-permissions` on
+  an admin-configured repo. Key is revoked after the run
+  (`_revoke_run_key`), which is the important control. Impact is bounded
+  by scope: no `admin`, so no ability to mint keys, edit connections,
+  etc. Still worth calling out because scope alone is what stops the
+  eval box from mutating knowledge docs and other write-scope surfaces.
+- Recommendation: Introduce a narrower scope (e.g. `read`-only, or
+  `eval_read`) for the eval-runner MCP token; write-scope surfaces used
+  by the eval flow can be re-checked or restricted to only knowledge
+  overlays via `X-SP-Eval-Docs`.
+- Confidence: medium
+
+### [INFO] Gateway container mounts `/var/run/docker.sock`
+
+- File: `docker-compose.yml:105`
+- Category: blast radius
+- Description: The gateway container has direct Docker daemon access. This
+  is required for the eval-runner + eval-setup flows but means any RCE
+  reaching the gateway process (see the HIGH finding above) is trivially
+  a host root escape.
+- Recommendation: Route Docker calls through
+  `tecnativa/docker-socket-proxy` (or similar) with only the container
+  endpoints the eval runner uses whitelisted (`GET /containers/json`,
+  `POST /containers/create` scoped to a fixed image allow-list,
+  `POST /containers/{id}/start|kill|logs`, `DELETE /containers/{id}`).
+- Confidence: high
+
+### [INFO] `_run_setup_container` `image` from manifest + `env_file` parsing
+
+- File: `signalpilot/gateway/gateway/evals/runner.py:553, 580`
+- Category: least privilege
+- Description: `_parse_env_file(repo_dir, eval_set.setup.get("env_file", ""))`
+  reads an env file from the repo checkout — attacker-controlled contents
+  become container env vars, which is fine on its own but pairs with the
+  attacker-chosen `image` to allow arbitrary code selection.
+- Recommendation: See the HIGH finding — restricting the image is the
+  primary control here.
+- Confidence: medium
+
+### [INFO] `github_bot.client.GitHubBotClient` accepts `token` verbatim
+
+- File: `signalpilot/gateway/gateway/github_bot/client.py:35-46`
+- Category: hardening
+- Description: The token is placed in `Authorization: token <token>` on
+  every subsequent request. `resolve_bot_token` looks up an
+  installation-scoped token first, falling back to a PAT
+  (`SP_GITHUB_BOT_TOKEN`) if the DB lookup raises. That fallback is
+  logged as a warning — good — but it swaps identity silently. A
+  transient DB error during a `synchronize` event would make the shared
+  PAT scan a repo linked to a different customer.
+- Recommendation: Do not fall back to the PAT when the installation
+  lookup errors; fail the scan (webhook already returns 503 on lookup
+  failure, so keep that behavior consistent inside `run_pr_scan`).
+- Confidence: medium
+
+### [INFO] `notion.webhook_router` receiver processes any `comment.created` payload after signature check
+
+- File: `signalpilot/gateway/gateway/api/notion.py:666+`
+- Category: informational
+- Description: The signature check is enforced; from there on the code
+  writes to `gateway_notion_webhook_deliveries`. Signature checking uses
+  the shared secret — the audit did not surface a bypass. This entry is
+  a "reviewed clean" marker.
+- Confidence: high
+
+---
+
+## Areas reviewed clean
+
+- **Semantic-layer providers** (`gateway/semantic_layer/providers.py`) —
+  all identifiers pass through `_check_ident` / `_check_qualified` before
+  being interpolated into SQL; string-literal interpolation (`WHERE
+  table_catalog = '{parts[0]}'`) is safe because the same regex validator
+  runs first (`_IDENT_RE = ^[A-Za-z_][A-Za-z0-9_$]*$`).
+- **PipelineProof scanner SQL construction**
+  (`gateway/github_bot/scanner.py`) — model names come from
+  `parse_changed_models` which filters via `_MODEL_RE`; schema/table
+  values used with f-string interpolation into `information_schema`
+  queries originate from that regex-validated split. `_qid` /
+  `_qname` quoting is applied to identifiers used in the final aggregate
+  query.
+- **Redshift `SET search_path`** — schema list comes from `pg_namespace`,
+  each name double-quote escaped before joining.
+- **Knowledge search** (`store/knowledge_search.py`) — all filters use
+  named binds (`:org_id`, `:q`, etc.) via `text()` + parameter dict.
+- **GitHub webhook HMAC verification** — SHA-256, `hmac.compare_digest`,
+  and prefix stripping.
+- **Xata credential indirection** (`connectors/xata_creds.py`) — the
+  demo flow correctly stores only `xata_credential_ref="demo"`, resolves
+  the org key from env at use time, and `enforce_xata_scope` pins
+  project + branch; the pinned-connection edit-guard in
+  `connections/crud.py` blocks moving these fields.
+- **Eval upload multipart flow** — S3 keys are server-generated, key
+  shape is re-validated on `complete` / `abort`, size is enforced twice
+  (initiate on declared size, complete on `head_object` after upload),
+  and the notification email is plain-text.
+- **CSRF middleware** — cookie-only mutation requests are gated on
+  `Sec-Fetch-Site` / `Origin` / `Referer` against an explicit allow-list;
+  webhook prefixes are exempted with a documented reason.
+- **CORS allow-list construction** — cloud mode filters non-HTTPS
+  origins out and falls back to hardcoded prod origins if
+  `SP_ALLOWED_ORIGINS` is empty.
+- **Body size middleware** — pure ASGI, early rejects on
+  `Content-Length`, wraps `receive` for chunked bodies, tracks
+  `response.start` to avoid ASGI protocol violations on late rejects.
+- **New DB models** (`db/models.py`) — `GatewayKnowledgeRetrieval` and
+  `GatewaySchemaWatch` both carry `org_id NOT NULL` and have indexes /
+  unique constraints scoped by `org_id`.
+- **Dbt error parsing** (`gateway/dbt/error_parse.py`) — pure regex, no
+  code execution paths.
+- **Slack OAuth redirect** (`api/slack.py`) — `_safe_redirect_url` +
+  `_is_safe_redirect_target` allow-list, so open-redirect is blocked.
+- **`schema_watch/runner.py` PR creation** — deterministic branch names,
+  base64-encoded file contents, `github_repo` and `connection_name`
+  patterns limit path traversal into the `PUT contents` API.
+- **Sandbox delete IDOR** (`api/sandboxes.py`) — `get_sandbox(id, org_id)`
+  scoping applied before delete/kill.

--- a/security/frontend-audit.md
+++ b/security/frontend-audit.md
@@ -1,0 +1,98 @@
+# Frontend Security Audit
+
+Scope: `git diff main..HEAD` for `signalpilot/web/**` and `signalpilot/notebook-server/**` (JS/TS only), plus `plugin/**`. Backend Python and secrets scanning are out of scope. No `plugin/` files were modified in this branch.
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| Critical | 0 |
+| High | 0 |
+| Medium | 2 |
+| Low | 4 |
+| Info | 3 |
+
+Verdict: **APPROVE with hardening notes.** No exploitable frontend vulnerabilities were introduced by this branch. All new HTML-rendering paths are guarded (DOMPurify allowlist on sandbox dataframe HTML; hand-rolled Markdown for KB entries emits React children with a URL allowlist; eval transcript uses `react-markdown` with GFM only, no `rehype-raw`; no new `dangerouslySetInnerHTML` sinks). Findings below are mostly pre-existing hardening items surfaced by the changed surface, plus one supply-chain observation and one architectural note about the new client-side Anthropic API-key input.
+
+## Findings
+
+### [MEDIUM] Next.js downgrade in `package.json`
+- File: `signalpilot/web/package.json:101,162`
+- Category: dependency / supply chain
+- Description: This branch downgrades `next` from `^16.2.11` to `^16.2.9` and `eslint-config-next` from `16.2.11` to `16.2.4`. Also drops the pinned `sharp: 0.35.3`/`svgo: 0.4.0.2` overrides and moves `@img/sharp-*` optionalDependencies from `0.35.3` to `0.34.5`. Downgrading a framework (especially Next.js middleware/edge, which is the CSP + Clerk auth chokepoint) is a red flag: it may reintroduce patched CVEs (Next 15.x had `CVE-2025-29927` middleware auth bypass; the 16.x line has had similar tightening in the .10/.11 patch releases). `brace-expansion` override also moved from 5.0.7 back to 5.0.6.
+- Impact: If any of the Next.js patches between 16.2.9 and 16.2.11 addressed a middleware/CSP/routing security issue, this branch reopens the window. Same concern for the sharp downgrade (image processing has repeated CVE history around libvips).
+- Recommendation: Justify the downgrade in the PR description and confirm no security fixes were pulled back. If the downgrade is only to work around a build issue, prefer pinning at `16.2.11` with the specific fix rather than reverting. Run `npm audit --production` and record the result in the PR.
+- Confidence: medium
+
+### [MEDIUM] Anthropic API key entered client-side and transmitted through the gateway
+- File: `signalpilot/web/notebook/components/chat/agent-chat-panel.tsx:50-99`
+- Category: secret handling / trust boundary
+- Description: The redesigned `ApiKeySetup` now accepts an Anthropic API key (`sk-ant-...`) via a plain `<input type="password">` inside the notebook iframe and POSTs it JSON-encoded to `POST /api/agent/save-api-key`. The prior UX pushed the user to admin/integrations. Frontend concerns with the new path:
+  1. The DOM value is readable by any script running in the notebook iframe (the notebook renders untrusted-shaped content — Vega specs, mermaid, HTML tables — even if today's paths sanitize, the blast radius of an XSS regression now includes the user's Anthropic key while the modal is open).
+  2. The key is sent to `runtimeManager.getAgentURL("save-api-key")`, which is the gateway origin. That request rides on the same Bearer token as everything else, but there is no CSRF/anti-replay concern because Authorization headers are not sent cross-site — OK.
+  3. The success handler flips `aiConfigured` state but the key value is never explicitly cleared from React state (`setApiKey(apiKey.trim())` only reads it once); the closure keeps `apiKey` alive until the component unmounts.
+  4. No hint about HTTPS. In local mode this posts to `http://localhost:3300` in the clear, which is acceptable, but the user-facing copy says "Your key is stored securely on the server" — verify with the backend reviewer that `save-api-key` requires auth and stores the value only in the org's encrypted secrets store, not in a broadly-readable session log.
+- Impact: Regression risk if XSS is ever introduced to the notebook host; potential accidental logging of the raw key in developer tools / error boundaries because it lives in React state.
+- Recommendation: (a) Clear `apiKey` state (`setApiKey("")`) immediately after a successful save and after a failure that reveals the request body in an error message; (b) do not `String(e)` a fetch error into the UI without stripping the request body from thrown messages; (c) confirm the backend endpoint requires authentication (this reviewer did not audit `agent.py:save_api_key` for auth — flag to backend security review); (d) if IS_CLOUD_MODE, hide this UI and keep the "Ask an admin" flow — otherwise anyone with a shared browser can register a key against another user's org.
+- Confidence: high (client-side observations); backend integration needs a second look from the backend reviewer
+
+### [LOW] CSP retains `'unsafe-inline'` and `'unsafe-eval'` in `script-src`
+- File: `signalpilot/web/middleware.ts:61-65`
+- Category: CSP
+- Description: Not introduced by this branch (pre-existing), but this branch touches `middleware.ts` and the surrounding CSP block, so it is in scope for review. Both `unsafe-inline` and `unsafe-eval` are still allowed for the entire origin because Next.js hydration and Vega both need them. The rationale is documented inline, which is good.
+- Impact: XSS mitigations via CSP are limited to the `object-src 'none'`, `frame-ancestors 'none'`, and `default-src 'self'` fallbacks. An injected `<script>` can execute.
+- Recommendation: Long-term, migrate to a nonce-based CSP (Next.js 15+ supports `<Script nonce>`) and isolate Vega into an iframe/worker so `unsafe-eval` can be dropped. Not blocking this PR.
+- Confidence: high
+
+### [LOW] `base-uri` includes the gateway origin
+- File: `signalpilot/web/middleware.ts:125`
+- Category: CSP
+- Description: `base-uri 'self' ${gatewayUrl}`. Allowing an untrusted-if-compromised gateway to become the base URI would let a stored `<base>` tag from HTML output rewrite all relative URLs. The sandbox page renders HTML through DOMPurify with `<base>` implicitly forbidden (not in `ALLOWED_TAGS`), so today this is fine. But `base-uri` typically should be `'self'` only.
+- Impact: Defense-in-depth erosion if any HTML sink ever allows `<base>` or if an attacker injects a `<base>` via non-CSP-protected route.
+- Recommendation: Change to `base-uri 'self'`. The gateway does not need to be a `base-uri` target.
+- Confidence: high
+
+### [LOW] `postMessage` targets `"*"` in vscode-bindings.ts (unchanged, but adjacent to embed refactor)
+- File: `signalpilot/web/notebook/core/vscode/vscode-bindings.ts:152`
+- Category: postMessage
+- Description: `sendToPanelManager()` calls `window.parent?.postMessage(msg, "*")` — targets any origin — and the `message` listener on line 53 accepts any `event.data` without verifying `event.origin` or `event.source`. Only activated when `?vscode` query param is present AND the page is embedded. Not modified by this branch, but the embed harness (`SpEmbedProviders`, `mount.tsx`) was heavily restructured, so re-evaluated. Data sent is limited to selection text / clipboard content — an eavesdropping parent can steal clipboard-adjacent data. The paste-from-parent path calls `document.execCommand("insertText", false, message.text)` with attacker-controlled text if `?vscode` is on.
+- Impact: If a page is embedded with `?vscode`, any parent frame can inject arbitrary text into the active input by posting `{command: "paste", text: "..."}`, and can read every text selection the user makes. `frame-ancestors 'none'` in CSP is the primary mitigation; this only affects intentional VS Code webview integration.
+- Recommendation: Restrict `postMessage` target to a validated origin (the VS Code webview host injects `acquireVsCodeApi().postMessage`, but if you continue to use raw `postMessage`, target the specific parent origin discovered at bind time). Filter the `message` listener with `event.origin` / `event.source === window.parent`. Add a shape validator on `message.command` and `message.text`.
+- Confidence: high
+
+### [LOW] `parse-check.mjs` reads env-derived path and passes it to `fs.readFileSync`
+- File: `signalpilot/web/parse-check.mjs:3`
+- Category: input handling (dev/diagnostic script)
+- Description: `fs.readFileSync(process.env.TEMP + "/transcript.txt", "utf8")` — dev-only diagnostic script for the eval transcript parser. Not shipped to the browser, not on any code path. Flagged only because it's a new file introduced in this branch.
+- Impact: None in the browser bundle. If accidentally imported into a route, would fail at build (Node fs). Path traversal is not exploitable since `TEMP` is a local env var.
+- Recommendation: Move to `signalpilot/web/scripts/` or `tools/` and add a header comment explaining it is not part of the app.
+- Confidence: high
+
+### [INFO] Sandbox dataframe HTML sink is properly sanitized
+- File: `signalpilot/web/app/sandboxes/[id]/page.tsx:499`, sanitizer at `:44-52`
+- Category: XSS
+- Description: `dangerouslySetInnerHTML={{ __html: entry.htmlContent }}` is fed only by `sanitizeTableHtml()`, which calls `DOMPurify.sanitize(html, { ALLOWED_TAGS: [table, thead, tbody, ..., pre, code], ALLOWED_ATTR: [colspan, rowspan, class, scope], FORBID_ATTR: [style, id, onclick, onerror, onload, onmouseover] })`. Strict allowlist; no `<a>`, no `<img>`, no `<script>`, no event handlers, no `<style>`. Regex extraction of `<table>...</table>` from output before sanitization is fine — DOMPurify is the actual boundary. Approved.
+- Confidence: high
+
+### [INFO] KB DocumentView markdown renderer is safe by construction
+- File: `signalpilot/web/app/knowledge/_components/DocumentView.tsx`
+- Category: XSS
+- Description: Custom markdown renderer emits React children (never `dangerouslySetInnerHTML`). Link handling explicitly checks `SAFE_URL = /^https?:\/\//` before rendering `<a href={m[2]} target="_blank" rel="noopener noreferrer">`. Wikilinks `[[…]]` are resolved against the local doc list and rendered as `<button>` with `onNavigate(resolved.id)` — the anchor never receives untrusted href. Approved. Note that the comment "SAFE_URL anchors the external-link allowlist. DO NOT broaden to javascript:/data:/etc." is well placed — keep it.
+- Confidence: high
+
+### [INFO] Eval transcript / chats reader uses `react-markdown` without `rehype-raw`
+- File: `signalpilot/web/app/evals/_components/Markdown.tsx`, `turns.tsx`, `app/chats/page.tsx`
+- Category: XSS
+- Description: `<ReactMarkdown remarkPlugins={[remarkGfm]}>` with no `rehype-raw`/`rehype-html` — raw HTML in the source is escaped by default. Tool inputs/results are rendered as text or in `<pre>` blocks. The transcript is populated from `parseTranscript(raw)` which `JSON.parse`s line-delimited events and passes only strings into `<Md>`. Approved.
+- Confidence: high
+
+## Areas reviewed clean
+
+- `signalpilot/web/notebook/embed/` (SpEmbedProviders, createSignalpilotClient, SignalpilotEditor, SignalpilotHome, initStoreOnce, mount.tsx): refactor moves registry creation eager rather than lazy and inlines the SpApp import. No new `postMessage`, iframe, `eval`, or dangerous DOM sinks introduced. `mount.tsx` inlines a Zod schema for mount options — parses/validates external `options`, no `passthrough` shortcut for auth-relevant fields, and `authToken` accepts only `string | function | null` via a `z.custom` predicate.
+- `signalpilot/web/notebook/components/editor/Output.tsx` + deleted `VegaOutput.tsx`: pure code-motion (LazyVegaOutput inlined into OutputRenderer). No new sinks; Vega still uses canvas renderer.
+- `signalpilot/web/notebook/core/runtime/runtime.ts`: only adds `"save-api-key"` to the allowed path union. No runtime code exec change.
+- `signalpilot/web/lib/api.ts`: new multipart-upload path uses `XMLHttpRequest.open("PUT", url)` where `url` comes from the trusted gateway `initiate` response (part_urls). Auth model (Bearer from Clerk or sessionStorage local key) is unchanged and consistent. `sessionStorage` migration from `localStorage` is the correct direction for reducing XSS blast radius.
+- `signalpilot/web/app/chats/page.tsx`, `evals/upload/page.tsx`, `demo-db/page.tsx`, `knowledge/*`, `sandboxes/*` (styling), `settings/*`, `evals/_components/TranscriptView.tsx`, `turns.tsx`: no `innerHTML`, no `dangerouslySetInnerHTML`, no `eval`, no dynamic `href` from untrusted values, no new `postMessage`, no `NEXT_PUBLIC_*` secrets leaked. Only trusted env vars shipped to the bundle (gateway URL, backend URL, deployment mode, Clerk publishable key, MCP URL, eval S3 origin, version, sp version) — all appropriate for public disclosure.
+- `signalpilot/web/middleware.ts`: adds S3 upload origin to `connect-src` behind `isSafeUrl()`. Correctly gated by http/https protocol check. `X-Frame-Options: DENY` and `frame-ancestors 'none'` retained — clickjacking mitigated. HSTS conditional on `x-forwarded-proto === https` — fine.
+- `signalpilot/web/e2e/agent-chat.spec.ts`, `e2e-*.mjs`: e2e/dev only, no shipped code.
+- No hardcoded `sk-`, `sk-ant-`, Anthropic/Xata/OpenAI/AWS keys, DSNs, or Clerk secret keys found in the diff. `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is (correctly) a publishable key.

--- a/security/secrets-and-private-docs.md
+++ b/security/secrets-and-private-docs.md
@@ -1,0 +1,171 @@
+# Secrets & Private Documents Audit
+
+Audit date: 2026-07-29
+Branch: `autofyn/run-a-security-a-880618` vs `main`
+Scope: 272 files changed, ~19.8k insertions. Focused on (a) credential leaks in the branch diff, (b) private/internal markdown that must not ship publicly.
+
+## Summary
+
+| Category | Count |
+|---|---|
+| CRITICAL secrets in diff | 0 |
+| HIGH/MEDIUM secret-shaped items in diff | 0 (all values examined were placeholders, test fakes, or env-var references) |
+| Pre-existing suspicious items in `main` | 1 (LOW — a well-known "EXAMPLE" AWS key in a test file) |
+| Private/internal markdown docs flagged | 13 (2 CRITICAL, 8 HIGH, 3 MEDIUM) |
+| Files/patterns confirmed clean | many (see clean-list) |
+
+Severity mix: no live credentials leaked, but a large `writeups/` directory with roadmap details, private repo/customer names, and internal partnership economics is currently included in the diff and must be removed before publishing.
+
+---
+
+## Secrets Found (in branch diff)
+
+None. Every string matching secret-shaped regexes in the diff was one of:
+
+- Test fixtures with obvious fakes (`xoxb-test`, `xapp-test`, `sk-ant-api03-ABCDEFGHIJKLMNOP-XYZ9`, `sk-ant-old-org-key`, `sk-ant-rotated-SECRET`, `xau_users_own_key`, `-----BEGIN ... FAKE ...-----`).
+- Env var references (`${XATA_KEY:-}`, `${SP_GITHUB_BOT_TOKEN:-}`, `${CLAUDE_CODE_OAUTH_TOKEN:-}`) in `docker-compose.yml`. No actual values.
+- MinIO local-dev default `minioadmin/minioadmin` in the compose file — acceptable for a local dev stack when documented, but see hardening note below.
+- Placeholder private-key strings in UI placeholders and test files (`-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----`).
+- Documentation examples using RFC-5737 / obvious sample IPs like `172.31.99.42` (test data), `bastion.example.com`, `db.internal.example.com`, `100.64.1.50`, `203.0.113.10`, `10.0.2.45` — these are RFC-5737/RFC-1918/CGNAT examples, not real hosts.
+
+### Hardening notes (non-blocking)
+
+- `docker-compose.yml` sets `MINIO_ROOT_PASSWORD: minioadmin` and `SP_EVAL_UPLOADS_S3_ACCESS_KEY/SECRET_KEY: minioadmin`. Fine for local dev; add a comment stating this file is DEV-ONLY, or template these to env vars for the prod compose to avoid the default ever making it into a production image.
+- `.gitignore` correctly adds `.env`, `.redshift-nala-creds.txt`, `research-7-20/`, `research-7-24/`, `presentations/`, `dh.json`, `xata-partnership.md`, `five-customer-problems.md`, `knowledge-base-redesign.md`, `AGENTS.md`, `cc.md`, various `demo-*` scratch dirs. This is the right posture and none of these appear in the diff. Good.
+- The removed `signalpilot/gateway/gateway/dev_local_api_key.py` used `secrets.token_hex(16)` — not a leak, just noting it was scrubbed cleanly.
+
+---
+
+## Suspicious Content in `main` (pre-existing)
+
+### [LOW] `tests/test_iam_auth.py:25,30`
+- Excerpt: `"aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"`
+- This is the AWS-documented **example** access key ID (literally ends in `EXAMPLE`, published in AWS IAM docs). Not a real secret. Left as-is; noted only because grep flagged it.
+
+No other real-secret-shaped strings were found in `main` (spot-checked with the full pattern set: `sk-ant-`, `AKIA…` non-EXAMPLE, `ghp_`, `xoxb-`, `AIza`, `-----BEGIN … PRIVATE KEY-----` outside of placeholders/tests/docs). The private-key hits in `main` were all UI placeholders, doc examples, and fake test fixtures — none are live keys.
+
+---
+
+## Private / Internal Markdown Files
+
+The entire `writeups/` directory (13 files) is new in this branch and reads as internal sprint-tracking / roadmap / partnership documentation. **None of it should ship on a public OSS release.** Details below.
+
+### [CRITICAL] `writeups/HUMAN-TASKS.md`
+- Why private: Names a private customer/scratch GitHub repo, an internal container name, dollar-figure hosting cost projections tied to a Xata partnership, and a live to-ship credential-management directive naming the exact env var.
+- Excerpts:
+  - `"kiwi0401/sp-pipelineproof-test — PRs #1–#4 there are the test artifacts; delete the repo when done"`
+  - `"XATA_KEY must go into AWS Secrets Manager before this ships. It is the org-wide Xata control-plane key."` — pointing at (and giving a name to) an unrotated, still-live production key.
+  - `"AKASA has no companion dbt repo yet"` — reveals customer/partner name AKASA and its unreleased state.
+  - `"~$0.024/hr ≈ $17/mo each, plus $0.28/GB storage"` — internal Xata unit economics.
+  - `"The nala-warehouse-pg container was attached to the signalpilot_default docker network"` — internal infra.
+- Recommendation: **REMOVE from the diff entirely.** Move to a private repo. If any of the guidance is still needed publicly, rewrite as generic operator docs with no repo/customer/vendor economics.
+
+### [CRITICAL] `writeups/SPRINT-SUMMARY.md`
+- Why private: Sprint-planning artifact enumerating unshipped features, cross-org authorization holes, a SQL injection vector, per-feature "live PRs" on a private test repo, and dollar-figure agent-token costs.
+- Excerpts:
+  - `"A cross-org authorization hole (schema watches could PR to another org's repo with that org's installation token)."`
+  - `"A SQL injection vector (MetricProof where-clause passthrough)."`
+  - `"~5.7M subagent tokens across 8 panels + 4 sweep agents"`
+  - `"live PR on kiwi0401/sp-pipelineproof-test#1 — 3.48M-row model verified, ghost model failed"`
+- Publishing this after fixes are landed is still risky: it forensically catalogues where security bugs *were*, which invites regression hunting. Also names the private test repo repeatedly.
+- Recommendation: **REMOVE.** Keep as an internal artifact.
+
+### [HIGH] `writeups/feature-1-kb-semantic-search.md`
+- Why private: Reads like an internal design memo — references `research-7-20/17, §1.3` (a private research folder listed in `.gitignore`), internal roadmap items, and enumerates unresolved product decisions ("needs an API key decision (human)"). Discusses agent-side data (task descriptions) stored 90d and calls out a needed PII/retention decision.
+- Excerpt: `"the realism audit (research-7-20/17, §1.3) flagged as the top greenfield gap"`; `"needs a PII/retention decision before cloud GA"`.
+- Recommendation: Remove or heavily redact; consider a public engineering blog version with the private references stripped.
+
+### [HIGH] `writeups/feature-1-panels.md`
+- Why private: Explicit internal-security-review log listing bugs by severity and internal roadmap ("KB Reflector usage signal … feeds roadmap M2", "PII scrubbing for logged queries … Governance review before cloud GA"). Also lists roadmap-classified backlog items.
+- Excerpt: `"PII scrubbing for logged queries — task descriptions can contain customer data; queries stored 90d. Governance review before cloud GA."`
+- Recommendation: Remove.
+
+### [HIGH] `writeups/feature-2-retrieval-heatmap.md`
+- Why private: 8-agent panel outcomes; enumerated backlog with roadmap prioritization; internal review process detail.
+- Excerpt: `"Panel outcomes (16 agents, ~616k tokens)"` and a bug-list with severities.
+- Recommendation: Remove.
+
+### [HIGH] `writeups/feature-3-github-bot.md`
+- Why private:
+  - Names the private test repo `kiwi0401/sp-pipelineproof-test` and includes real-world row counts (`3,485,520 rows`) from a live warehouse (`perf_nala_pg`, likely NALA customer/env).
+  - Describes an internal auth-token fallback chain and admin routes.
+  - Excerpt: `"Private repo kiwi0401/sp-pipelineproof-test, PR #1 … stg_fx__fx_rates → pass — 3,485,520 rows, grain rate_id unique, auto-resolved to analytics_staging.stg_fx__fx_rates on connection perf_nala_pg."`
+- Recommendation: Remove. If a public writeup is desired, redact the repo name, warehouse/connection names, and row counts.
+
+### [HIGH] `writeups/feature-4-schema-diff-cron.md`
+- Why private: Direct URLs to PRs on the private repo (`https://github.com/kiwi0401/sp-pipelineproof-test/pull/2`), internal warehouse name and table counts (`perf_nala_pg (261 tables)`), and — critically — again names the cross-org auth vulnerability.
+- Excerpt: `"the panel found the cross-org hole: org A could otherwise PR to org B's linked repo with org B's installation token."`
+- Recommendation: Remove.
+
+### [HIGH] `writeups/feature-5-databricks-testing.md`
+- Why private: Internal audit-vs-roadmap gap analysis; panel-review internal process.
+- Excerpt: `"Panel outcomes (16 agents, ~666k tokens)"`.
+- Recommendation: Remove. Lower risk than 3/4 (no customer names) but still leaks internal process and unshipped-decision backlog.
+
+### [HIGH] `writeups/feature-6-metricproof.md`
+- Why private: Explicitly discloses that a critical SQL-injection vector was in the code, references un-live features awaiting human validation, and includes competitive/GTM strategy language.
+- Excerpts:
+  - `"where-clause injection removal (critical)"`
+  - `"the partner-shaped play against Snowflake/Databricks instead of a war-shaped one"` — internal positioning language.
+- Recommendation: Remove.
+
+### [HIGH] `writeups/feature-7-dbt-fusion.md`
+- Why private: Internal vendor-probe results ("recon assumptions"), specific dbt-fusion preview version, and known-remaining-gap disclosure of an unfixed benchmark-infra vulnerability.
+- Excerpt: `"benchmark/Dockerfile.dbt-agent faketime shim: LD_PRELOAD interception of a Rust binary is unreliable"`.
+- Recommendation: Remove or convert to a public engineering post after review.
+
+### [MEDIUM] `writeups/feature-8-ux-overhaul.md`
+- Why private: References an internal design doc (`signalpilot/web/UX.md`, also in the diff), enumerates a shipping bug that made prod ("Ctrl+C hijack (shipping bug)"), and lists open TODO backlog.
+- Excerpt: `"Ctrl+C hijack (shipping bug): the Chats nav shortcut intercepted the copy chord"`.
+- Recommendation: Remove or rework as a public design post; the shipping-bug callout is embarrassing but not exploitable.
+
+### [MEDIUM] `writeups/kb-search-test-suite.md`
+- Why private: Internal benchmarks with subagent-generated test details, but the content is largely engineering-substantive and could plausibly be a public blog post after light edit.
+- Excerpt: `"800+ assertions … The generators were held to a 'provable expectations only' contract"`.
+- Recommendation: Remove from OSS repo; can be a public engineering post separately.
+
+### [CRITICAL] `writeups/research-metric-sources-and-connectors.md`
+- Why private: This is a **competitive intelligence and licensing-strategy memo** citing a specific person by first name, discussing which OSS licenses can be embedded, and analyzing partnership candidates.
+- Excerpts:
+  - `"Question from Dan: validate the metric-scatter hypothesis"` — names an internal stakeholder.
+  - `"Nango is the sleeper in the source-available tier … the partnership/embed candidate if we want one-click OAuth"` — partnership-strategy speculation.
+  - `"ELv2 exposure note for us specifically: SignalPilot itself is a governed gateway — if we ever expose an embedded ELv2 component's own API surface to customers we edge toward the forbidden zone … Counsel review before any ELv2 embed ships."` — legal-strategy internal note.
+- Recommendation: **REMOVE.** This is the single highest-risk file — mixes personal names, competitive analysis, licensing strategy, and internal legal posture. Ship nowhere near public.
+
+### [MEDIUM] `writeups/kb-search-test-suite.md` and other `benchmark/` MDs
+- The `benchmark/prompts/kb_generation_system.md` and `benchmark/signalpilot-plugin/skills/dbt-knowledgebase/SKILL.md` changes are small formatting/style additions and appear safe. No customer or roadmap detail.
+- `signalpilot/web/UX.md` (added, ~110 lines): a product-design document. Mostly generic UX/typography direction, but it does reference the internal `WebstormProjects/signalpilot/landing-page` local path in the header, plus internal loop naming. Recommendation: LOW — either strip the WebstormProjects reference line and ship it, or move to internal wiki.
+
+---
+
+## Additional flags outside `writeups/`
+
+- **`CONTRIBUTING.md`**: the diff removes a large block of dev-stack documentation. That's a content decision, not a security concern — no secrets exposed by the change.
+- **`.gitignore`** additions include mentions of private files by name (e.g., `xata-partnership.md`, `dh.json`, `five-customer-problems.md`, `research-7-*`). Ignoring the *names* of private files in `.gitignore` is a mild information leak (adversaries learn those files exist), but the standard tradeoff is worth it. **Consider deleting the `.gitignore` line for `dh.json` and `.redshift-nala-creds.txt` after confirming those files have never been committed** — advertising them by name in a public repo mildly increases their target value. Severity: LOW.
+
+---
+
+## Clean-list (checked and confirmed OK)
+
+- `docker-compose.yml`, `docker-compose.dev.yml`: no hardcoded live secrets. `${XATA_KEY:-}`, `${SP_GITHUB_BOT_TOKEN:-}`, `${SP_GITHUB_WEBHOOK_SECRET:-}`, `${CLAUDE_CODE_OAUTH_TOKEN:-}` are env-var references. MinIO dev creds are default and non-sensitive but flagged for hardening.
+- `.env.example` deletion — the old file contained only commented-out variable names, no values.
+- All `xoxb-test` / `xapp-test` / `sk-ant-…-XYZ9` / `xau_users_own_key` occurrences in the test suite: obvious fakes.
+- All `-----BEGIN … PRIVATE KEY-----` occurrences: UI placeholders, doc examples with `\n...`, or test fixtures with literal `\nFAKE\n` bodies.
+- No AWS access-key IDs matching `AKIA[0-9A-Z]{16}` other than the AWS-documented `AKIAIOSFODNN7EXAMPLE` in tests.
+- No `ghp_…` / `gho_…` GitHub tokens found anywhere in the diff or `main`.
+- No `AIza…` Google API keys.
+- No JWTs with real-looking payloads (`eyJhbGciO…`) in code paths.
+- No `postgres://user:password@…` or other DB connection strings with embedded credentials in the diff.
+- Internal IPs found in code are all example ranges (172.31.99.42 in a test, 100.64.1.50/203.0.113.10/10.0.2.45 in docs).
+- `demo-2.zip`, `demo-3/`, `nala-demo.zip`, `akasa_dbt.zip`, `redshift_nala_load.py`, `.redshift-nala-creds.txt`, `dh.json`, `xata-partnership.md`, `research-7-*/`, `presentations/`, `AGENTS.md`, `cc.md`, `eval-format.md`, `eval-upload-spec.md`, `five-customer-problems.md`, `knowledge-base-redesign.md`, `codex-signalpilot-plugin/`, `redshift_export/` are all in `.gitignore` and confirmed **not present** in the diff.
+
+---
+
+## Action items (recommended, not implemented — this is diagnostic)
+
+1. Delete the entire `writeups/` directory from this branch before merging to `main` for public release. Move to a private tracking repo.
+2. Add `writeups/` to `.gitignore` so future sprints do not re-introduce the same leak.
+3. Independently rotate `XATA_KEY`, `SP_GITHUB_BOT_TOKEN`, `SP_GITHUB_WEBHOOK_SECRET`, `CLAUDE_CODE_OAUTH_TOKEN`, and any credentials associated with `kiwi0401/sp-pipelineproof-test` — because their existence, purpose, and location are documented in the writeups that were already in the git history of this branch (even if you delete the files now, they persist in reflogs unless the branch is force-recreated or the objects garbage-collected on the remote).
+4. Consider whether `kiwi0401/sp-pipelineproof-test`, `kiwi0401/parallax-demo`, `perf_nala_pg`, `nala-warehouse-pg`, and `AKASA` are names you want in the *commit history* of a public repo. If not, this branch should be rebased/squashed before pushing, and any prior remote pushes reviewed.
+5. Strip the "WebstormProjects/signalpilot/landing-page" local path reference from `signalpilot/web/UX.md` before shipping.
+6. In `docker-compose.yml`, add a `# DEV ONLY — do not use in production` comment above the `minioadmin` block.


### PR DESCRIPTION
Adds a `/security/` directory containing a security and secrets-leak audit of every file this branch adds relative to `main`, plus a review of markdown files that should not ship in a public OSS repo.

## Reports

- `security/README.md` — index + executive summary + combined severity tally.
- `security/secrets-and-private-docs.md` — credential/API-key scan of the diff, glance at `main`, and private-markdown flagging.
- `security/backend-audit.md` — Python/FastAPI gateway, sandbox, connectors, Docker/compose, scripts.
- `security/frontend-audit.md` — Next.js/React notebook UI, embed code, Claude Code plugin.

## Combined severity tally

- CRITICAL: 2
- HIGH: 10
- MEDIUM: 9
- LOW: 8
- INFO: 8

## Top items to fix before public release

1. **CRITICAL** — `writeups/HUMAN-TASKS.md` and `writeups/research-metric-sources-and-connectors.md` contain internal roadmap, unshipped-feature specs, a private repo path, customer/partner names, acknowledged open security holes, and partnership economics. Must not ship OSS.
2. **HIGH** — 11 more `writeups/*.md` and `signalpilot/web/UX.md` with sprint plans, feature-1..7 writeups, UX overhaul plan. Recommend moving `writeups/` to a private repo and adding to `.gitignore`.
3. **HIGH** — Unauthenticated `POST /save-api-key` in `signalpilot/notebook-server/signalpilot/_server/api/endpoints/agent.py:115-160` accepts a secret from request body and mutates `os.environ` process-wide.
4. **HIGH** — Eval runner (`gateway/evals/runner.py:553`) picks a Docker image from an admin-supplied manifest while `docker-compose.yml:105` mounts the docker socket — host-root RCE for a hostile `repo_url`.
5. **MEDIUM** — GitHub-webhook local-mode signature-check fallback, `git clone` of admin-supplied `repo_url` with shell-quoted args, legacy upload spool sizing, Notion `verification_token` short-circuit, Next.js/sharp downgrade, client-side Anthropic key retained in React state.

## What is NOT a finding

- No live secrets in the diff.
- No live secrets in `main` (one AWS-documented example key in a test).
- No exploitable frontend XSS — HTML rendering uses DOMPurify with a strict allowlist and `react-markdown` without `rehype-raw`.

Per the user's request, this PR contains only the audit reports. All fixes will be applied in follow-up work by the user.

---
**Branch:** `autofyn/run-a-security-a-880618` · **Run:** `5e0d4d20-d372-4b44-914f-5bc506687f3f` · *Generated by AutoFyn*