### PR TITLE
feat: redesign eval controls, accuracy insights, and onboarding

### DIFF
--- a/docker-compose.evalprod.yml
+++ b/docker-compose.evalprod.yml
@@ -83,6 +83,11 @@ services:
   web:
     profiles:
       - webui
+    build:
+      args:
+        NEXT_PUBLIC_GATEWAY_URL: http://localhost:3410
+    environment:
+      NEXT_PUBLIC_GATEWAY_URL: http://localhost:3410
 
   minio:
     ports: !override

--- a/signalpilot/gateway/gateway/api/eval_runs.py
+++ b/signalpilot/gateway/gateway/api/eval_runs.py
@@ -374,6 +374,35 @@ async def get_eval_run(store: StoreD, run_id: str):
     return run
 
 
+@router.post("/evals/runs/{run_id}/cancel", dependencies=EVAL_EXECUTE_GUARDS)
+async def cancel_eval_run(store: StoreD, run_id: str):
+    """Request cancellation and return the persisted run state."""
+    from ..store import evals as evals_store
+
+    run_id = _safe_id(run_id)
+    run = await store.get_eval_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    if run["status"] == "cancelled":
+        return run
+    if run["status"] not in ("preparing", "running", "cancelling"):
+        raise HTTPException(status_code=409, detail="Only an active eval run can be cancelled")
+
+    await evals_store.update_run(
+        store.session,
+        org_id=store.org_id,
+        run_id=run_id,
+        status="cancelling",
+    )
+    task = _active_tasks.get(run_id)
+    if task is not None and not task.done():
+        task.cancel()
+    else:
+        await runner.mark_run_cancelled(store.org_id, run_id)
+        await runner.revoke_run_keys(store.org_id, run_id)
+    return await store.get_eval_run(run_id)
+
+
 @router.get(
     "/evals/runs/{run_id}/tasks/{task_id}/setup/{phase}/log",
     response_class=PlainTextResponse,
@@ -471,6 +500,7 @@ async def get_eval_accuracy(store: StoreD, limit: int = Query(200, ge=1, le=1000
     return {
         "history": await store.list_eval_accuracy(limit=limit),
         "regressions": await store.list_eval_regressions(),
+        "task_performance": await store.list_eval_task_performance(),
     }
 
 

--- a/signalpilot/gateway/gateway/api/eval_runs.py
+++ b/signalpilot/gateway/gateway/api/eval_runs.py
@@ -16,7 +16,7 @@ import zipfile
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse, Response, StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ..config import get_governance_settings
 from ..config.evals import get_eval_run_settings
@@ -64,6 +64,8 @@ EXPORT_MAX_BYTES = 256 * 1024 * 1024
 
 class EvalConfig(BaseModel):
     repo_url: str = Field("", max_length=2048)
+    repo_installation_id: str | None = Field(None, max_length=64)
+    repo_id: int | None = Field(None, gt=0)
     model: str = Field("sonnet", max_length=64)
     max_tasks: int = Field(0, ge=0, le=200)  # 0 = all
     prompt_preamble: str = Field("", max_length=4000)
@@ -91,6 +93,12 @@ class EvalConfig(BaseModel):
             if len(e) > 254 or "@" not in e or " " in e or e.count("@") != 1:
                 raise ValueError(f"not an email address: {e!r}")
         return v
+
+    @model_validator(mode="after")
+    def _private_repo_binding_is_complete(self):
+        if (self.repo_installation_id is None) != (self.repo_id is None):
+            raise ValueError("repo_installation_id and repo_id must be set together")
+        return self
 
 
 class EvalRunRequest(BaseModel):
@@ -128,8 +136,43 @@ async def get_eval_config(store: StoreD):
 @router.put("/evals/config", dependencies=EVAL_EXECUTE_GUARDS)
 async def put_eval_config(store: StoreD, cfg: EvalConfig):
     pin = await _require_pinned_connection(store, cfg.connection)
-    cfg = cfg.model_copy(update={"connection": pin})
+    cfg = await _verify_private_eval_repo(store, cfg.model_copy(update={"connection": pin}))
     return await store.save_eval_config(cfg.model_dump(mode="json"))
+
+
+async def _verify_private_eval_repo(store: StoreD, cfg: EvalConfig) -> EvalConfig:
+    """Verify that the selected installation can read the bound eval repository."""
+    if cfg.repo_installation_id is None:
+        return cfg
+    prefix = "https://github.com/"
+    if not cfg.repo_url.startswith(prefix):
+        raise HTTPException(status_code=422, detail="A private eval repository must use a GitHub HTTPS URL")
+    full_name = cfg.repo_url.removeprefix(prefix).removesuffix(".git").strip("/")
+    if full_name.count("/") != 1:
+        raise HTTPException(status_code=422, detail="The private eval repository URL is invalid")
+
+    from ..github_client import list_installation_repos
+    from ..store import github as github_store
+
+    installation = await github_store.get_installation(
+        store.session,
+        org_id=store.org_id,
+        installation_id=cfg.repo_installation_id,
+    )
+    if installation is None or installation.status != "active":
+        raise HTTPException(status_code=422, detail="The selected GitHub installation is not connected")
+    try:
+        token = await github_store.get_valid_token(store.session, installation)
+        repos = await list_installation_repos(token)
+    except Exception as exc:
+        logger.warning("Could not verify eval repository access for org=%s: %s", store.org_id, type(exc).__name__)
+        raise HTTPException(status_code=502, detail="GitHub repository access could not be verified") from exc
+
+    selected = next((repo for repo in repos if int(repo.get("id", 0)) == cfg.repo_id), None)
+    if selected is None or str(selected.get("full_name", "")).casefold() != full_name.casefold():
+        raise HTTPException(status_code=422, detail="The selected GitHub installation cannot access this repository")
+    canonical_url = f"https://github.com/{selected['full_name']}.git"
+    return cfg.model_copy(update={"repo_url": canonical_url})
 
 
 async def _require_pinned_connection(store: StoreD, connection: str | None) -> str:

--- a/signalpilot/gateway/gateway/db/engine.py
+++ b/signalpilot/gateway/gateway/db/engine.py
@@ -610,6 +610,17 @@ async def _ensure_eval_run_lease_columns(engine) -> None:
     logger.info("Ensured lease columns on gateway_eval_runs")
 
 
+async def _ensure_eval_config_repo_binding_columns(engine) -> None:
+    """Add the GitHub installation binding used by private eval repositories."""
+    async with engine.begin() as conn:
+        for ddl in (
+            "ALTER TABLE gateway_eval_configs ADD COLUMN IF NOT EXISTS repo_installation_id VARCHAR(64)",
+            "ALTER TABLE gateway_eval_configs ADD COLUMN IF NOT EXISTS repo_id BIGINT",
+        ):
+            await conn.execute(text(ddl))
+    logger.info("Ensured private repository binding columns on gateway_eval_configs")
+
+
 async def _ensure_notebook_session_org_id(engine) -> None:
     """Add org_id to gateway_notebook_sessions and fill NULL values.
 
@@ -653,6 +664,7 @@ async def init_db() -> None:
     await _ensure_github_authorized_repos_column(engine)
     await _ensure_notebook_token_plaintext_dropped(engine)
     await _ensure_api_key_eval_binding_columns(engine)
+    await _ensure_eval_config_repo_binding_columns(engine)
     await _ensure_eval_run_lease_columns(engine)
     await _ensure_eval_regression_change_columns(engine)
     logger.info("Gateway database tables initialized")

--- a/signalpilot/gateway/gateway/db/models.py
+++ b/signalpilot/gateway/gateway/db/models.py
@@ -1177,6 +1177,8 @@ class GatewayEvalConfig(GatewayBase):
 
     org_id: Mapped[str] = mapped_column(String, primary_key=True)
     repo_url: Mapped[str] = mapped_column(String(2048), nullable=False, default="")
+    repo_installation_id: Mapped[str | None] = mapped_column(String(64))
+    repo_id: Mapped[int | None] = mapped_column(BigInteger)
     model: Mapped[str] = mapped_column(String(64), nullable=False, default="sonnet")
     max_tasks: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     prompt_preamble: Mapped[str] = mapped_column(Text, nullable=False, default="")

--- a/signalpilot/gateway/gateway/evals/coverage.py
+++ b/signalpilot/gateway/gateway/evals/coverage.py
@@ -139,11 +139,15 @@ async def compute_coverage(
     executed_task_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     declared: set[str] = set()
+    declared_by_task: dict[str, set[str]] = {}
     for task in eval_set.tasks:
         if executed_task_ids is not None and task.id not in executed_task_ids:
             continue  # partial run: an unexecuted task's covers aren't coverage
-        declared.update(_model_key(c) for c in task.covers)
-        declared.update(_model_key(b) for b in task.builds)
+        task_models = {_model_key(c) for c in task.covers} | {
+            _model_key(b) for b in task.builds
+        }
+        declared.update(task_models)
+        declared_by_task[task.id] = task_models
 
     observed_by_task = await observed_tables_for_run(org_id, run_id)
     observed: set[str] = set()
@@ -169,6 +173,25 @@ async def compute_coverage(
             bucket["total"] += 1
             if str(m["name"]).lower() in hit:
                 bucket["covered"] += 1
+        result["models"] = [
+            {
+                "name": str(model["name"]),
+                "layer": str(model.get("layer", "other")),
+                "covered": _model_key(str(model["name"])) in covered,
+                "declared_by": sorted(
+                    task_id
+                    for task_id, models in declared_by_task.items()
+                    if _model_key(str(model["name"])) in models
+                ),
+                "observed_by": sorted(
+                    task_id
+                    for task_id, models in observed_by_task.items()
+                    if _model_key(str(model["name"]))
+                    in {_model_key(name) for name in models}
+                ),
+            }
+            for model in sorted(project_models, key=lambda item: str(item["name"]))
+        ]
         result["models_total"] = len(project_models)
         result["models_covered"] = len(hit)
         result["pct"] = round(len(hit) / len(project_models) * 100.0, 1)

--- a/signalpilot/gateway/gateway/evals/retention.py
+++ b/signalpilot/gateway/gateway/evals/retention.py
@@ -102,12 +102,17 @@ async def recover_stale_runs() -> int:
         except Exception:
             logger.exception("could not revoke keys for stale run %s", run_id)
         async with factory() as session:
+            was_cancelling = run.get("status") == "cancelling"
             await evals_store.update_run(
                 session,
                 org_id=org_id,
                 run_id=run_id,
-                status="failed",
-                error="run did not finish — the gateway executing it stopped responding",
+                status="cancelled" if was_cancelling else "failed",
+                error=(
+                    None
+                    if was_cancelling
+                    else "run did not finish because the gateway executing it stopped responding"
+                ),
                 finished_at=_now_iso(),
                 lease_expires_at=None,
             )

--- a/signalpilot/gateway/gateway/evals/runner.py
+++ b/signalpilot/gateway/gateway/evals/runner.py
@@ -301,7 +301,13 @@ def _assert_repo_allowed(repo_url: str, *, settings: EvalRunSettings, what: str)
         raise RepoRefused(f"{what}: local paths must live under {settings.projects_dir} — refused {url[:120]!r}")
 
 
-async def _authed_clone_url(org_id: str, repo_url: str) -> str:
+async def _authed_clone_url(
+    org_id: str,
+    repo_url: str,
+    *,
+    repo_installation_id: str | None = None,
+    repo_id: int | None = None,
+) -> str:
     """Swap in a short-lived installation token for a private GitHub repo.
 
     The resolver rejects a repository that belongs to another organization.
@@ -314,7 +320,20 @@ async def _authed_clone_url(org_id: str, repo_url: str) -> str:
 
     factory = get_session_factory()
     async with factory() as session:
-        token = await gh_store.get_org_token_for_repo(session, org_id=org_id, repo_full_name=full_name)
+        if repo_installation_id:
+            installation = await gh_store.get_installation(
+                session,
+                org_id=org_id,
+                installation_id=repo_installation_id,
+            )
+            if installation is None or installation.status != "active":
+                raise RepoRefused("the GitHub installation for this eval repository is not connected")
+            authorized_ids = installation.authorized_repository_ids
+            if authorized_ids is not None and repo_id not in {int(value) for value in authorized_ids}:
+                raise RepoRefused("the GitHub installation is not authorized for this eval repository")
+            token = await gh_store.get_valid_token(session, installation)
+        else:
+            token = await gh_store.get_org_token_for_repo(session, org_id=org_id, repo_full_name=full_name)
     if token:
         return f"https://x-access-token:{token}@github.com/{full_name}.git"
     # Public repositories can clone without GitHub App authorization.
@@ -322,11 +341,24 @@ async def _authed_clone_url(org_id: str, repo_url: str) -> str:
     return repo_url
 
 
-async def fetch_eval_repo(org_id: str, repo_url: str, dest: Path, settings: EvalRunSettings) -> str:
+async def fetch_eval_repo(
+    org_id: str,
+    repo_url: str,
+    dest: Path,
+    settings: EvalRunSettings,
+    *,
+    repo_installation_id: str | None = None,
+    repo_id: int | None = None,
+) -> str:
     """Clone (or resolve) the eval set into dest. Returns the git ref."""
     _assert_repo_allowed(repo_url, settings=settings, what="eval repo")
     if repo_url.startswith(("http://", "https://", "git@")):
-        url = await _authed_clone_url(org_id, repo_url)
+        url = await _authed_clone_url(
+            org_id,
+            repo_url,
+            repo_installation_id=repo_installation_id,
+            repo_id=repo_id,
+        )
         code, out = await _git(["clone", "--depth", "1", url, str(dest)])
         if code != 0:
             # Do not include `url` in output because it can contain a token.
@@ -357,8 +389,11 @@ async def get_eval_set(org_id: str, cfg: dict, settings: EvalRunSettings) -> Eva
     repo_url = str(cfg.get("repo_url", "") or "")
     if not repo_url:
         raise FileNotFoundError("no eval repo configured")
+    repo_installation_id = cfg.get("repo_installation_id")
+    repo_id = cfg.get("repo_id")
+    cache_key = f"{repo_url}\x00{repo_installation_id or ''}\x00{repo_id or ''}"
     cache_root = Path(tempfile.gettempdir()) / "sp-eval-cache"
-    slug = hashlib.sha256(f"{org_id}\x00{repo_url}".encode()).hexdigest()[:16]
+    slug = hashlib.sha256(f"{org_id}\x00{cache_key}".encode()).hexdigest()[:16]
     dest = cache_root / slug
     meta = dest / ".sp-cache-meta"
     fresh = False
@@ -370,15 +405,22 @@ async def get_eval_set(org_id: str, cfg: dict, settings: EvalRunSettings) -> Eva
     if meta.is_file():
         try:
             cached = json.loads(meta.read_text())
-            fresh = cached.get("url") == repo_url and time.time() - cached.get("at", 0) < _REPO_CACHE_SECONDS
+            fresh = cached.get("key") == cache_key and time.time() - cached.get("at", 0) < _REPO_CACHE_SECONDS
             ref = str(cached.get("ref", ""))
         except ValueError:
             fresh = False
     if not fresh:
         shutil.rmtree(dest, ignore_errors=True)
         dest.parent.mkdir(parents=True, exist_ok=True)
-        ref = await fetch_eval_repo(org_id, repo_url, dest, settings)
-        meta.write_text(json.dumps({"url": repo_url, "at": time.time(), "ref": ref}))
+        ref = await fetch_eval_repo(
+            org_id,
+            repo_url,
+            dest,
+            settings,
+            repo_installation_id=repo_installation_id,
+            repo_id=repo_id,
+        )
+        meta.write_text(json.dumps({"key": cache_key, "at": time.time(), "ref": ref}))
     eval_set = load_eval_set(dest)
     eval_set.ref = ref
     return eval_set
@@ -812,7 +854,14 @@ async def _execute_run_inner(org_id: str, run_id: str, api_key: str | None) -> N
     try:
         try:
             shutil.rmtree(repo_dir, ignore_errors=True)
-            eval_ref = await fetch_eval_repo(org_id, run["repo_url"], repo_dir, settings)
+            eval_ref = await fetch_eval_repo(
+                org_id,
+                run["repo_url"],
+                repo_dir,
+                settings,
+                repo_installation_id=(cfg.get("repo_installation_id") if cfg.get("repo_url") == run["repo_url"] else None),
+                repo_id=(cfg.get("repo_id") if cfg.get("repo_url") == run["repo_url"] else None),
+            )
             eval_set = load_eval_set(repo_dir)
             eval_set.ref = eval_ref
         except (ManifestError, RuntimeError, ValueError, FileNotFoundError) as exc:

--- a/signalpilot/gateway/gateway/evals/runner.py
+++ b/signalpilot/gateway/gateway/evals/runner.py
@@ -111,6 +111,15 @@ class RunDB:
         async with self._factory() as session:
             await evals_store.renew_lease(session, org_id=self.org_id, run_id=self.run_id, ttl_s=ttl_s)
 
+    async def cancel_open_tasks(self, finished_at: str) -> None:
+        async with self._factory() as session:
+            await evals_store.cancel_open_tasks(
+                session,
+                org_id=self.org_id,
+                run_id=self.run_id,
+                finished_at=finished_at,
+            )
+
     async def store(self):
         """A short-lived Store for org-scoped operations (connections, KB)."""
         session = self._factory()
@@ -181,7 +190,11 @@ def derive_progress(run: dict) -> dict:
     return {
         "run_id": run["id"],
         "status": run.get("status"),
-        "phase": progress.get("phase") or ("finished" if run.get("status") in ("completed", "failed") else "preparing"),
+        "phase": progress.get("phase") or (
+            "finished"
+            if run.get("status") in ("completed", "failed", "cancelled")
+            else "preparing"
+        ),
         "done": progress.get("done", 0),
         "total": progress.get("total", 0),
         "active": progress.get("active", []),
@@ -645,6 +658,12 @@ async def execute_run(
     lease_task = asyncio.create_task(lease_loop())
     try:
         await _execute_run_inner(org_id, run_id, api_key)
+    except asyncio.CancelledError:
+        logger.info("eval run %s was cancelled", run_id)
+        try:
+            await mark_run_cancelled(org_id, run_id)
+        except Exception:
+            logger.exception("could not mark run %s cancelled", run_id)
     except Exception as exc:  # last-resort: the run row must never stay "running"
         logger.exception("eval run %s crashed", run_id)
         try:
@@ -663,6 +682,44 @@ async def execute_run(
             await db.update_run(lease_expires_at=None)
         except Exception:
             logger.warning("could not clear lease for run %s", run_id)
+
+
+async def mark_run_cancelled(org_id: str, run_id: str) -> None:
+    """Finish the persisted state for a run that no longer executes."""
+    db = RunDB(org_id, run_id)
+    finished_at = _now()
+    await db.cancel_open_tasks(finished_at)
+    run = await db.get_run()
+    tasks = list((run or {}).get("tasks") or [])
+    summary = {
+        "total": len(tasks),
+        "correct": sum(1 for task in tasks if task.get("verdict") == "CORRECT"),
+        "partial": sum(1 for task in tasks if task.get("verdict") == "PARTIAL"),
+        "off": sum(1 for task in tasks if task.get("verdict") == "OFF"),
+        "unknown": sum(1 for task in tasks if task.get("verdict") == "UNKNOWN"),
+        "ungraded": sum(1 for task in tasks if task.get("verdict") == "UNGRADED"),
+        "error": sum(1 for task in tasks if task.get("verdict") == "ERROR"),
+        "setup_failed": sum(1 for task in tasks if task.get("verdict") == "SETUP_FAILED"),
+        "cancelled": sum(1 for task in tasks if task.get("verdict") == "CANCELLED"),
+    }
+    progress = dict((run or {}).get("progress") or {})
+    progress.update(
+        {
+            "phase": "cancelled",
+            "done": len(tasks),
+            "total": len(tasks),
+            "active": [],
+            "updated_at": finished_at,
+        }
+    )
+    await db.update_run(
+        status="cancelled",
+        summary=summary,
+        progress=progress,
+        error=None,
+        finished_at=finished_at,
+        lease_expires_at=None,
+    )
 
 
 async def revoke_run_keys(org_id: str, run_id: str, api_key_id: str | None = None) -> None:
@@ -1035,6 +1092,7 @@ async def _run_task(ctx: TaskContext, task: EvalTask) -> None:
     transcript = ""
     verdict, check_results, answer, error = "ERROR", [], "", None
 
+    cancelled = False
     try:
         if task.task_class == "write":
             verdict, check_results, answer, transcript, error = await _run_write_task(ctx, task)
@@ -1046,6 +1104,11 @@ async def _run_task(ctx: TaskContext, task: EvalTask) -> None:
                 error = f"agent container exited {exit_code}"
             else:
                 verdict, check_results = _grade_answer(task, answer)
+    except asyncio.CancelledError:
+        cancelled = True
+        verdict = "CANCELLED"
+        answer = "Run cancelled by user."
+        raise
     except Exception as exc:
         logger.exception("task %s failed", task.id)
         from .sandboxes import redact
@@ -1060,7 +1123,7 @@ async def _run_task(ctx: TaskContext, task: EvalTask) -> None:
                 logger.exception("could not store transcript for %s", task.id)
         await db.update_task(
             task.id,
-            status="done",
+            status="cancelled" if cancelled else "done",
             verdict=verdict,
             check_results=check_results,
             answer=(answer or "")[:2000],

--- a/signalpilot/gateway/gateway/store/evals.py
+++ b/signalpilot/gateway/gateway/store/evals.py
@@ -35,6 +35,8 @@ TRACE_RUN_WINDOW = 100
 
 _CONFIG_FIELDS = (
     "repo_url",
+    "repo_installation_id",
+    "repo_id",
     "model",
     "max_tasks",
     "prompt_preamble",
@@ -48,6 +50,8 @@ def _config_dict(row: GatewayEvalConfig | None) -> dict[str, Any]:
     if row is None:
         return {
             "repo_url": "",
+            "repo_installation_id": None,
+            "repo_id": None,
             "model": "sonnet",
             "max_tasks": 0,
             "prompt_preamble": "",
@@ -57,6 +61,8 @@ def _config_dict(row: GatewayEvalConfig | None) -> dict[str, Any]:
         }
     return {
         "repo_url": row.repo_url,
+        "repo_installation_id": row.repo_installation_id,
+        "repo_id": row.repo_id,
         "model": row.model,
         "max_tasks": row.max_tasks,
         "prompt_preamble": row.prompt_preamble,

--- a/signalpilot/gateway/gateway/store/evals.py
+++ b/signalpilot/gateway/gateway/store/evals.py
@@ -258,7 +258,7 @@ async def list_live_runs(session: AsyncSession, *, org_id: str | None = None) ->
     Use the lease instead of status to determine whether a run is active.
     """
     stmt = select(GatewayEvalRun).where(
-        GatewayEvalRun.status.in_(("preparing", "running")),
+        GatewayEvalRun.status.in_(("preparing", "running", "cancelling")),
         GatewayEvalRun.lease_expires_at.is_not(None),
         GatewayEvalRun.lease_expires_at > time.time(),
     )
@@ -274,7 +274,7 @@ async def list_stale_runs(session: AsyncSession) -> list[dict[str, Any]]:
         (
             await session.execute(
                 select(GatewayEvalRun).where(
-                    GatewayEvalRun.status.in_(("preparing", "running")),
+                    GatewayEvalRun.status.in_(("preparing", "running", "cancelling")),
                     (GatewayEvalRun.lease_expires_at.is_(None))
                     | (GatewayEvalRun.lease_expires_at <= time.time()),
                 )
@@ -338,6 +338,29 @@ async def update_task(
             GatewayEvalRunTask.task_id == task_id,
         )
         .values(**fields)
+    )
+    await session.commit()
+
+
+async def cancel_open_tasks(
+    session: AsyncSession, *, org_id: str, run_id: str, finished_at: str
+) -> None:
+    """Mark every task that did not finish as cancelled."""
+    await session.execute(
+        update(GatewayEvalRunTask)
+        .where(
+            GatewayEvalRunTask.org_id == org_id,
+            GatewayEvalRunTask.run_id == run_id,
+            GatewayEvalRunTask.status.in_(("pending", "running")),
+        )
+        .values(
+            status="cancelled",
+            verdict="CANCELLED",
+            answer="Run cancelled by user.",
+            error=None,
+            finished_at=finished_at,
+            sandbox=None,
+        )
     )
     await session.commit()
 
@@ -447,6 +470,101 @@ async def list_accuracy(
         }
         for r in rows
     ]
+
+
+async def list_task_performance(
+    session: AsyncSession, *, org_id: str, limit_runs: int = 50
+) -> list[dict[str, Any]]:
+    """Aggregate recent completed task results for the accuracy page."""
+    run_ids = list(
+        (
+            await session.execute(
+                select(GatewayEvalRun.id)
+                .where(
+                    GatewayEvalRun.org_id == org_id,
+                    GatewayEvalRun.status.in_(("completed", "failed")),
+                )
+                .order_by(GatewayEvalRun.created_at.desc())
+                .limit(limit_runs)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not run_ids:
+        return []
+
+    rows = (
+        (
+            await session.execute(
+                select(GatewayEvalRunTask, GatewayEvalRun.created_at)
+                .join(
+                    GatewayEvalRun,
+                    (GatewayEvalRun.id == GatewayEvalRunTask.run_id)
+                    & (GatewayEvalRun.org_id == GatewayEvalRunTask.org_id),
+                )
+                .where(
+                    GatewayEvalRunTask.org_id == org_id,
+                    GatewayEvalRunTask.run_id.in_(run_ids),
+                    GatewayEvalRunTask.verdict.is_not(None),
+                    GatewayEvalRunTask.verdict != "CANCELLED",
+                )
+                .order_by(GatewayEvalRun.created_at.desc())
+            )
+        )
+        .all()
+    )
+    by_task: dict[str, dict[str, Any]] = {}
+    for task, _created_at in rows:
+        item = by_task.setdefault(
+            task.task_id,
+            {
+                "task_id": task.task_id,
+                "title": task.title,
+                "kind": task.kind,
+                "class": task.task_class,
+                "covers": sorted(set(task.covers or []) | set(task.builds or [])),
+                "attempts": 0,
+                "correct": 0,
+                "partial": 0,
+                "off": 0,
+                "errors": 0,
+                "duration_total_s": 0.0,
+                "duration_samples": 0,
+                "last_verdict": task.verdict,
+                "last_run_id": task.run_id,
+            },
+        )
+        item["attempts"] += 1
+        verdict = str(task.verdict or "").upper()
+        if verdict == "CORRECT":
+            item["correct"] += 1
+        elif verdict == "PARTIAL":
+            item["partial"] += 1
+        elif verdict in ("OFF", "UNKNOWN"):
+            item["off"] += 1
+        elif verdict in ("ERROR", "SETUP_FAILED"):
+            item["errors"] += 1
+        if task.duration_s is not None:
+            item["duration_total_s"] += float(task.duration_s)
+            item["duration_samples"] += 1
+
+    result = []
+    for item in by_task.values():
+        attempts = item.pop("attempts")
+        duration_total = item.pop("duration_total_s")
+        duration_samples = item.pop("duration_samples")
+        result.append(
+            {
+                **item,
+                "attempts": attempts,
+                "pass_rate_pct": round(item["correct"] / attempts * 100.0, 1),
+                "avg_duration_s": (
+                    round(duration_total / duration_samples, 1) if duration_samples else None
+                ),
+            }
+        )
+    return sorted(result, key=lambda item: (item["pass_rate_pct"], -item["attempts"], item["task_id"]))
 
 
 async def trailing_baseline(
@@ -578,7 +696,7 @@ async def runs_outside_window(
                     GatewayEvalRun.org_id == org_id,
                     col.is_(False),
                     GatewayEvalRun.id.not_in(keep),
-                    GatewayEvalRun.status.not_in(("preparing", "running")),
+                    GatewayEvalRun.status.not_in(("preparing", "running", "cancelling")),
                 )
             )
         )

--- a/signalpilot/gateway/gateway/store/store.py
+++ b/signalpilot/gateway/gateway/store/store.py
@@ -1504,3 +1504,11 @@ class Store:
 
         oid = self._require_org_id()
         return await evals.list_regressions(self.session, org_id=oid, limit=limit)
+
+    async def list_eval_task_performance(self, limit_runs: int = 50) -> list[dict]:
+        from . import evals
+
+        oid = self._require_org_id()
+        return await evals.list_task_performance(
+            self.session, org_id=oid, limit_runs=limit_runs
+        )

--- a/signalpilot/gateway/tests/e2e_cloud/routes.py
+++ b/signalpilot/gateway/tests/e2e_cloud/routes.py
@@ -25,6 +25,7 @@ ADMIN_PROBE_SKIP: frozenset[tuple[str, str]] = frozenset(
         ("POST", "/api/demo/connector"),  # provisions a real Xata branch
         ("POST", "/api/github/bot/scan"),  # calls the GitHub API
         ("POST", "/api/evals/runs"),  # can launch an eval runner
+        ("POST", "/api/evals/runs/{run_id}/cancel"),
     }
 )
 

--- a/signalpilot/gateway/tests/test_eval_coverage.py
+++ b/signalpilot/gateway/tests/test_eval_coverage.py
@@ -109,6 +109,10 @@ class TestComputeCoverage:
         )
         assert partial["declared"] == ["fct_orders"]
         assert partial["models_covered"] == 1
+        marts = {model["name"]: model for model in partial["models"]}
+        assert marts["fct_orders"]["declared_by"] == ["t1"]
+        assert marts["fct_orders"]["observed_by"] == ["t1"]
+        assert marts["fct_untouched"]["covered"] is False
 
         full = await coverage.compute_coverage(ORG, RUN, self._set(), self._models)
         assert full["declared"] == ["dim_users", "fct_orders", "fct_untouched"]

--- a/signalpilot/gateway/tests/test_eval_org_allowlist.py
+++ b/signalpilot/gateway/tests/test_eval_org_allowlist.py
@@ -157,6 +157,7 @@ EXPECTED_TIERS: dict[tuple[str, str], str] = {
     ("PUT", "/api/evals/config"): "admin",
     ("GET", "/api/evals/tasks"): "read",
     ("POST", "/api/evals/runs"): "admin",
+    ("POST", "/api/evals/runs/{run_id}/cancel"): "admin",
     ("GET", "/api/evals/runs"): "read",
     ("GET", "/api/evals/runs/{run_id}"): "read",
     ("GET", "/api/evals/runs/{run_id}/progress"): "read",

--- a/signalpilot/gateway/tests/test_eval_private_repo.py
+++ b/signalpilot/gateway/tests/test_eval_private_repo.py
@@ -1,0 +1,127 @@
+"""Verify private GitHub repository binding for evaluation sets."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from gateway.api.eval_runs import EvalConfig, _verify_private_eval_repo
+from gateway.evals import runner
+from gateway.store import github as github_store
+
+
+def _config(**updates) -> EvalConfig:
+    values = {
+        "repo_url": "https://github.com/acme/private-evals",
+        "repo_installation_id": "installation-1",
+        "repo_id": 42,
+        "connection": "warehouse",
+    }
+    values.update(updates)
+    return EvalConfig(**values)
+
+
+def test_private_binding_requires_both_identifiers() -> None:
+    with pytest.raises(ValidationError):
+        _config(repo_id=None)
+
+
+@pytest.mark.asyncio
+async def test_private_binding_verifies_repo_and_canonicalizes_url(monkeypatch) -> None:
+    installation = SimpleNamespace(status="active")
+
+    async def get_installation(*args, **kwargs):
+        return installation
+
+    async def get_valid_token(*args, **kwargs):
+        return "installation-token"
+
+    async def get_repos(token):
+        assert token == "installation-token"
+        return [{"id": 42, "full_name": "acme/private-evals"}]
+
+    monkeypatch.setattr(github_store, "get_installation", get_installation)
+    monkeypatch.setattr(github_store, "get_valid_token", get_valid_token)
+    monkeypatch.setattr("gateway.github_client.list_installation_repos", get_repos)
+    store = SimpleNamespace(session=object(), org_id="org-a")
+
+    verified = await _verify_private_eval_repo(store, _config())
+
+    assert verified.repo_url == "https://github.com/acme/private-evals.git"
+
+
+@pytest.mark.asyncio
+async def test_private_binding_rejects_repo_outside_installation(monkeypatch) -> None:
+    installation = SimpleNamespace(status="active")
+
+    async def get_installation(*args, **kwargs):
+        return installation
+
+    async def get_valid_token(*args, **kwargs):
+        return "installation-token"
+
+    async def get_repos(token):
+        return [{"id": 99, "full_name": "acme/other"}]
+
+    monkeypatch.setattr(github_store, "get_installation", get_installation)
+    monkeypatch.setattr(github_store, "get_valid_token", get_valid_token)
+    monkeypatch.setattr("gateway.github_client.list_installation_repos", get_repos)
+    store = SimpleNamespace(session=object(), org_id="org-a")
+
+    with pytest.raises(HTTPException) as exc:
+        await _verify_private_eval_repo(store, _config())
+
+    assert exc.value.status_code == 422
+
+
+class _SessionContext:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_clone_uses_only_the_bound_org_installation(monkeypatch) -> None:
+    installation = SimpleNamespace(status="active", authorized_repository_ids=[42])
+
+    async def get_installation(*args, **kwargs):
+        assert kwargs == {"org_id": "org-a", "installation_id": "installation-1"}
+        return installation
+
+    async def get_valid_token(*args, **kwargs):
+        return "bound-token"
+
+    monkeypatch.setattr(runner, "get_session_factory", lambda: lambda: _SessionContext())
+    monkeypatch.setattr(github_store, "get_installation", get_installation)
+    monkeypatch.setattr(github_store, "get_valid_token", get_valid_token)
+
+    clone_url = await runner._authed_clone_url(
+        "org-a",
+        "https://github.com/acme/private-evals.git",
+        repo_installation_id="installation-1",
+        repo_id=42,
+    )
+
+    assert clone_url == "https://x-access-token:bound-token@github.com/acme/private-evals.git"
+
+
+@pytest.mark.asyncio
+async def test_clone_rejects_repo_outside_captured_scope(monkeypatch) -> None:
+    installation = SimpleNamespace(status="active", authorized_repository_ids=[99])
+
+    async def get_installation(*args, **kwargs):
+        return installation
+
+    monkeypatch.setattr(runner, "get_session_factory", lambda: lambda: _SessionContext())
+    monkeypatch.setattr(github_store, "get_installation", get_installation)
+
+    with pytest.raises(runner.RepoRefused):
+        await runner._authed_clone_url(
+            "org-a",
+            "https://github.com/acme/private-evals.git",
+            repo_installation_id="installation-1",
+            repo_id=42,
+        )

--- a/signalpilot/gateway/tests/test_eval_runs_org_scoping.py
+++ b/signalpilot/gateway/tests/test_eval_runs_org_scoping.py
@@ -231,6 +231,14 @@ class TestEvalRouteOrgScoping:
         async with _client(session, "org-a") as client:
             assert (await client.get(f"/api/evals/runs/{RUN_A}/progress")).status_code == 200
 
+    async def test_cancel_cannot_reach_a_foreign_or_finished_run(self, session) -> None:
+        await _seed_run(session, "org-a", RUN_A)
+        async with _client(session, "org-b") as client:
+            assert (await client.post(f"/api/evals/runs/{RUN_A}/cancel")).status_code == 404
+        async with _client(session, "org-a") as client:
+            response = await client.post(f"/api/evals/runs/{RUN_A}/cancel")
+        assert response.status_code == 409
+
     async def test_transcript_keys_are_org_prefixed(self, session, fake_obj) -> None:
         """A foreign org asking for the same run/task reads its own (absent)
         key, never org-a's object."""
@@ -279,7 +287,7 @@ class TestEvalRouteOrgScoping:
         )
         async with _client(session, "org-b") as client:
             body = (await client.get("/api/evals/accuracy")).json()
-        assert body == {"history": [], "regressions": []}
+        assert body == {"history": [], "regressions": [], "task_performance": []}
 
     async def test_bad_run_id_is_rejected_before_any_lookup(self, session) -> None:
         async with _client(session, "org-a") as client:

--- a/signalpilot/gateway/tests/test_eval_store.py
+++ b/signalpilot/gateway/tests/test_eval_store.py
@@ -61,6 +61,8 @@ class TestConfig:
         cfg = await evals_store.get_config(session, org_id=ORG)
         assert cfg == {
             "repo_url": "",
+            "repo_installation_id": None,
+            "repo_id": None,
             "model": "sonnet",
             "max_tasks": 0,
             "prompt_preamble": "",
@@ -86,6 +88,19 @@ class TestConfig:
         assert cfg["notify_emails"] == ["a@example.com", "b@example.com"]
         # Untouched fields keep their defaults.
         assert cfg["model"] == "sonnet"
+
+    async def test_private_repo_binding_roundtrip(self, session) -> None:
+        saved = await evals_store.save_config(
+            session,
+            org_id=ORG,
+            cfg={
+                "repo_url": "https://github.com/acme/private-evals.git",
+                "repo_installation_id": "installation-1",
+                "repo_id": 42,
+            },
+        )
+        assert saved["repo_installation_id"] == "installation-1"
+        assert saved["repo_id"] == 42
 
     async def test_partial_update_keeps_other_fields(self, session) -> None:
         await evals_store.save_config(

--- a/signalpilot/gateway/tests/test_eval_store.py
+++ b/signalpilot/gateway/tests/test_eval_store.py
@@ -152,6 +152,43 @@ class TestRunsAndTasks:
         assert task["answer"] == "42"
         assert task["duration_s"] == 1.5
 
+    async def test_cancel_open_tasks_preserves_finished_tasks(self, session) -> None:
+        run_id = await _mk_run(session, 1, status="running")
+        await evals_store.seed_tasks(
+            session,
+            org_id=ORG,
+            run_id=run_id,
+            tasks=[{"task_id": "done"}, {"task_id": "active"}, {"task_id": "queued"}],
+        )
+        await evals_store.update_task(
+            session,
+            org_id=ORG,
+            run_id=run_id,
+            task_id="done",
+            status="done",
+            verdict="CORRECT",
+        )
+        await evals_store.update_task(
+            session,
+            org_id=ORG,
+            run_id=run_id,
+            task_id="active",
+            status="running",
+            sandbox={"name": "sandbox-1"},
+        )
+        await evals_store.cancel_open_tasks(
+            session,
+            org_id=ORG,
+            run_id=run_id,
+            finished_at="2026-01-01T00:00:05+00:00",
+        )
+        tasks = {task["id"]: task for task in await evals_store.get_tasks(session, org_id=ORG, run_id=run_id)}
+        assert tasks["done"]["verdict"] == "CORRECT"
+        assert tasks["active"]["status"] == "cancelled"
+        assert tasks["active"]["verdict"] == "CANCELLED"
+        assert tasks["active"]["sandbox"] is None
+        assert tasks["queued"]["status"] == "cancelled"
+
     async def test_list_runs_newest_first(self, session) -> None:
         for n in (1, 3, 2):
             await _mk_run(session, n)
@@ -251,6 +288,42 @@ class TestAccuracyHistory:
         assert [h["run_id"] for h in history] == [_run_id(2), _run_id(1)]
         assert history[0]["accuracy_pct"] == 80.0
         assert await evals_store.list_accuracy(session, org_id=OTHER) == []
+
+    async def test_task_performance_aggregates_recent_runs(self, session) -> None:
+        for number, verdict, duration in ((1, "CORRECT", 10.0), (2, "OFF", 20.0)):
+            run_id = await _mk_run(session, number, status="completed")
+            await evals_store.seed_tasks(
+                session,
+                org_id=ORG,
+                run_id=run_id,
+                tasks=[
+                    {
+                        "task_id": "q1",
+                        "title": "Revenue total",
+                        "task_class": "read",
+                        "covers": ["fct_revenue"],
+                    }
+                ],
+            )
+            await evals_store.update_task(
+                session,
+                org_id=ORG,
+                run_id=run_id,
+                task_id="q1",
+                status="done",
+                verdict=verdict,
+                duration_s=duration,
+            )
+        (performance,) = await evals_store.list_task_performance(session, org_id=ORG)
+        assert performance["task_id"] == "q1"
+        assert performance["attempts"] == 2
+        assert performance["correct"] == 1
+        assert performance["off"] == 1
+        assert performance["pass_rate_pct"] == 50.0
+        assert performance["avg_duration_s"] == 15.0
+        assert performance["last_verdict"] == "OFF"
+        assert performance["covers"] == ["fct_revenue"]
+        assert await evals_store.list_task_performance(session, org_id=OTHER) == []
 
     async def test_trailing_baseline_filters_ref_fingerprint_and_time(self, session) -> None:
         await evals_store.append_accuracy(session, org_id=ORG, entry=self._entry(1, acc=90))

--- a/signalpilot/web/app/evals/_components/ControlDeck.tsx
+++ b/signalpilot/web/app/evals/_components/ControlDeck.tsx
@@ -152,9 +152,21 @@ export function ControlDeck({
             <span className="label">{live ? "current phase" : "model"}</span>
             <strong>{live ? phase : model}</strong>
           </div>
-          <div className="ev-progress-dial" style={{ "--progress": `${percent * 3.6}deg` } as CSSProperties}>
-            <span>{live ? `${percent}%` : "GO"}</span>
-          </div>
+          {live ? (
+            <div className="ev-progress-dial" style={{ "--progress": `${percent * 3.6}deg` } as CSSProperties}>
+              <span>{percent}%</span>
+            </div>
+          ) : (
+            <button
+              onClick={runSuite}
+              disabled={!runnerEnabled || !repoUrl || starting}
+              className="ev-progress-dial ev-progress-launch"
+              aria-label="Run the full evaluation suite"
+              title="Run the full evaluation suite"
+            >
+              <span>{starting ? "..." : "RUN"}</span>
+            </button>
+          )}
         </div>
       </div>
 

--- a/signalpilot/web/app/evals/_components/ControlDeck.tsx
+++ b/signalpilot/web/app/evals/_components/ControlDeck.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import useSWR, { mutate } from "swr";
+import { BarChart3, FlaskConical, Loader2, Play, Settings2, Square } from "lucide-react";
+import { useState, type CSSProperties } from "react";
+import {
+  cancelEvalRun,
+  getEvalRunProgress,
+  startBaselineEvalRun,
+  type EvalRun,
+  type EvalSetInfo,
+} from "~/lib/api";
+import { useToast } from "~/components/ui/toast";
+
+type ControlDeckProps = {
+  evalSet?: EvalSetInfo;
+  repoUrl: string;
+  model: string;
+  runnerEnabled: boolean;
+  activeRun?: EvalRun;
+  onStarted: (runId: string) => void;
+  onConfigure: () => void;
+};
+
+const STAGES = ["queue", "sandbox", "grade", "evidence"];
+
+function stageIndex(phase: string, live: boolean): number {
+  if (phase === "preparing" || phase === "provisioning") return 0;
+  if (phase === "agent" || phase === "setup") return 1;
+  if (phase === "grading" || phase === "capture") return 2;
+  if (phase === "teardown" || phase === "finished") return 3;
+  return live ? 1 : -1;
+}
+
+function setName(repoUrl: string): string {
+  const tail = repoUrl.split("/").pop() || "Evaluation suite";
+  return tail.replace(/\.git$/, "");
+}
+
+export function ControlDeck({
+  evalSet,
+  repoUrl,
+  model,
+  runnerEnabled,
+  activeRun,
+  onStarted,
+  onConfigure,
+}: ControlDeckProps) {
+  const [starting, setStarting] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const { toast } = useToast();
+  const live = activeRun?.status === "preparing" || activeRun?.status === "running" || activeRun?.status === "cancelling";
+  const { data: progress } = useSWR(
+    live ? `eval-run-progress-${activeRun.id}` : null,
+    () => getEvalRunProgress(activeRun!.id),
+    { refreshInterval: 1500 },
+  );
+  const tasks = evalSet?.tasks ?? [];
+  const writes = tasks.filter((task) => task.class === "write").length;
+  const done = progress?.done ?? 0;
+  const total = progress?.total || tasks.length;
+  const percent = total ? Math.round((done / total) * 100) : 0;
+  const phase = progress?.active?.[0]?.phase ?? progress?.phase ?? (live ? "preparing" : "ready");
+  const currentStage = stageIndex(phase, Boolean(live));
+
+  async function runSuite() {
+    setStarting(true);
+    try {
+      const run = await startBaselineEvalRun();
+      await mutate("eval-runs");
+      onStarted(run.id);
+      toast(`eval run started: ${run.id}`, "success");
+    } catch (error) {
+      toast(`could not start run: ${error instanceof Error ? error.message : "unknown"}`, "error");
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function stopRun() {
+    if (!activeRun) return;
+    setStopping(true);
+    try {
+      await cancelEvalRun(activeRun.id);
+      await Promise.all([mutate("eval-runs"), mutate(`eval-run-${activeRun.id}`)]);
+      toast("eval cancellation requested", "success");
+    } catch (error) {
+      toast(`could not stop run: ${error instanceof Error ? error.message : "unknown"}`, "error");
+    } finally {
+      setStopping(false);
+    }
+  }
+
+  return (
+    <section className={`ev-command-stage ${live ? "is-live" : ""}`}>
+      <div className="ev-command-head">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2.5">
+            <FlaskConical className="w-4 h-4 text-[var(--color-success)]" strokeWidth={1.5} />
+            <h2>{evalSet?.name || setName(repoUrl)}</h2>
+            <span className={`ev-command-state ${live ? "is-live" : ""}`}>{live ? activeRun?.status : "ready"}</span>
+          </div>
+          <p>{repoUrl || "Configure an eval repository to begin"}</p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Link href="/evals/accuracy" className="ev-icon-command" title="Open agent accuracy" aria-label="Open agent accuracy">
+            <BarChart3 className="w-4 h-4" strokeWidth={1.5} />
+          </Link>
+          <button
+            onClick={runSuite}
+            disabled={!runnerEnabled || !repoUrl || starting || live}
+            className="ev-primary-command"
+          >
+            {starting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5" strokeWidth={1.5} />}
+            Run suite
+          </button>
+          {live && (
+            <button onClick={stopRun} disabled={stopping || activeRun?.status === "cancelling"} className="ev-stop-command">
+              {stopping || activeRun?.status === "cancelling" ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Square className="w-3.5 h-3.5" fill="currentColor" />}
+              {activeRun?.status === "cancelling" ? "Stopping" : "Stop run"}
+            </button>
+          )}
+          <button onClick={onConfigure} className="ev-secondary-command" title="Configure evals">
+            <Settings2 className="w-3.5 h-3.5" strokeWidth={1.5} />
+            Configure
+          </button>
+        </div>
+      </div>
+
+      <div className="ev-flightdeck" aria-label={live ? `Run ${percent}% complete` : "Evaluation execution stages"}>
+        <div className="ev-flightdeck-grid" aria-hidden="true" />
+        <div className="ev-stage-rail">
+          {STAGES.map((stage, index) => (
+            <div key={stage} className={`ev-stage-node ${currentStage === index ? "is-active" : ""} ${currentStage > index ? "is-done" : ""}`}>
+              <span className="ev-stage-signal" />
+              <span>{stage}</span>
+            </div>
+          ))}
+          {live && <span className="ev-run-pulse" />}
+        </div>
+        <div className="ev-flightdeck-readout">
+          <div>
+            <span className="label">{live ? "active run" : "suite"}</span>
+            <strong>{live ? activeRun?.id : `${tasks.length} tasks armed`}</strong>
+          </div>
+          <div>
+            <span className="label">{live ? "progress" : "execution"}</span>
+            <strong>{live ? `${done} / ${total}` : `${tasks.length - writes} read / ${writes} write`}</strong>
+          </div>
+          <div>
+            <span className="label">{live ? "current phase" : "model"}</span>
+            <strong>{live ? phase : model}</strong>
+          </div>
+          <div className="ev-progress-dial" style={{ "--progress": `${percent * 3.6}deg` } as CSSProperties}>
+            <span>{live ? `${percent}%` : "GO"}</span>
+          </div>
+        </div>
+      </div>
+
+      {!runnerEnabled && <p className="ev-command-error">Runner disabled: SP_EVAL_RUNNER_IMAGE is not set on the gateway.</p>}
+    </section>
+  );
+}

--- a/signalpilot/web/app/evals/_components/EvalOnboarding.tsx
+++ b/signalpilot/web/app/evals/_components/EvalOnboarding.tsx
@@ -11,10 +11,17 @@ import {
   Database,
   ExternalLink,
   FolderGit2,
+  Github,
+  Globe2,
+  HardDrive,
+  LockKeyhole,
   Loader2,
 } from "lucide-react";
 import {
   getConnections,
+  getGitHubInstallations,
+  getGitHubInstallUrl,
+  getGitHubRepos,
   putEvalConfig,
   type EvalConfig,
 } from "~/lib/api";
@@ -22,6 +29,8 @@ import { useToast } from "~/components/ui/toast";
 
 type Draft = {
   repo_url: string;
+  repo_installation_id: string | null;
+  repo_id: number | null;
   model: string;
   max_tasks: number;
   prompt_preamble: string;
@@ -29,6 +38,8 @@ type Draft = {
   notify_emails: string;
   autorun_on_knowledge_add: boolean;
 };
+
+type SourceKind = "public" | "private" | "mounted";
 
 const STEPS = [
   { label: "Eval set", icon: FolderGit2 },
@@ -39,6 +50,8 @@ const STEPS = [
 function initialDraft(config: EvalConfig): Draft {
   return {
     repo_url: config.repo_url ?? "",
+    repo_installation_id: config.repo_installation_id ?? null,
+    repo_id: config.repo_id ?? null,
     model: config.model || "sonnet",
     max_tasks: config.max_tasks ?? 0,
     prompt_preamble: config.prompt_preamble ?? "",
@@ -46,6 +59,12 @@ function initialDraft(config: EvalConfig): Draft {
     notify_emails: (config.notify_emails ?? []).join(", "),
     autorun_on_knowledge_add: config.autorun_on_knowledge_add ?? false,
   };
+}
+
+function initialSourceKind(config: EvalConfig): SourceKind {
+  if (config.repo_installation_id) return "private";
+  if (config.repo_url?.startsWith("/eval-projects/")) return "mounted";
+  return "public";
 }
 
 function sourceError(value: string): string | null {
@@ -59,11 +78,11 @@ function sourceError(value: string): string | null {
 
   try {
     const url = new URL(source);
-    if (url.protocol === "https:" && url.hostname && !url.username && !url.password) return null;
+    if (url.protocol === "https:" && url.hostname === "github.com" && !url.username && !url.password) return null;
   } catch {
     // The mounted-path format is checked before URL parsing.
   }
-  return "Use an HTTPS Git URL or a path under /eval-projects.";
+  return "Use a GitHub HTTPS URL or a path under /eval-projects.";
 }
 
 function emailError(value: string): string | null {
@@ -72,8 +91,10 @@ function emailError(value: string): string | null {
   return invalid ? `Check the email address: ${invalid}` : null;
 }
 
-function draftError(draft: Draft): string | null {
-  return sourceError(draft.repo_url)
+function draftError(draft: Draft, sourceKind: SourceKind): string | null {
+  return (sourceKind === "private" && (!draft.repo_installation_id || !draft.repo_id)
+    ? "Select a repository from a connected GitHub account."
+    : sourceError(draft.repo_url))
     || (!draft.connection ? "Select the warehouse connection used for grading." : null)
     || (draft.max_tasks < 0 || draft.max_tasks > 200 ? "Max tasks must be between 0 and 200." : null)
     || emailError(draft.notify_emails);
@@ -91,14 +112,27 @@ export function EvalOnboarding({
     "connections",
     getConnections,
   );
+  const { data: installations, isLoading: installationsLoading } = useSWR(
+    "github-installations",
+    getGitHubInstallations,
+  );
   const [step, setStep] = useState(0);
   const [furthestStep, setFurthestStep] = useState(0);
   const [draft, setDraft] = useState<Draft>(() => initialDraft(config));
+  const [sourceKind, setSourceKind] = useState<SourceKind>(() => initialSourceKind(config));
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [connectingGitHub, setConnectingGitHub] = useState(false);
+  const { data: githubRepos, isLoading: reposLoading } = useSWR(
+    sourceKind === "private" && draft.repo_installation_id
+      ? `github-repos-${draft.repo_installation_id}`
+      : null,
+    () => getGitHubRepos(draft.repo_installation_id as string),
+  );
 
   useEffect(() => {
     setDraft(initialDraft(config));
+    setSourceKind(initialSourceKind(config));
   }, [config]);
 
   const selectedConnection = useMemo(
@@ -107,7 +141,12 @@ export function EvalOnboarding({
   );
 
   function validateCurrentStep(): string | null {
-    if (step === 0) return sourceError(draft.repo_url);
+    if (step === 0) {
+      if (sourceKind === "private" && (!draft.repo_installation_id || !draft.repo_id)) {
+        return "Select a repository from a connected GitHub account.";
+      }
+      return sourceError(draft.repo_url);
+    }
     if (step === 1) {
       if (!draft.connection) return "Select the warehouse connection used for grading.";
       if (draft.max_tasks < 0 || draft.max_tasks > 200) return "Max tasks must be between 0 and 200.";
@@ -129,7 +168,7 @@ export function EvalOnboarding({
   }
 
   async function finish() {
-    const message = draftError(draft);
+    const message = draftError(draft, sourceKind);
     if (message) {
       setError(message);
       return;
@@ -140,6 +179,8 @@ export function EvalOnboarding({
     try {
       await putEvalConfig({
         repo_url: draft.repo_url.trim(),
+        repo_installation_id: sourceKind === "private" ? draft.repo_installation_id : null,
+        repo_id: sourceKind === "private" ? draft.repo_id : null,
         model: draft.model,
         max_tasks: draft.max_tasks,
         prompt_preamble: draft.prompt_preamble.trim(),
@@ -154,6 +195,32 @@ export function EvalOnboarding({
       setError(err instanceof Error ? err.message : "Could not save the eval configuration.");
     } finally {
       setSaving(false);
+    }
+  }
+
+  function chooseSourceKind(kind: SourceKind) {
+    if (kind === sourceKind) return;
+    setSourceKind(kind);
+    setDraft({
+      ...draft,
+      repo_url: "",
+      repo_installation_id: null,
+      repo_id: null,
+    });
+    setError(null);
+  }
+
+  async function connectGitHub() {
+    setConnectingGitHub(true);
+    setError(null);
+    try {
+      sessionStorage.setItem("sp_github_return_to", "/evals");
+      const { install_url } = await getGitHubInstallUrl();
+      window.location.assign(install_url);
+    } catch (err) {
+      sessionStorage.removeItem("sp_github_return_to");
+      setError(err instanceof Error ? err.message : "Could not start the GitHub connection.");
+      setConnectingGitHub(false);
     }
   }
 
@@ -199,22 +266,112 @@ export function EvalOnboarding({
               <span>01</span>
               <div>
                 <h2>Eval source</h2>
-                <p>Use a public Git repository or a mounted eval project.</p>
+                <p>Choose where SignalPilot reads the evaluation manifest and prompts.</p>
               </div>
             </div>
-            <label className="ev-onboarding-field">
-              <span>Repository</span>
-              <input
-                autoFocus
-                value={draft.repo_url}
-                onChange={(event) => {
-                  setDraft({ ...draft, repo_url: event.target.value });
-                  setError(null);
-                }}
-                placeholder="https://github.com/org/eval-set.git"
-              />
-              <small>Mounted projects must use /eval-projects/&lt;name&gt;.</small>
-            </label>
+            <div className="ev-source-kinds" role="group" aria-label="Repository access">
+              <button type="button" className={sourceKind === "public" ? "is-selected" : ""} onClick={() => chooseSourceKind("public")}>
+                <Globe2 /> <span><strong>Public GitHub</strong><small>Clone over HTTPS</small></span>
+              </button>
+              <button type="button" className={sourceKind === "private" ? "is-selected" : ""} onClick={() => chooseSourceKind("private")}>
+                <LockKeyhole /> <span><strong>Private GitHub</strong><small>Use the GitHub App</small></span>
+              </button>
+              <button type="button" className={sourceKind === "mounted" ? "is-selected" : ""} onClick={() => chooseSourceKind("mounted")}>
+                <HardDrive /> <span><strong>Mounted path</strong><small>Read from this host</small></span>
+              </button>
+            </div>
+
+            {sourceKind === "public" && (
+              <label className="ev-onboarding-field">
+                <span>Public repository URL</span>
+                <input
+                  autoFocus
+                  value={draft.repo_url}
+                  onChange={(event) => {
+                    setDraft({ ...draft, repo_url: event.target.value });
+                    setError(null);
+                  }}
+                  placeholder="https://github.com/org/eval-set.git"
+                />
+              </label>
+            )}
+
+            {sourceKind === "mounted" && (
+              <label className="ev-onboarding-field">
+                <span>Mounted project path</span>
+                <input
+                  autoFocus
+                  value={draft.repo_url}
+                  onChange={(event) => {
+                    setDraft({ ...draft, repo_url: event.target.value });
+                    setError(null);
+                  }}
+                  placeholder="/eval-projects/northwind"
+                />
+                <small>The path must remain under /eval-projects.</small>
+              </label>
+            )}
+
+            {sourceKind === "private" && (
+              <div className="ev-private-source">
+                {installationsLoading ? (
+                  <div className="ev-private-loading"><Loader2 className="animate-spin" /> Loading GitHub accounts...</div>
+                ) : installations?.length ? (
+                  <>
+                    <div className="ev-private-grid">
+                      <label className="ev-onboarding-field">
+                        <span>GitHub account</span>
+                        <select
+                          value={draft.repo_installation_id ?? ""}
+                          onChange={(event) => {
+                            setDraft({ ...draft, repo_installation_id: event.target.value || null, repo_id: null, repo_url: "" });
+                            setError(null);
+                          }}
+                        >
+                          <option value="">Select an account</option>
+                          {installations.map((installation) => (
+                            <option key={installation.id} value={installation.id}>{installation.github_account_login}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="ev-onboarding-field">
+                        <span>Repository</span>
+                        <select
+                          value={draft.repo_id ?? ""}
+                          disabled={!draft.repo_installation_id || reposLoading}
+                          onChange={(event) => {
+                            const repo = githubRepos?.find((item) => item.id === Number(event.target.value));
+                            setDraft({
+                              ...draft,
+                              repo_id: repo?.id ?? null,
+                              repo_url: repo ? `https://github.com/${repo.full_name}.git` : "",
+                            });
+                            setError(null);
+                          }}
+                        >
+                          <option value="">{reposLoading ? "Loading repositories..." : "Select a repository"}</option>
+                          {githubRepos?.map((repo) => (
+                            <option key={repo.id} value={repo.id}>{repo.full_name}{repo.private ? " (private)" : ""}</option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+                    <button type="button" className="ev-connect-github-secondary" disabled={connectingGitHub} onClick={connectGitHub}>
+                      <Github /> Connect another GitHub account
+                    </button>
+                  </>
+                ) : (
+                  <div className="ev-connect-github">
+                    <Github />
+                    <div><strong>Connect GitHub</strong><p>Choose the account and grant access to the repository that contains this eval set.</p></div>
+                    <button type="button" disabled={connectingGitHub} onClick={connectGitHub}>
+                      {connectingGitHub ? <Loader2 className="animate-spin" /> : <Github />}
+                      Connect GitHub
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
             <div className="ev-onboarding-manifest">
               <span><Check /> manifest</span>
               <span><Check /> prompts</span>

--- a/signalpilot/web/app/evals/_components/EvalOnboarding.tsx
+++ b/signalpilot/web/app/evals/_components/EvalOnboarding.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import useSWR, { mutate } from "swr";
+import {
+  ArrowLeft,
+  ArrowRight,
+  BellRing,
+  Check,
+  Database,
+  ExternalLink,
+  FolderGit2,
+  Loader2,
+} from "lucide-react";
+import {
+  getConnections,
+  putEvalConfig,
+  type EvalConfig,
+} from "~/lib/api";
+import { useToast } from "~/components/ui/toast";
+
+type Draft = {
+  repo_url: string;
+  model: string;
+  max_tasks: number;
+  prompt_preamble: string;
+  connection: string;
+  notify_emails: string;
+  autorun_on_knowledge_add: boolean;
+};
+
+const STEPS = [
+  { label: "Eval set", icon: FolderGit2 },
+  { label: "Runtime", icon: Database },
+  { label: "Automation", icon: BellRing },
+] as const;
+
+function initialDraft(config: EvalConfig): Draft {
+  return {
+    repo_url: config.repo_url ?? "",
+    model: config.model || "sonnet",
+    max_tasks: config.max_tasks ?? 0,
+    prompt_preamble: config.prompt_preamble ?? "",
+    connection: config.connection ?? "",
+    notify_emails: (config.notify_emails ?? []).join(", "),
+    autorun_on_knowledge_add: config.autorun_on_knowledge_add ?? false,
+  };
+}
+
+function sourceError(value: string): string | null {
+  const source = value.trim();
+  if (!source) return "Enter an eval repository.";
+  if (source.startsWith("/eval-projects/")) {
+    const segments = source.slice("/eval-projects/".length).split("/");
+    if (segments.every((segment) => segment && segment !== "." && segment !== "..")) return null;
+    return "Use a project path without empty, current-directory, or parent-directory segments.";
+  }
+
+  try {
+    const url = new URL(source);
+    if (url.protocol === "https:" && url.hostname && !url.username && !url.password) return null;
+  } catch {
+    // The mounted-path format is checked before URL parsing.
+  }
+  return "Use an HTTPS Git URL or a path under /eval-projects.";
+}
+
+function emailError(value: string): string | null {
+  const addresses = value.split(",").map((email) => email.trim()).filter(Boolean);
+  const invalid = addresses.find((email) => !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
+  return invalid ? `Check the email address: ${invalid}` : null;
+}
+
+function draftError(draft: Draft): string | null {
+  return sourceError(draft.repo_url)
+    || (!draft.connection ? "Select the warehouse connection used for grading." : null)
+    || (draft.max_tasks < 0 || draft.max_tasks > 200 ? "Max tasks must be between 0 and 200." : null)
+    || emailError(draft.notify_emails);
+}
+
+export function EvalOnboarding({
+  config,
+  onComplete,
+}: {
+  config: EvalConfig;
+  onComplete: () => void;
+}) {
+  const { toast } = useToast();
+  const { data: connections, error: connectionsError, isLoading: connectionsLoading } = useSWR(
+    "connections",
+    getConnections,
+  );
+  const [step, setStep] = useState(0);
+  const [furthestStep, setFurthestStep] = useState(0);
+  const [draft, setDraft] = useState<Draft>(() => initialDraft(config));
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setDraft(initialDraft(config));
+  }, [config]);
+
+  const selectedConnection = useMemo(
+    () => connections?.find((connection) => connection.name === draft.connection),
+    [connections, draft.connection],
+  );
+
+  function validateCurrentStep(): string | null {
+    if (step === 0) return sourceError(draft.repo_url);
+    if (step === 1) {
+      if (!draft.connection) return "Select the warehouse connection used for grading.";
+      if (draft.max_tasks < 0 || draft.max_tasks > 200) return "Max tasks must be between 0 and 200.";
+    }
+    if (step === 2) return emailError(draft.notify_emails);
+    return null;
+  }
+
+  function advance() {
+    const message = validateCurrentStep();
+    if (message) {
+      setError(message);
+      return;
+    }
+    const next = Math.min(step + 1, STEPS.length - 1);
+    setError(null);
+    setStep(next);
+    setFurthestStep((current) => Math.max(current, next));
+  }
+
+  async function finish() {
+    const message = draftError(draft);
+    if (message) {
+      setError(message);
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await putEvalConfig({
+        repo_url: draft.repo_url.trim(),
+        model: draft.model,
+        max_tasks: draft.max_tasks,
+        prompt_preamble: draft.prompt_preamble.trim(),
+        connection: draft.connection,
+        autorun_on_knowledge_add: draft.autorun_on_knowledge_add,
+        notify_emails: draft.notify_emails.split(",").map((email) => email.trim()).filter(Boolean),
+      });
+      await mutate("eval-config");
+      toast("eval set connected", "success");
+      onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save the eval configuration.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="ev-onboarding" aria-labelledby="eval-onboarding-title">
+      <header className="ev-onboarding-header">
+        <div>
+          <p className="ev-onboarding-kicker">Evaluation workspace</p>
+          <h1 id="eval-onboarding-title">Connect your eval set</h1>
+          <p>Pin the task repository, warehouse, and run policy.</p>
+        </div>
+        <span className="ev-onboarding-count">{step + 1} / {STEPS.length}</span>
+      </header>
+
+      <nav className="ev-onboarding-steps" aria-label="Setup progress">
+        {STEPS.map((item, index) => {
+          const Icon = item.icon;
+          const complete = index < step;
+          const available = index <= furthestStep;
+          return (
+            <button
+              key={item.label}
+              type="button"
+              className={index === step ? "is-current" : complete ? "is-complete" : ""}
+              disabled={!available || saving}
+              onClick={() => {
+                setStep(index);
+                setError(null);
+              }}
+              aria-current={index === step ? "step" : undefined}
+            >
+              <span>{complete ? <Check /> : <Icon />}</span>
+              {item.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="ev-onboarding-body">
+        {step === 0 && (
+          <div className="ev-onboarding-panel">
+            <div className="ev-onboarding-heading">
+              <span>01</span>
+              <div>
+                <h2>Eval source</h2>
+                <p>Use a public Git repository or a mounted eval project.</p>
+              </div>
+            </div>
+            <label className="ev-onboarding-field">
+              <span>Repository</span>
+              <input
+                autoFocus
+                value={draft.repo_url}
+                onChange={(event) => {
+                  setDraft({ ...draft, repo_url: event.target.value });
+                  setError(null);
+                }}
+                placeholder="https://github.com/org/eval-set.git"
+              />
+              <small>Mounted projects must use /eval-projects/&lt;name&gt;.</small>
+            </label>
+            <div className="ev-onboarding-manifest">
+              <span><Check /> manifest</span>
+              <span><Check /> prompts</span>
+              <code>eval-format.md</code>
+            </div>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div className="ev-onboarding-panel">
+            <div className="ev-onboarding-heading">
+              <span>02</span>
+              <div>
+                <h2>Grading runtime</h2>
+                <p>Choose the warehouse and execution limits for every run.</p>
+              </div>
+            </div>
+            <div className="ev-onboarding-grid">
+              <label className="ev-onboarding-field">
+                <span>Warehouse connection</span>
+                <select
+                  value={draft.connection}
+                  disabled={connectionsLoading || !connections?.length}
+                  onChange={(event) => {
+                    setDraft({ ...draft, connection: event.target.value });
+                    setError(null);
+                  }}
+                >
+                  <option value="">{connectionsLoading ? "Loading connections..." : "Select a connection"}</option>
+                  {connections?.map((connection) => (
+                    <option key={connection.id} value={connection.name}>
+                      {connection.name} ({connection.db_type})
+                    </option>
+                  ))}
+                </select>
+                {selectedConnection && (
+                  <small>{selectedConnection.database || selectedConnection.host || selectedConnection.db_type}</small>
+                )}
+              </label>
+              <label className="ev-onboarding-field">
+                <span>Model</span>
+                <select value={draft.model} onChange={(event) => setDraft({ ...draft, model: event.target.value })}>
+                  <option value="sonnet">Sonnet</option>
+                  <option value="opus">Opus</option>
+                  <option value="haiku">Haiku</option>
+                </select>
+              </label>
+              <label className="ev-onboarding-field">
+                <span>Max tasks per run</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={200}
+                  value={draft.max_tasks}
+                  onChange={(event) => setDraft({ ...draft, max_tasks: Number(event.target.value) || 0 })}
+                />
+                <small>Use 0 to run the complete set.</small>
+              </label>
+              <label className="ev-onboarding-field ev-onboarding-field-wide">
+                <span>Prompt preamble</span>
+                <textarea
+                  rows={3}
+                  value={draft.prompt_preamble}
+                  onChange={(event) => setDraft({ ...draft, prompt_preamble: event.target.value })}
+                  placeholder="Use the SignalPilot MCP tools with connection northwind_ro_conn."
+                />
+              </label>
+            </div>
+            {!connectionsLoading && !connections?.length && (
+              <div className="ev-onboarding-notice">
+                <span>{connectionsError ? "Connections could not be loaded." : "Add a warehouse connection before continuing."}</span>
+                <Link href="/connections">Open connections <ExternalLink /></Link>
+              </div>
+            )}
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="ev-onboarding-panel">
+            <div className="ev-onboarding-heading">
+              <span>03</span>
+              <div>
+                <h2>Run policy</h2>
+                <p>Set regression alerts and knowledge-triggered runs.</p>
+              </div>
+            </div>
+            <label className="ev-onboarding-field">
+              <span>Notify emails</span>
+              <input
+                value={draft.notify_emails}
+                onChange={(event) => {
+                  setDraft({ ...draft, notify_emails: event.target.value });
+                  setError(null);
+                }}
+                placeholder="data-team@acme.com, oncall@acme.com"
+              />
+              <small>Separate multiple addresses with commas.</small>
+            </label>
+            <label className="ev-onboarding-toggle">
+              <input
+                type="checkbox"
+                checked={draft.autorun_on_knowledge_add}
+                onChange={(event) => setDraft({ ...draft, autorun_on_knowledge_add: event.target.checked })}
+              />
+              <span aria-hidden="true" />
+              <div>
+                <strong>Autorun after knowledge changes</strong>
+                <small>Run the complete set after an entry is added. Changes coalesce for two minutes.</small>
+              </div>
+            </label>
+            <dl className="ev-onboarding-review">
+              <div><dt>Source</dt><dd>{draft.repo_url}</dd></div>
+              <div><dt>Connection</dt><dd>{draft.connection}</dd></div>
+              <div><dt>Runtime</dt><dd>{draft.model} / {draft.max_tasks === 0 ? "all tasks" : `${draft.max_tasks} tasks`}</dd></div>
+            </dl>
+          </div>
+        )}
+      </div>
+
+      <footer className="ev-onboarding-footer">
+        <div role="alert" aria-live="polite">{error}</div>
+        <div>
+          {step > 0 && (
+            <button type="button" className="ev-onboarding-back" disabled={saving} onClick={() => {
+              setStep((current) => current - 1);
+              setError(null);
+            }}>
+              <ArrowLeft /> Back
+            </button>
+          )}
+          {step < STEPS.length - 1 ? (
+            <button type="button" className="ev-onboarding-next" onClick={advance}>
+              Continue <ArrowRight />
+            </button>
+          ) : (
+            <button type="button" className="ev-onboarding-next" disabled={saving} onClick={finish}>
+              {saving ? <Loader2 className="animate-spin" /> : <Check />}
+              Connect eval set
+            </button>
+          )}
+        </div>
+      </footer>
+    </section>
+  );
+}

--- a/signalpilot/web/app/evals/accuracy/accuracy.css
+++ b/signalpilot/web/app/evals/accuracy/accuracy.css
@@ -1,0 +1,138 @@
+.acc-page { color: var(--color-text); }
+.acc-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.acc-back { display: inline-flex; align-items: center; gap: 0.45rem; height: 34px; padding: 0 0.75rem; border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text-muted); font-size: 12px; }
+.acc-back:hover { border-color: var(--color-border-hover); color: var(--color-text); }
+.acc-back svg { width: 14px; height: 14px; }
+.acc-overview { display: grid; grid-template-columns: minmax(320px, 1.2fr) minmax(520px, 1.8fr); border-top: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); }
+.acc-score { display: flex; align-items: center; gap: 1.5rem; padding: 2rem 2rem 2rem 0; border-right: 1px solid var(--color-border); }
+.acc-score-ring { --score: 0deg; flex: 0 0 auto; display: grid; width: 132px; height: 132px; place-items: center; border-radius: 50%; background: conic-gradient(var(--color-success) var(--score), var(--color-border) 0); position: relative; }
+.acc-score-ring::before { content: ""; position: absolute; inset: 8px; border-radius: inherit; background: var(--color-bg); }
+.acc-score-ring > div { position: relative; display: flex; align-items: baseline; }
+.acc-score-ring strong { font-size: 42px; font-weight: 550; line-height: 1; }
+.acc-score-ring span { color: var(--color-text-dim); font-size: 13px; }
+.acc-eyebrow { display: block; margin-bottom: 0.45rem; color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; }
+.acc-score h1 { max-width: 420px; font-size: 24px; font-weight: 580; line-height: 1.15; }
+.acc-score p, .acc-section-head p { margin-top: 0.5rem; color: var(--color-text-muted); font-size: 12px; line-height: 1.5; }
+.acc-metrics { display: grid; grid-template-columns: repeat(2, 1fr); }
+.acc-metric { padding: 1.3rem 1.5rem; border-bottom: 1px solid var(--color-border); }
+.acc-metric:nth-child(odd) { border-right: 1px solid var(--color-border); }
+.acc-metric:nth-child(n+3) { border-bottom: 0; }
+.acc-metric > span { display: block; color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; }
+.acc-metric strong { display: block; margin-top: 0.3rem; font-family: var(--font-mono, ui-monospace, monospace); font-size: 22px; font-weight: 500; }
+.acc-metric p { margin-top: 0.2rem; color: var(--color-text-dim); font-size: 10px; }
+.acc-metric.is-good strong { color: var(--color-success); }
+.acc-metric.is-bad strong { color: #e5484d; }
+.acc-insights { display: grid; grid-template-columns: 1.35fr repeat(3, 1fr); margin: 1.5rem 0 2.5rem; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-bg-card); }
+.acc-insight-lead, .acc-insight { min-width: 0; padding: 1rem 1.15rem; border-right: 1px solid var(--color-border); }
+.acc-insight:last-child { border-right: 0; }
+.acc-insight-lead { display: flex; align-items: center; gap: 0.8rem; }
+.acc-insight-lead svg { flex: 0 0 auto; width: 18px; color: var(--color-success); }
+.acc-insight span, .acc-insight-lead span { display: block; color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; }
+.acc-insight strong, .acc-insight-lead strong { display: block; margin-top: 0.28rem; overflow: hidden; color: var(--color-text); font-size: 12px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.acc-insight small { display: block; margin-top: 0.25rem; color: var(--color-text-dim); font-size: 10px; }
+.acc-section { margin: 0 0 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--color-border); }
+.acc-section-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
+.acc-section-head h2 { font-size: 17px; font-weight: 550; }
+.acc-trend { min-height: 390px; }
+.acc-tooltip { display: flex; flex-direction: column; gap: 0.2rem; padding: 0.7rem 0.8rem; border: 1px solid var(--color-border-hover); border-radius: 6px; background: var(--color-bg-card); font-size: 11px; }
+.acc-tooltip code, .acc-tooltip span { color: var(--color-text-dim); }
+.acc-tooltip strong { font-weight: 500; }
+.acc-legend { display: flex; align-items: center; gap: 1rem; color: var(--color-text-dim); font-size: 10px; }
+.acc-legend span { display: inline-flex; align-items: center; gap: 0.35rem; white-space: nowrap; }
+.acc-legend i { display: inline-block; width: 10px; height: 10px; border: 1px solid var(--color-border-hover); }
+.acc-legend i.accuracy { border: 0; border-top: 2px solid var(--color-success); }
+.acc-legend i.coverage { border: 0; border-top: 2px dashed #52a9a1; }
+.acc-legend i.regression { border: 0; border-radius: 50%; background: #e5484d; }
+.acc-legend i.declared { background: #4b739e; }
+.acc-legend i.observed { background: #52a9a1; }
+.acc-legend i.both { background: var(--color-success); }
+.acc-legend i.none { background: transparent; }
+.acc-chart-empty, .acc-empty, .acc-regression-empty { display: flex; align-items: center; gap: 0.75rem; min-height: 120px; color: var(--color-text-dim); font-size: 12px; }
+.acc-chart-empty { justify-content: center; min-height: 280px; }
+.acc-chart-empty svg, .acc-empty svg, .acc-regression-empty svg { width: 18px; }
+.acc-empty h2 { color: var(--color-text); font-size: 15px; }
+.acc-empty p { margin-top: 0.3rem; }
+.acc-search { display: flex; align-items: center; gap: 0.45rem; width: 190px; height: 32px; padding: 0 0.6rem; border: 1px solid var(--color-border); border-radius: 6px; }
+.acc-search:focus-within { border-color: var(--color-border-hover); }
+.acc-search svg { flex: 0 0 auto; width: 13px; color: var(--color-text-dim); }
+.acc-search input { min-width: 0; width: 100%; border: 0; outline: 0; background: transparent; color: var(--color-text); font-size: 11px; }
+.acc-coverage-summary { display: grid; grid-template-columns: 125px minmax(180px, 1fr) auto; align-items: center; gap: 1rem; padding: 0.9rem 1rem; border: 1px solid var(--color-border); border-radius: 6px; background: var(--color-bg-card); }
+.acc-coverage-number strong { display: block; font-family: var(--font-mono, ui-monospace, monospace); font-size: 20px; font-weight: 500; }
+.acc-coverage-number span { color: var(--color-text-dim); font-size: 9px; text-transform: uppercase; }
+.acc-coverage-track { height: 6px; overflow: hidden; background: var(--color-border); }
+.acc-coverage-track span { display: block; height: 100%; background: var(--color-success); transition: width 0.5s ease; }
+.acc-matrix-wrap { margin-top: 1rem; overflow-x: auto; border: 1px solid var(--color-border); border-radius: 6px; }
+.acc-matrix { --task-count: 1; min-width: calc(240px + var(--task-count) * 72px); background: var(--color-bg-card); }
+.acc-matrix-corner, .acc-matrix-row { display: grid; grid-template-columns: 240px repeat(var(--task-count), minmax(72px, 1fr)); }
+.acc-matrix-corner { position: absolute; width: 240px; height: 96px; align-items: end; padding: 0.8rem; border-right: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; }
+.acc-matrix-task { display: inline-flex; align-items: flex-end; justify-content: center; width: max(72px, calc((100% - 240px) / var(--task-count))); height: 96px; margin-left: 0; padding: 0.6rem 0.2rem; border-right: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); transform: translateX(240px); vertical-align: top; }
+.acc-matrix-task span { display: block; max-width: 84px; overflow: hidden; color: var(--color-text-dim); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; transform: rotate(-42deg); transform-origin: center; }
+.acc-matrix-row { min-height: 44px; border-bottom: 1px solid var(--color-border); }
+.acc-matrix-row:last-child { border-bottom: 0; }
+.acc-mart-name { display: flex; align-items: center; gap: 0.65rem; min-width: 0; padding: 0 0.8rem; border-right: 1px solid var(--color-border); }
+.acc-mart-name > span { width: 6px; height: 6px; border: 1px solid var(--color-border-hover); border-radius: 50%; }
+.acc-mart-name > span.is-covered { border-color: var(--color-success); background: var(--color-success); }
+.acc-mart-name code { overflow: hidden; color: var(--color-text); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.acc-matrix-cell { display: grid; place-items: center; border-right: 1px solid var(--color-border); }
+.acc-matrix-cell > span { width: 18px; height: 18px; border: 1px solid var(--color-border); border-radius: 3px; }
+.acc-matrix-cell > span.is-declared { border-color: #4b739e; background: #4b739e; }
+.acc-matrix-cell > span.is-observed { border-color: #52a9a1; background: #52a9a1; }
+.acc-matrix-cell > span.is-both { border-color: var(--color-success); background: var(--color-success); box-shadow: 0 0 10px color-mix(in srgb, var(--color-success) 30%, transparent); }
+.acc-table-tools { display: flex; align-items: center; gap: 0.65rem; }
+.acc-segments { display: inline-flex; height: 32px; overflow: hidden; border: 1px solid var(--color-border); border-radius: 6px; }
+.acc-segments button { padding: 0 0.65rem; border-right: 1px solid var(--color-border); color: var(--color-text-dim); font-size: 10px; text-transform: uppercase; }
+.acc-segments button:last-child { border-right: 0; }
+.acc-segments button.is-on { background: var(--color-bg-card); color: var(--color-text); }
+.acc-task-table { border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+.acc-task-head, .acc-task-row { display: grid; grid-template-columns: minmax(240px, 1.5fr) minmax(150px, 0.8fr) minmax(190px, 1fr) 90px 90px; align-items: center; gap: 1rem; padding: 0.7rem 1rem; }
+.acc-task-head { border-bottom: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; }
+.acc-task-row { min-height: 62px; border-bottom: 1px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }
+.acc-task-row:last-child { border-bottom: 0; }
+.acc-task-row:hover { background: var(--color-bg-card); }
+.acc-task-row > div:first-child { min-width: 0; }
+.acc-task-row > div:first-child strong, .acc-task-row > div:first-child code { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.acc-task-row > div:first-child strong { color: var(--color-text); font-size: 12px; font-weight: 500; }
+.acc-task-row > div:first-child code { margin-top: 0.2rem; color: var(--color-text-dim); font-size: 9px; }
+.acc-rate { display: flex; align-items: center; gap: 0.6rem; }
+.acc-rate > span { flex: 1; height: 4px; background: var(--color-border); }
+.acc-rate i { display: block; height: 100%; background: var(--color-success); }
+.acc-rate strong { width: 34px; color: var(--color-text); font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; font-weight: 500; }
+.acc-outcomes { display: flex; gap: 0.55rem; color: var(--color-text-dim); }
+.acc-outcomes .good { color: var(--color-success); }
+.acc-outcomes .bad { color: #e5484d; }
+.acc-verdict { justify-self: start; padding: 0.15rem 0.4rem; border: 1px solid var(--color-border); border-radius: 4px; font-size: 9px; text-transform: uppercase; }
+.acc-verdict.is-correct { color: var(--color-success); border-color: color-mix(in srgb, var(--color-success) 45%, transparent); }
+.acc-verdict.is-off, .acc-verdict.is-error, .acc-verdict.is-setup_failed { color: #e5484d; border-color: color-mix(in srgb, #e5484d 45%, transparent); }
+.acc-no-results { padding: 1rem; color: var(--color-text-dim); font-size: 11px; }
+.acc-regressions { border-top: 1px solid var(--color-border); }
+.acc-regression-row { display: grid; grid-template-columns: 24px minmax(220px, 1fr) auto 90px 18px; align-items: center; gap: 0.8rem; min-height: 64px; border-bottom: 1px solid var(--color-border); color: var(--color-text-dim); }
+.acc-regression-row > svg:first-child { width: 15px; color: #e5484d; }
+.acc-regression-row > svg:last-child { width: 13px; }
+.acc-regression-row strong, .acc-regression-row span { display: block; }
+.acc-regression-row strong { color: var(--color-text); font-size: 12px; font-weight: 500; }
+.acc-regression-row span { margin-top: 0.2rem; font-size: 10px; }
+.acc-regression-row code, .acc-regression-row time { font-size: 10px; }
+@media (max-width: 1050px) {
+  .acc-overview { grid-template-columns: 1fr; }
+  .acc-score { border-right: 0; border-bottom: 1px solid var(--color-border); }
+  .acc-insights { grid-template-columns: 1fr 1fr; }
+  .acc-insight-lead, .acc-insight { border-bottom: 1px solid var(--color-border); }
+  .acc-insight:nth-child(2) { border-right: 0; }
+  .acc-task-table { overflow-x: auto; }
+  .acc-task-head, .acc-task-row { min-width: 900px; }
+}
+@media (max-width: 700px) {
+  .acc-page { padding: 1.25rem; }
+  .acc-title-row, .acc-section-head { align-items: flex-start; flex-direction: column; }
+  .acc-score { align-items: flex-start; padding-right: 0; }
+  .acc-score-ring { width: 100px; height: 100px; }
+  .acc-score-ring strong { font-size: 32px; }
+  .acc-metrics, .acc-insights { grid-template-columns: 1fr; }
+  .acc-metric, .acc-metric:nth-child(odd), .acc-insight, .acc-insight-lead { border-right: 0; border-bottom: 1px solid var(--color-border); }
+  .acc-metric:last-child, .acc-insight:last-child { border-bottom: 0; }
+  .acc-coverage-summary { grid-template-columns: 1fr; }
+  .acc-table-tools { align-items: stretch; flex-direction: column; width: 100%; }
+  .acc-search { width: 100%; }
+  .acc-regression-row { grid-template-columns: 20px 1fr 16px; }
+  .acc-regression-row code, .acc-regression-row time { display: none; }
+}

--- a/signalpilot/web/app/evals/accuracy/page.tsx
+++ b/signalpilot/web/app/evals/accuracy/page.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState, type CSSProperties } from "react";
+import useSWR from "swr";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowUpRight,
+  CircleDot,
+  Grid3X3,
+  Search,
+  ShieldCheck,
+  TrendingDown,
+  TrendingUp,
+} from "lucide-react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  getEvalAccuracy,
+  getEvalAvailability,
+  listEvalRuns,
+  listEvalTasks,
+  type EvalCoverageModel,
+  type EvalRegression,
+  type EvalTask,
+  type EvalTaskPerformance,
+} from "~/lib/api";
+import { PageHeader } from "~/components/ui/page-header";
+import "../evals.css";
+import "./accuracy.css";
+
+type TrendPoint = {
+  run_id: string;
+  label: string;
+  accuracy: number;
+  coverage: number | null;
+  regressed: boolean;
+  passed: number;
+  total: number;
+};
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds == null) return "no data";
+  if (seconds < 60) return `${seconds.toFixed(0)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+}
+
+function TrendTooltip({ active, payload }: { active?: boolean; payload?: Array<{ payload: TrendPoint }> }) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0].payload;
+  return (
+    <div className="acc-tooltip">
+      <code>{point.run_id}</code>
+      <strong>{point.accuracy.toFixed(1)}% accuracy</strong>
+      <span>{point.passed}/{point.total} tasks passed</span>
+      {point.coverage != null && <span>{point.coverage.toFixed(1)}% mart coverage</span>}
+    </div>
+  );
+}
+
+function Metric({ label, value, note, tone = "default" }: { label: string; value: string; note: string; tone?: "default" | "good" | "bad" }) {
+  return (
+    <div className={`acc-metric is-${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <p>{note}</p>
+    </div>
+  );
+}
+
+function InsightStrip({ tasks, latest, baseline, regression }: {
+  tasks: EvalTaskPerformance[];
+  latest: number | null;
+  baseline: number | null;
+  regression?: EvalRegression;
+}) {
+  const strongest = [...tasks].sort((a, b) => b.pass_rate_pct - a.pass_rate_pct || b.attempts - a.attempts)[0];
+  const weakest = tasks.find((task) => task.attempts >= 2) ?? tasks[0];
+  const delta = latest != null && baseline != null ? latest - baseline : null;
+  return (
+    <section className="acc-insights" aria-label="Performance insights">
+      <div className="acc-insight-lead">
+        {delta == null ? <CircleDot /> : delta >= 0 ? <TrendingUp /> : <TrendingDown />}
+        <div>
+          <span>Current signal</span>
+          <strong>
+            {delta == null
+              ? "Establishing a comparable baseline"
+              : delta >= 0
+                ? `${delta.toFixed(1)} points above the trailing median`
+                : `${Math.abs(delta).toFixed(1)} points below the trailing median`}
+          </strong>
+        </div>
+      </div>
+      <div className="acc-insight">
+        <span>Most reliable</span>
+        <strong>{strongest?.title || "Awaiting task history"}</strong>
+        {strongest && <small>{strongest.pass_rate_pct.toFixed(0)}% across {strongest.attempts} attempts</small>}
+      </div>
+      <div className="acc-insight">
+        <span>Needs attention</span>
+        <strong>{weakest?.title || "Awaiting task history"}</strong>
+        {weakest && <small>{weakest.pass_rate_pct.toFixed(0)}% pass rate</small>}
+      </div>
+      <div className="acc-insight">
+        <span>Regression watch</span>
+        <strong>{regression ? `${regression.drop_pct.toFixed(1)} point drop` : "No detected regression"}</strong>
+        <small>{regression ? `${regression.flipped_tasks.length} tasks flipped` : "Latest comparable run is stable"}</small>
+      </div>
+    </section>
+  );
+}
+
+function MartCoverage({ models, tasks }: { models: EvalCoverageModel[]; tasks: EvalTask[] }) {
+  const [query, setQuery] = useState("");
+  const marts = useMemo(
+    () => models.filter((model) => model.layer === "marts" && model.name.toLowerCase().includes(query.toLowerCase().trim())),
+    [models, query],
+  );
+  const taskMap = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
+  const taskIds = useMemo(() => {
+    const ids = new Set<string>();
+    models.filter((model) => model.layer === "marts").forEach((model) => {
+      model.declared_by.forEach((id) => ids.add(id));
+      model.observed_by.forEach((id) => ids.add(id));
+    });
+    return [...ids].sort();
+  }, [models]);
+  const covered = models.filter((model) => model.layer === "marts" && model.covered).length;
+  const total = models.filter((model) => model.layer === "marts").length;
+
+  if (!total) {
+    return (
+      <section className="acc-section acc-empty">
+        <Grid3X3 />
+        <div>
+          <h2>Mart coverage map</h2>
+          <p>Complete a run with a connected dbt project to map marts to the tasks that declare or observe them.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="acc-section">
+      <div className="acc-section-head">
+        <div>
+          <span className="acc-eyebrow">Coverage topology</span>
+          <h2>Which tests protect each mart</h2>
+          <p>{covered} of {total} marts have declared or observed eval coverage.</p>
+        </div>
+        <div className="acc-search">
+          <Search aria-hidden="true" />
+          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Filter marts" aria-label="Filter marts" />
+        </div>
+      </div>
+
+      <div className="acc-coverage-summary">
+        <div className="acc-coverage-number"><strong>{total ? Math.round(covered / total * 100) : 0}%</strong><span>mart coverage</span></div>
+        <div className="acc-coverage-track"><span style={{ width: `${total ? covered / total * 100 : 0}%` }} /></div>
+        <div className="acc-legend">
+          <span><i className="declared" /> declared</span>
+          <span><i className="observed" /> observed</span>
+          <span><i className="both" /> both</span>
+          <span><i className="none" /> uncovered</span>
+        </div>
+      </div>
+
+      <div className="acc-matrix-wrap">
+        <div className="acc-matrix" style={{ "--task-count": Math.max(taskIds.length, 1) } as CSSProperties}>
+          <div className="acc-matrix-corner">mart / eval task</div>
+          {taskIds.map((taskId) => (
+            <div className="acc-matrix-task" key={taskId} title={taskMap.get(taskId)?.title || taskId}>
+              <span>{taskMap.get(taskId)?.title || taskId}</span>
+            </div>
+          ))}
+          {marts.map((mart) => (
+            <div className="acc-matrix-row" key={mart.name}>
+              <div className="acc-mart-name">
+                <span className={mart.covered ? "is-covered" : ""} />
+                <code>{mart.name}</code>
+              </div>
+              {taskIds.map((taskId) => {
+                const declared = mart.declared_by.includes(taskId);
+                const observed = mart.observed_by.includes(taskId);
+                const state = declared && observed ? "both" : declared ? "declared" : observed ? "observed" : "none";
+                return (
+                  <div className="acc-matrix-cell" key={taskId} title={`${mart.name} / ${taskMap.get(taskId)?.title || taskId}: ${state}`}>
+                    <span className={`is-${state}`} />
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+      {marts.length === 0 && <p className="acc-no-results">No marts match “{query}”.</p>}
+    </section>
+  );
+}
+
+function TaskReliability({ tasks }: { tasks: EvalTaskPerformance[] }) {
+  const [query, setQuery] = useState("");
+  const [classFilter, setClassFilter] = useState<"all" | "read" | "write">("all");
+  const filtered = tasks.filter((task) => {
+    if (classFilter !== "all" && task.class !== classFilter) return false;
+    const needle = query.trim().toLowerCase();
+    return !needle || task.title.toLowerCase().includes(needle) || task.task_id.toLowerCase().includes(needle);
+  });
+  return (
+    <section className="acc-section">
+      <div className="acc-section-head">
+        <div>
+          <span className="acc-eyebrow">Task reliability</span>
+          <h2>Where the agent succeeds and fails</h2>
+          <p>Pass rates use the most recent 50 completed or failed runs.</p>
+        </div>
+        <div className="acc-table-tools">
+          <div className="acc-segments" aria-label="Filter by task class">
+            {(["all", "read", "write"] as const).map((value) => <button key={value} className={classFilter === value ? "is-on" : ""} onClick={() => setClassFilter(value)}>{value}</button>)}
+          </div>
+          <div className="acc-search"><Search /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Find a task" aria-label="Find a task" /></div>
+        </div>
+      </div>
+      <div className="acc-task-table">
+        <div className="acc-task-head"><span>task</span><span>reliability</span><span>outcomes</span><span>mean time</span><span>latest</span></div>
+        {filtered.map((task) => (
+          <Link href={`/evals?run=${task.last_run_id}`} className="acc-task-row" key={task.task_id}>
+            <div><strong>{task.title}</strong><code>{task.task_id}</code></div>
+            <div className="acc-rate"><span><i style={{ width: `${task.pass_rate_pct}%` }} /></span><strong>{task.pass_rate_pct.toFixed(0)}%</strong></div>
+            <div className="acc-outcomes"><span className="good">{task.correct} pass</span><span>{task.partial} partial</span><span className="bad">{task.off + task.errors} fail</span></div>
+            <span>{formatDuration(task.avg_duration_s)}</span>
+            <span className={`acc-verdict is-${task.last_verdict.toLowerCase()}`}>{task.last_verdict.toLowerCase()}</span>
+          </Link>
+        ))}
+      </div>
+      {!filtered.length && <p className="acc-no-results">No tasks match the selected filters.</p>}
+    </section>
+  );
+}
+
+export default function AccuracyPage() {
+  const { data: availability, isLoading } = useSWR("eval-availability", getEvalAvailability);
+  const enabled = availability?.enabled === true;
+  const { data: accuracy } = useSWR(enabled ? "eval-accuracy" : null, getEvalAccuracy, { refreshInterval: 30000 });
+  const { data: runs } = useSWR(enabled ? "eval-runs" : null, listEvalRuns);
+  const { data: evalSet } = useSWR(enabled ? "eval-tasks-accuracy" : null, listEvalTasks);
+  const history = useMemo(
+    () => [...(accuracy?.history ?? [])].sort((a, b) => b.created_at.localeCompare(a.created_at)),
+    [accuracy],
+  );
+  const regressions = useMemo(() => accuracy?.regressions ?? [], [accuracy]);
+  const taskPerformance = useMemo(() => accuracy?.task_performance ?? [], [accuracy]);
+  const latest = history[0];
+  const baseline = median(history.slice(1, 6).map((point) => point.accuracy_pct));
+  const delta = latest && baseline != null ? latest.accuracy_pct - baseline : null;
+  const latestCoverageRun = runs?.runs.find((run) => run.coverage?.models?.length);
+  const coverageModels = latestCoverageRun?.coverage?.models ?? [];
+  const martCoverage = latestCoverageRun?.coverage?.marts_pct ?? latest?.coverage_pct ?? null;
+  const averageDuration = median(taskPerformance.map((task) => task.avg_duration_s).filter((value): value is number => value != null));
+  const points = useMemo<TrendPoint[]>(() => {
+    const regressedRuns = new Set(regressions.map((regression) => regression.run_id));
+    return [...history].reverse().map((point) => ({
+      run_id: point.run_id,
+      label: new Date(point.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+      accuracy: point.accuracy_pct,
+      coverage: point.coverage_pct,
+      regressed: regressedRuns.has(point.run_id),
+      passed: point.tasks_passed,
+      total: point.tasks_total,
+    }));
+  }, [history, regressions]);
+
+  if (isLoading || !availability) return <div className="min-h-screen p-8 text-sm text-[var(--color-text-dim)]">Loading accuracy...</div>;
+  if (!enabled) return <div className="min-h-screen p-8"><PageHeader title="accuracy" subtitle="evals" description="agent performance and dbt mart coverage" /><p className="text-sm text-[var(--color-text-muted)]">Evals are not enabled for this workspace.</p></div>;
+
+  return (
+    <main className="min-h-screen p-8 animate-fade-in acc-page">
+      <div className="acc-title-row">
+        <PageHeader title="accuracy" subtitle="evals" description="agent performance, regressions, and dbt mart coverage" />
+        <Link href="/evals" className="acc-back"><ArrowLeft /> Eval control</Link>
+      </div>
+
+      <section className="acc-overview">
+        <div className="acc-score">
+          <div className="acc-score-ring" style={{ "--score": `${(latest?.accuracy_pct ?? 0) * 3.6}deg` } as CSSProperties}>
+            <div><strong>{latest ? latest.accuracy_pct.toFixed(0) : "--"}</strong><span>%</span></div>
+          </div>
+          <div>
+            <span className="acc-eyebrow">Agent confidence</span>
+            <h1>{latest ? (latest.accuracy_pct >= 90 ? "Production-ready signal" : latest.accuracy_pct >= 75 ? "Stable with visible gaps" : "Intervention recommended") : "Awaiting the first run"}</h1>
+            <p>{latest ? `${latest.tasks_passed} of ${latest.tasks_total} graded tasks passed in the latest run.` : "Run the evaluation suite to establish a performance baseline."}</p>
+          </div>
+        </div>
+        <div className="acc-metrics">
+          <Metric label="vs trailing median" value={delta == null ? "--" : `${delta >= 0 ? "+" : ""}${delta.toFixed(1)} pt`} note={baseline == null ? "Needs two comparable runs" : `${baseline.toFixed(1)}% trailing median`} tone={delta == null ? "default" : delta >= 0 ? "good" : "bad"} />
+          <Metric label="mart coverage" value={martCoverage == null ? "--" : `${martCoverage.toFixed(0)}%`} note={coverageModels.length ? `${coverageModels.filter((model) => model.layer === "marts" && model.covered).length} covered marts` : "Complete a project-backed run"} />
+          <Metric label="task latency" value={formatDuration(averageDuration)} note="Median of task mean times" />
+          <Metric label="regressions" value={String(regressions.length)} note={regressions.length ? "Detected in retained history" : "No drops detected"} tone={regressions.length ? "bad" : "good"} />
+        </div>
+      </section>
+
+      <InsightStrip tasks={taskPerformance} latest={latest?.accuracy_pct ?? null} baseline={baseline} regression={regressions[0]} />
+
+      <section className="acc-section acc-trend">
+        <div className="acc-section-head">
+          <div><span className="acc-eyebrow">Performance history</span><h2>Accuracy and mart coverage</h2><p>Regression markers identify statistically comparable drops.</p></div>
+          <div className="acc-legend"><span><i className="accuracy" /> accuracy</span><span><i className="coverage" /> coverage</span><span><i className="regression" /> regression</span></div>
+        </div>
+        {points.length < 2 ? <div className="acc-chart-empty"><TrendingUp /><span>Two completed runs are required for a trend.</span></div> : (
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={points} margin={{ top: 10, right: 10, left: -15, bottom: 0 }}>
+              <CartesianGrid stroke="var(--color-border)" strokeDasharray="2 6" vertical={false} />
+              <XAxis dataKey="label" tick={{ fontSize: 10, fill: "var(--color-text-dim)" }} tickLine={false} axisLine={false} />
+              <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "var(--color-text-dim)" }} tickLine={false} axisLine={false} />
+              <Tooltip content={<TrendTooltip />} cursor={{ stroke: "var(--color-border-hover)" }} />
+              <Line type="monotone" dataKey="coverage" stroke="#52a9a1" strokeDasharray="5 5" strokeWidth={1.5} dot={false} connectNulls isAnimationActive />
+              <Line type="monotone" dataKey="accuracy" stroke="var(--color-success)" strokeWidth={2} dot={(props) => { const point = props.payload as TrendPoint; return <circle key={`${props.cx}-${props.cy}`} cx={props.cx} cy={props.cy} r={point.regressed ? 5 : 3} fill={point.regressed ? "#e5484d" : "var(--color-success)"} />; }} isAnimationActive />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </section>
+
+      <MartCoverage models={coverageModels} tasks={evalSet?.tasks ?? []} />
+      <TaskReliability tasks={taskPerformance} />
+
+      <section className="acc-section">
+        <div className="acc-section-head"><div><span className="acc-eyebrow">Regression ledger</span><h2>Detected performance drops</h2><p>Attribution names a knowledge entry only when it is the sole changed input.</p></div></div>
+        <div className="acc-regressions">
+          {!regressions.length && <div className="acc-regression-empty"><ShieldCheck /><span>No regressions detected.</span></div>}
+          {regressions.map((regression) => (
+            <Link href={`/evals?run=${regression.run_id}`} key={regression.id} className="acc-regression-row">
+              <AlertTriangle />
+              <div><strong>{regression.drop_pct.toFixed(1)} point accuracy drop</strong><span>{regression.flipped_tasks.length} tasks flipped{regression.sole_change && regression.suspected_doc_ids[0] ? ` after ${regression.suspected_doc_ids[0]}` : ""}</span></div>
+              <code>{regression.run_id}</code>
+              <time>{new Date(regression.created_at).toLocaleDateString()}</time>
+              <ArrowUpRight />
+            </Link>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/signalpilot/web/app/evals/evals.css
+++ b/signalpilot/web/app/evals/evals.css
@@ -1,6 +1,74 @@
 /* These styles apply only to the evaluation management page.
    The styles use the tokens, radii, labels, and evidence fonts from UX.md. */
 
+.ev-command-stage {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--color-border-hover);
+  border-radius: 8px;
+  background: var(--color-bg-card);
+}
+.ev-command-stage.is-live { border-color: color-mix(in srgb, var(--color-success) 55%, var(--color-border)); }
+.ev-command-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+.ev-command-head h2 { color: var(--color-text); font-size: 15px; font-weight: 600; }
+.ev-command-head p { margin-top: 0.25rem; color: var(--color-text-dim); font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ev-command-state { padding: 0.15rem 0.45rem; border: 1px solid var(--color-border); border-radius: 4px; color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; }
+.ev-command-state.is-live { border-color: color-mix(in srgb, var(--color-success) 50%, transparent); color: var(--color-success); }
+.ev-primary-command, .ev-secondary-command, .ev-stop-command, .ev-icon-command {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  height: 34px;
+  border-radius: 6px;
+  padding: 0 0.8rem;
+  font-size: 12px;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.ev-primary-command { border: 1px solid color-mix(in srgb, var(--color-success) 65%, var(--color-border)); background: color-mix(in srgb, var(--color-success) 10%, var(--color-bg-card)); color: var(--color-text); }
+.ev-primary-command:hover:not(:disabled) { background: color-mix(in srgb, var(--color-success) 17%, var(--color-bg-card)); }
+.ev-primary-command:disabled, .ev-stop-command:disabled { cursor: not-allowed; opacity: 0.45; }
+.ev-secondary-command, .ev-icon-command { border: 1px solid var(--color-border); color: var(--color-text-muted); }
+.ev-secondary-command:hover, .ev-icon-command:hover { border-color: var(--color-border-hover); color: var(--color-text); }
+.ev-icon-command { width: 34px; padding: 0; }
+.ev-stop-command { border: 1px solid color-mix(in srgb, #e5484d 58%, var(--color-border)); background: color-mix(in srgb, #e5484d 8%, var(--color-bg-card)); color: #f07178; }
+.ev-stop-command:hover:not(:disabled) { background: color-mix(in srgb, #e5484d 15%, var(--color-bg-card)); }
+.ev-flightdeck { position: relative; min-height: 245px; padding: 2rem 1.5rem 1.25rem; background: color-mix(in srgb, var(--color-bg) 65%, var(--color-bg-card)); }
+.ev-flightdeck-grid { position: absolute; inset: 0; opacity: 0.28; background-image: linear-gradient(var(--color-border) 1px, transparent 1px), linear-gradient(90deg, var(--color-border) 1px, transparent 1px); background-size: 32px 32px; mask-image: linear-gradient(to bottom, black, transparent 82%); }
+.ev-stage-rail { position: relative; z-index: 1; display: grid; grid-template-columns: repeat(4, minmax(80px, 1fr)); max-width: 900px; margin: 1rem auto 3.5rem; }
+.ev-stage-rail::before { content: ""; position: absolute; top: 9px; left: 12.5%; right: 12.5%; height: 1px; background: var(--color-border-hover); }
+.ev-stage-node { position: relative; display: flex; flex-direction: column; align-items: center; gap: 0.65rem; color: var(--color-text-dim); font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; }
+.ev-stage-signal { z-index: 1; width: 18px; height: 18px; border: 1px solid var(--color-border-hover); border-radius: 50%; background: var(--color-bg-card); box-shadow: 0 0 0 5px var(--color-bg-card); }
+.ev-stage-node.is-active { color: var(--color-text); }
+.ev-stage-node.is-active .ev-stage-signal { border-color: var(--color-success); background: var(--color-success); box-shadow: 0 0 0 5px var(--color-bg-card), 0 0 24px color-mix(in srgb, var(--color-success) 65%, transparent); animation: ev-signal 1.35s ease-in-out infinite; }
+.ev-stage-node.is-done .ev-stage-signal { border-color: var(--color-success); background: color-mix(in srgb, var(--color-success) 30%, var(--color-bg-card)); }
+.ev-run-pulse { position: absolute; z-index: 2; top: 6px; left: 12.5%; width: 7px; height: 7px; border-radius: 50%; background: #8fd3ca; box-shadow: 0 0 12px #8fd3ca; animation: ev-run-flight 3.2s linear infinite; }
+.ev-flightdeck-readout { position: relative; z-index: 1; display: grid; grid-template-columns: minmax(180px, 1.6fr) repeat(2, minmax(120px, 1fr)) 64px; align-items: end; gap: 1.25rem; max-width: 960px; margin: 0 auto; padding-top: 1rem; border-top: 1px solid var(--color-border); }
+.ev-flightdeck-readout > div:not(.ev-progress-dial) { min-width: 0; }
+.ev-flightdeck-readout .label { display: block; margin-bottom: 0.3rem; color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; }
+.ev-flightdeck-readout strong { display: block; overflow: hidden; color: var(--color-text); font-family: var(--font-mono, ui-monospace, monospace); font-size: 12px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.ev-progress-dial { --progress: 0deg; display: grid; width: 56px; height: 56px; place-items: center; border-radius: 50%; background: conic-gradient(var(--color-success) var(--progress), var(--color-border) 0); position: relative; }
+.ev-progress-dial::after { content: ""; position: absolute; inset: 4px; border-radius: inherit; background: var(--color-bg-card); }
+.ev-progress-dial span { z-index: 1; color: var(--color-text); font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; }
+.ev-command-error { margin: 0; padding: 0.75rem 1.25rem; border-top: 1px solid color-mix(in srgb, #e5484d 40%, var(--color-border)); color: #e5484d; font-size: 12px; }
+@keyframes ev-signal { 50% { transform: scale(0.72); opacity: 0.72; } }
+@keyframes ev-run-flight { from { left: 12.5%; } to { left: 87.5%; } }
+@media (prefers-reduced-motion: reduce) { .ev-stage-node.is-active .ev-stage-signal, .ev-run-pulse { animation: none; } }
+@media (max-width: 760px) {
+  .ev-command-head { align-items: flex-start; flex-direction: column; }
+  .ev-flightdeck { min-height: 280px; padding-inline: 1rem; }
+  .ev-flightdeck-readout { grid-template-columns: 1fr 1fr; }
+  .ev-progress-dial { display: none; }
+  .ev-stage-node { font-size: 8px; }
+}
+
 .ev-card {
   border: 1px solid var(--color-border);
   background: var(--color-bg-card);

--- a/signalpilot/web/app/evals/evals.css
+++ b/signalpilot/web/app/evals/evals.css
@@ -622,6 +622,51 @@
 .ev-onboarding-field small { display: block; margin-top: 0.45rem; color: var(--color-text-dim); font-size: 10px; }
 .ev-onboarding-field-wide { grid-column: 1 / -1; }
 
+.ev-source-kinds {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.65rem;
+  margin-bottom: 1.4rem;
+}
+
+.ev-source-kinds > button {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  color: var(--color-text-dim);
+  text-align: left;
+  transition: border-color 130ms ease, background 130ms ease, color 130ms ease;
+}
+
+.ev-source-kinds > button:hover { border-color: var(--color-border-hover); color: var(--color-text-muted); }
+.ev-source-kinds > button.is-selected { border-color: color-mix(in srgb, var(--color-success) 65%, var(--color-border)); background: color-mix(in srgb, var(--color-success) 7%, transparent); color: var(--color-success); }
+.ev-source-kinds > button > svg { width: 17px; height: 17px; flex: 0 0 auto; stroke-width: 1.6; }
+.ev-source-kinds > button span { min-width: 0; }
+.ev-source-kinds strong { display: block; overflow: hidden; color: var(--color-text); font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.ev-source-kinds small { display: block; margin-top: 0.2rem; overflow: hidden; color: var(--color-text-dim); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+
+.ev-private-source { min-height: 85px; }
+.ev-private-grid { display: grid; grid-template-columns: 1fr 1.5fr; gap: 1rem; }
+.ev-private-loading { display: flex; align-items: center; gap: 0.5rem; min-height: 85px; color: var(--color-text-dim); font-size: 11px; }
+.ev-private-loading svg { width: 14px; height: 14px; }
+.ev-connect-github { display: grid; grid-template-columns: 32px 1fr auto; align-items: center; gap: 0.9rem; min-height: 85px; border: 1px solid var(--color-border); border-radius: 6px; padding: 1rem; }
+.ev-connect-github > svg { width: 24px; height: 24px; color: var(--color-text-muted); stroke-width: 1.5; }
+.ev-connect-github strong { display: block; color: var(--color-text); font-size: 12px; font-weight: 500; }
+.ev-connect-github p { margin: 0.3rem 0 0; color: var(--color-text-dim); font-size: 10px; line-height: 1.5; }
+.ev-connect-github button,
+.ev-connect-github-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem; border: 1px solid color-mix(in srgb, var(--color-success) 55%, var(--color-border)); border-radius: 6px; padding: 0.55rem 0.75rem; color: var(--color-text); font-size: 11px; white-space: nowrap; }
+.ev-connect-github button:hover:not(:disabled),
+.ev-connect-github-secondary:hover:not(:disabled) { background: color-mix(in srgb, var(--color-success) 10%, transparent); }
+.ev-connect-github button:disabled,
+.ev-connect-github-secondary:disabled { opacity: 0.45; }
+.ev-connect-github button svg,
+.ev-connect-github-secondary svg { width: 13px; height: 13px; }
+.ev-connect-github-secondary { margin-top: 0.75rem; border-color: var(--color-border); color: var(--color-text-muted); }
+
 .ev-onboarding-manifest {
   display: flex;
   align-items: center;
@@ -713,6 +758,10 @@
   .ev-onboarding-body { min-height: 440px; padding: 1.5rem; }
   .ev-onboarding-grid,
   .ev-onboarding-review { grid-template-columns: 1fr; }
+  .ev-source-kinds { grid-template-columns: 1fr; }
+  .ev-private-grid { grid-template-columns: 1fr; }
+  .ev-connect-github { grid-template-columns: 26px 1fr; }
+  .ev-connect-github button { grid-column: 1 / -1; }
   .ev-onboarding-footer { align-items: flex-start; flex-direction: column; padding: 1rem 1.5rem; }
   .ev-onboarding-footer > div:last-child { width: 100%; margin-left: 0; }
   .ev-onboarding-footer button { flex: 1; }

--- a/signalpilot/web/app/evals/evals.css
+++ b/signalpilot/web/app/evals/evals.css
@@ -57,6 +57,10 @@
 .ev-progress-dial { --progress: 0deg; display: grid; width: 56px; height: 56px; place-items: center; border-radius: 50%; background: conic-gradient(var(--color-success) var(--progress), var(--color-border) 0); position: relative; }
 .ev-progress-dial::after { content: ""; position: absolute; inset: 4px; border-radius: inherit; background: var(--color-bg-card); }
 .ev-progress-dial span { z-index: 1; color: var(--color-text); font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; }
+.ev-progress-launch { cursor: pointer; transition: box-shadow 0.15s ease, transform 0.15s ease; }
+.ev-progress-launch:hover:not(:disabled) { box-shadow: 0 0 18px color-mix(in srgb, var(--color-success) 38%, transparent); transform: translateY(-1px); }
+.ev-progress-launch:focus-visible { outline: 2px solid var(--color-success); outline-offset: 3px; }
+.ev-progress-launch:disabled { cursor: not-allowed; opacity: 0.4; }
 .ev-command-error { margin: 0; padding: 0.75rem 1.25rem; border-top: 1px solid color-mix(in srgb, #e5484d 40%, var(--color-border)); color: #e5484d; font-size: 12px; }
 @keyframes ev-signal { 50% { transform: scale(0.72); opacity: 0.72; } }
 @keyframes ev-run-flight { from { left: 12.5%; } to { left: 87.5%; } }

--- a/signalpilot/web/app/evals/evals.css
+++ b/signalpilot/web/app/evals/evals.css
@@ -446,3 +446,274 @@
   overflow-y: auto;
   margin: 0;
 }
+
+/* First-time eval setup */
+.ev-onboarding-page {
+  display: grid;
+  place-items: center;
+}
+
+.ev-onboarding-loading {
+  min-height: calc(100vh - 4rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: var(--color-text-dim);
+  font-size: 13px;
+}
+
+.ev-onboarding {
+  width: min(920px, 100%);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-card);
+  overflow: hidden;
+  box-shadow: 0 22px 70px rgb(0 0 0 / 20%);
+}
+
+.ev-onboarding-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem 2.25rem 1.75rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ev-onboarding-kicker {
+  margin: 0 0 0.6rem;
+  color: var(--color-success);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.ev-onboarding-header h1 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 24px;
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.ev-onboarding-header p:last-child {
+  margin: 0.6rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.ev-onboarding-count {
+  color: var(--color-text-dim);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.ev-onboarding-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ev-onboarding-steps button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  min-height: 58px;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-dim);
+  font-size: 12px;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.ev-onboarding-steps button:last-child { border-right: 0; }
+.ev-onboarding-steps button:not(:disabled):hover { color: var(--color-text); }
+.ev-onboarding-steps button.is-current { color: var(--color-text); background: color-mix(in srgb, var(--color-success) 6%, transparent); }
+.ev-onboarding-steps button.is-current::after { content: ""; position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; background: var(--color-success); }
+.ev-onboarding-steps button.is-complete { color: var(--color-success); }
+.ev-onboarding-steps button:disabled { cursor: default; }
+.ev-onboarding-steps button span { display: grid; place-items: center; width: 20px; height: 20px; }
+.ev-onboarding-steps svg { width: 15px; height: 15px; stroke-width: 1.7; }
+
+.ev-onboarding-body {
+  min-height: 390px;
+  padding: 2.25rem;
+}
+
+.ev-onboarding-panel {
+  animation: ev-onboarding-enter 180ms ease-out;
+}
+
+@keyframes ev-onboarding-enter {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ev-onboarding-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.ev-onboarding-heading > span {
+  color: var(--color-success);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  line-height: 1.8;
+}
+
+.ev-onboarding-heading h2 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.ev-onboarding-heading p {
+  margin: 0.35rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.ev-onboarding-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 1rem;
+}
+
+.ev-onboarding-field {
+  display: block;
+}
+
+.ev-onboarding-field > span {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.ev-onboarding-field input,
+.ev-onboarding-field select,
+.ev-onboarding-field textarea {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  padding: 0.7rem 0.8rem;
+  color: var(--color-text);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 130ms ease, box-shadow 130ms ease;
+}
+
+.ev-onboarding-field textarea { resize: vertical; min-height: 78px; }
+.ev-onboarding-field input::placeholder,
+.ev-onboarding-field textarea::placeholder { color: var(--color-text-dim); }
+.ev-onboarding-field input:focus,
+.ev-onboarding-field select:focus,
+.ev-onboarding-field textarea:focus { border-color: color-mix(in srgb, var(--color-success) 65%, var(--color-border)); box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 10%, transparent); }
+.ev-onboarding-field select:disabled { opacity: 0.55; }
+.ev-onboarding-field small { display: block; margin-top: 0.45rem; color: var(--color-text-dim); font-size: 10px; }
+.ev-onboarding-field-wide { grid-column: 1 / -1; }
+
+.ev-onboarding-manifest {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.ev-onboarding-manifest span { display: flex; align-items: center; gap: 0.4rem; }
+.ev-onboarding-manifest svg { width: 12px; height: 12px; color: var(--color-success); }
+.ev-onboarding-manifest code { margin-left: auto; color: var(--color-text-dim); font-size: 10px; }
+
+.ev-onboarding-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.ev-onboarding-notice a { display: inline-flex; align-items: center; gap: 0.35rem; color: var(--color-text); }
+.ev-onboarding-notice svg { width: 12px; height: 12px; }
+
+.ev-onboarding-toggle {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 0 0.8rem;
+  align-items: start;
+  margin-top: 1.4rem;
+  cursor: pointer;
+}
+
+.ev-onboarding-toggle input { position: absolute; opacity: 0; pointer-events: none; }
+.ev-onboarding-toggle > span { position: relative; width: 34px; height: 19px; margin-top: 1px; border: 1px solid var(--color-border-hover); border-radius: 10px; background: var(--color-bg); transition: background 140ms ease, border-color 140ms ease; }
+.ev-onboarding-toggle > span::after { content: ""; position: absolute; top: 3px; left: 3px; width: 11px; height: 11px; border-radius: 50%; background: var(--color-text-dim); transition: transform 140ms ease, background 140ms ease; }
+.ev-onboarding-toggle input:checked + span { border-color: var(--color-success); background: color-mix(in srgb, var(--color-success) 18%, var(--color-bg)); }
+.ev-onboarding-toggle input:checked + span::after { transform: translateX(15px); background: var(--color-success); }
+.ev-onboarding-toggle input:focus-visible + span { outline: 2px solid var(--color-success); outline-offset: 2px; }
+.ev-onboarding-toggle strong { display: block; color: var(--color-text); font-size: 12px; font-weight: 500; }
+.ev-onboarding-toggle small { display: block; margin-top: 0.3rem; color: var(--color-text-dim); font-size: 10px; line-height: 1.5; }
+
+.ev-onboarding-review {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 1rem;
+  margin: 1.5rem 0 0;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.ev-onboarding-review div { min-width: 0; }
+.ev-onboarding-review dt { color: var(--color-text-dim); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; }
+.ev-onboarding-review dd { margin: 0.35rem 0 0; overflow: hidden; color: var(--color-text-muted); font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+
+.ev-onboarding-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72px;
+  gap: 1rem;
+  padding: 1rem 2.25rem;
+  border-top: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-bg) 45%, var(--color-bg-card));
+}
+
+.ev-onboarding-footer > div:first-child { color: #f07178; font-size: 11px; }
+.ev-onboarding-footer > div:last-child { display: flex; align-items: center; gap: 0.65rem; margin-left: auto; }
+.ev-onboarding-footer button { display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem; min-height: 36px; border-radius: 6px; padding: 0.55rem 0.85rem; color: var(--color-text-muted); font-size: 12px; transition: color 130ms ease, background 130ms ease, border-color 130ms ease; }
+.ev-onboarding-footer button svg { width: 14px; height: 14px; }
+.ev-onboarding-footer button:disabled { opacity: 0.45; cursor: default; }
+.ev-onboarding-back { border: 1px solid var(--color-border); }
+.ev-onboarding-back:hover:not(:disabled) { border-color: var(--color-border-hover); color: var(--color-text); }
+.ev-onboarding-next { border: 1px solid color-mix(in srgb, var(--color-success) 60%, var(--color-border)); background: color-mix(in srgb, var(--color-success) 11%, var(--color-bg-card)); color: var(--color-text) !important; }
+.ev-onboarding-next:hover:not(:disabled) { background: color-mix(in srgb, var(--color-success) 18%, var(--color-bg-card)); }
+
+@media (max-width: 720px) {
+  .ev-onboarding-page { display: block; padding: 1rem; }
+  .ev-onboarding-header { padding: 1.5rem; }
+  .ev-onboarding-header h1 { font-size: 21px; }
+  .ev-onboarding-steps button { min-height: 52px; font-size: 0; }
+  .ev-onboarding-steps button span { margin: 0; }
+  .ev-onboarding-body { min-height: 440px; padding: 1.5rem; }
+  .ev-onboarding-grid,
+  .ev-onboarding-review { grid-template-columns: 1fr; }
+  .ev-onboarding-footer { align-items: flex-start; flex-direction: column; padding: 1rem 1.5rem; }
+  .ev-onboarding-footer > div:last-child { width: 100%; margin-left: 0; }
+  .ev-onboarding-footer button { flex: 1; }
+}

--- a/signalpilot/web/app/evals/page.tsx
+++ b/signalpilot/web/app/evals/page.tsx
@@ -161,6 +161,8 @@ function ConfigForm({ onSaved }: { onSaved: () => void }) {
   const { data, mutate } = useSWR("eval-config", getEvalConfig);
   const [form, setForm] = useState({
     repo_url: "",
+    repo_installation_id: null as string | null,
+    repo_id: null as number | null,
     model: "sonnet",
     max_tasks: 0,
     prompt_preamble: "",
@@ -175,6 +177,8 @@ function ConfigForm({ onSaved }: { onSaved: () => void }) {
     if (data && !loaded) {
       setForm({
         repo_url: data.repo_url ?? "",
+        repo_installation_id: data.repo_installation_id ?? null,
+        repo_id: data.repo_id ?? null,
         model: data.model ?? "sonnet",
         max_tasks: data.max_tasks ?? 0,
         prompt_preamble: data.prompt_preamble ?? "",
@@ -191,6 +195,8 @@ function ConfigForm({ onSaved }: { onSaved: () => void }) {
     try {
       await putEvalConfig({
         repo_url: form.repo_url,
+        repo_installation_id: form.repo_installation_id,
+        repo_id: form.repo_id,
         model: form.model,
         max_tasks: form.max_tasks,
         prompt_preamble: form.prompt_preamble,
@@ -220,7 +226,7 @@ function ConfigForm({ onSaved }: { onSaved: () => void }) {
         <label className="block text-xs text-[var(--color-text-muted)] mb-1.5">
           Repo — public git URL, or a local path under /eval-projects (format: eval-format.md)
         </label>
-        <input className={inputCls} value={form.repo_url} onChange={(e) => setForm({ ...form, repo_url: e.target.value })} placeholder="https://github.com/org/eval-set.git  ·  /eval-projects/northwind" />
+        <input className={inputCls} value={form.repo_url} onChange={(e) => setForm({ ...form, repo_url: e.target.value, repo_installation_id: null, repo_id: null })} placeholder="https://github.com/org/eval-set.git  ·  /eval-projects/northwind" />
       </div>
       <div>
         <label className="block text-xs text-[var(--color-text-muted)] mb-1.5">Model</label>

--- a/signalpilot/web/app/evals/page.tsx
+++ b/signalpilot/web/app/evals/page.tsx
@@ -73,6 +73,7 @@ import { useToast } from "~/components/ui/toast";
 import { Md, fmtNum } from "./_components/Markdown";
 import { RunProgressBar, SandboxPanel } from "./_components/SandboxPanel";
 import { ControlDeck } from "./_components/ControlDeck";
+import { EvalOnboarding } from "./_components/EvalOnboarding";
 import { TranscriptSlideOver } from "./_components/TranscriptView";
 import "./evals.css";
 
@@ -227,7 +228,7 @@ function ConfigForm({ onSaved }: { onSaved: () => void }) {
       </div>
       <div>
         <label className="block text-xs text-[var(--color-text-muted)] mb-1.5">Max tasks per run (0 = all)</label>
-        <input className={inputCls} type="number" min={0} max={100} value={form.max_tasks} onChange={(e) => setForm({ ...form, max_tasks: Number(e.target.value) || 0 })} />
+        <input className={inputCls} type="number" min={0} max={200} value={form.max_tasks} onChange={(e) => setForm({ ...form, max_tasks: Number(e.target.value) || 0 })} />
       </div>
       <div>
         <label className="block text-xs text-[var(--color-text-muted)] mb-1.5">Connection — warehouse connection the graded agent must use</label>
@@ -1418,7 +1419,7 @@ function EvalsPageInner() {
   const { data: availability, isLoading: availLoading } = useSWR("eval-availability", getEvalAvailability);
   const enabled = availability?.enabled === true;
 
-  const { data: cfg } = useSWR(enabled ? "eval-config" : null, getEvalConfig);
+  const { data: cfg, isLoading: cfgLoading } = useSWR(enabled ? "eval-config" : null, getEvalConfig);
   const { data: evalSet, error: tasksError } = useSWR(
     enabled && cfg?.repo_url ? `eval-tasks-${cfg.repo_url}` : null,
     () => listEvalTasks(),
@@ -1456,6 +1457,24 @@ function EvalsPageInner() {
     );
   }
 
+  if (cfgLoading || !cfg) {
+    return (
+      <div className="min-h-screen p-8 animate-fade-in">
+        <div className="ev-onboarding-loading">
+          <Loader2 className="w-4 h-4 animate-spin" /> Loading eval workspace...
+        </div>
+      </div>
+    );
+  }
+
+  if (!cfg.repo_url) {
+    return (
+      <div className="min-h-screen p-8 animate-fade-in ev-onboarding-page">
+        <EvalOnboarding config={cfg} onComplete={() => setConfigOpen(false)} />
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen p-8 animate-fade-in">
       {header}
@@ -1471,7 +1490,7 @@ function EvalsPageInner() {
           onConfigure={() => setConfigOpen((open) => !open)}
         />
 
-        {(configOpen || (!!cfg && !cfg.repo_url)) && (
+        {configOpen && (
           <div className="ev-card px-6 pb-6">
             <ConfigForm onSaved={() => setConfigOpen(false)} />
           </div>

--- a/signalpilot/web/app/evals/page.tsx
+++ b/signalpilot/web/app/evals/page.tsx
@@ -13,10 +13,12 @@
 
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import useSWR, { mutate } from "swr";
 import {
   BookOpen,
+  BarChart3,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
@@ -30,6 +32,7 @@ import {
   Save,
   Search,
   Settings2,
+  Square,
   TrendingUp,
   X,
   XCircle,
@@ -44,6 +47,7 @@ import {
   YAxis,
 } from "recharts";
 import {
+  cancelEvalRun,
   downloadEvalArtifact,
   downloadEvalRunExport,
   getEvalAccuracy,
@@ -68,6 +72,7 @@ import { PageHeader } from "~/components/ui/page-header";
 import { useToast } from "~/components/ui/toast";
 import { Md, fmtNum } from "./_components/Markdown";
 import { RunProgressBar, SandboxPanel } from "./_components/SandboxPanel";
+import { ControlDeck } from "./_components/ControlDeck";
 import { TranscriptSlideOver } from "./_components/TranscriptView";
 import "./evals.css";
 
@@ -81,6 +86,7 @@ const VERDICT_STYLE: Record<string, { color: string; label: string }> = {
   UNGRADED: { color: "var(--color-text-dim)", label: "ungraded" },
   ERROR: { color: "#e5484d", label: "run error" },
   SETUP_FAILED: { color: "#e5484d", label: "setup failed" },
+  CANCELLED: { color: "var(--color-text-dim)", label: "cancelled" },
 };
 
 function VerdictBadge({ verdict }: { verdict: string | null }) {
@@ -97,8 +103,9 @@ function StatusDot({ status }: { status: string }) {
   const color =
     status === "completed" ? "var(--color-success)"
     : status === "failed" ? "#e5484d"
+    : status === "cancelled" ? "var(--color-text-dim)"
     : "var(--color-warning, #f5a623)";
-  const live = status === "running" || status === "preparing";
+  const live = status === "running" || status === "preparing" || status === "cancelling";
   return (
     <span className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.12em]" style={{ color }}>
       <span className={`w-1.5 h-1.5 rounded-full ${live ? "animate-pulse" : ""}`} style={{ background: color }} />
@@ -925,10 +932,11 @@ function CoveragePanel({ coverage }: { coverage: EvalCoverage }) {
 function RunDetail({ runId }: { runId: string }) {
   const { toast } = useToast();
   const [exporting, setExporting] = useState(false);
+  const [stopping, setStopping] = useState(false);
   const { data: run } = useSWR(`eval-run-${runId}`, () => getEvalRun(runId), {
-    refreshInterval: (latest) => (latest && (latest.status === "running" || latest.status === "preparing") ? 3000 : 0),
+    refreshInterval: (latest) => (latest && (latest.status === "running" || latest.status === "preparing" || latest.status === "cancelling") ? 2000 : 0),
   });
-  const live = run?.status === "running" || run?.status === "preparing";
+  const live = run?.status === "running" || run?.status === "preparing" || run?.status === "cancelling";
   const { data: progress } = useSWR(
     live ? `eval-run-progress-${runId}` : null,
     () => getEvalRunProgress(runId),
@@ -944,6 +952,19 @@ function RunDetail({ runId }: { runId: string }) {
       toast(`export failed: ${err instanceof Error ? err.message : "unknown"}`, "error");
     } finally {
       setExporting(false);
+    }
+  }
+
+  async function stopRun() {
+    setStopping(true);
+    try {
+      await cancelEvalRun(runId);
+      await Promise.all([mutate("eval-runs"), mutate(`eval-run-${runId}`)]);
+      toast("eval cancellation requested", "success");
+    } catch (err) {
+      toast(`could not stop run: ${err instanceof Error ? err.message : "unknown"}`, "error");
+    } finally {
+      setStopping(false);
     }
   }
 
@@ -977,6 +998,16 @@ function RunDetail({ runId }: { runId: string }) {
           </p>
         </div>
         <div className="flex items-center gap-3 flex-wrap">
+          {live && (
+            <button
+              onClick={stopRun}
+              disabled={stopping || run.status === "cancelling"}
+              className="ev-stop-command"
+            >
+              {stopping || run.status === "cancelling" ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Square className="w-3 h-3" fill="currentColor" />}
+              {run.status === "cancelling" ? "Stopping" : "Stop run"}
+            </button>
+          )}
           {run.status === "completed" && (
             <div className="flex items-center gap-3 text-sm">
               {allPass ? <CheckCircle2 className="w-4 h-4 text-[var(--color-success)]" /> : <XCircle className="w-4 h-4 text-[#e5484d]" />}
@@ -1380,6 +1411,7 @@ function EvalsPageInner() {
   const searchParams = useSearchParams();
   const [selectedRun, setSelectedRun] = useState<string | null>(() => searchParams.get("run"));
   const [detailTask, setDetailTask] = useState<EvalTask | null>(null);
+  const [configOpen, setConfigOpen] = useState(false);
 
   // An unentitled workspace can call only the availability route.
   // Delay all other requests until the availability response confirms access.
@@ -1394,9 +1426,10 @@ function EvalsPageInner() {
   const tasks = evalSet?.tasks;
   const { data: runsData } = useSWR(enabled ? "eval-runs" : null, listEvalRuns, {
     refreshInterval: (latest) =>
-      latest?.runs?.some((r: EvalRun) => r.status === "running" || r.status === "preparing") ? 4000 : 15000,
+      latest?.runs?.some((r: EvalRun) => r.status === "running" || r.status === "preparing" || r.status === "cancelling") ? 2500 : 15000,
   });
   const runs = runsData?.runs ?? [];
+  const activeRun = runs.find((run) => run.status === "running" || run.status === "preparing" || run.status === "cancelling");
 
   const header = (
     <PageHeader
@@ -1428,7 +1461,21 @@ function EvalsPageInner() {
       {header}
 
       <div className="space-y-6">
-        <Hero evalSet={evalSet} repoUrl={cfg?.repo_url ?? ""} model={cfg?.model ?? "sonnet"} runnerEnabled={cfg?.enabled ?? true} cfgLoaded={!!cfg} />
+        <ControlDeck
+          evalSet={evalSet}
+          repoUrl={cfg?.repo_url ?? ""}
+          model={cfg?.model ?? "sonnet"}
+          runnerEnabled={cfg?.enabled ?? true}
+          activeRun={activeRun}
+          onStarted={setSelectedRun}
+          onConfigure={() => setConfigOpen((open) => !open)}
+        />
+
+        {(configOpen || (!!cfg && !cfg.repo_url)) && (
+          <div className="ev-card px-6 pb-6">
+            <ConfigForm onSaved={() => setConfigOpen(false)} />
+          </div>
+        )}
 
         {tasksError && cfg?.repo_url && (
           <p className="text-sm text-[var(--color-text-dim)]">
@@ -1443,8 +1490,6 @@ function EvalsPageInner() {
         {selectedRun && <RunDetail runId={selectedRun} />}
 
         <SandboxPanel />
-
-        <AccuracySection />
 
         <RunsList runs={runs} selectedRun={selectedRun} onSelect={setSelectedRun} />
       </div>

--- a/signalpilot/web/app/settings/github/page.tsx
+++ b/signalpilot/web/app/settings/github/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import {
   AlertTriangle,
   GitBranch,
@@ -34,6 +35,7 @@ import { useToast } from "~/components/ui/toast";
 export default function GitHubConnectionsPage() {
   const { toast } = useToast();
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   const [installations, setInstallations] = useState<GitHubInstallation[]>([]);
   const [repoLinks, setRepoLinks] = useState<GitHubRepoLink[]>([]);
@@ -78,11 +80,16 @@ export default function GitHubConnectionsPage() {
     refresh();
     if (searchParams.get("installed") === "true") {
       toast("GitHub App connected successfully", "success");
+      const returnTo = sessionStorage.getItem("sp_github_return_to");
+      if (returnTo === "/evals") {
+        sessionStorage.removeItem("sp_github_return_to");
+        router.replace(returnTo);
+      }
     }
     if (githubErrorMessage) {
       toast(githubErrorMessage, "error");
     }
-  }, [githubErrorMessage, refresh, searchParams, toast]);
+  }, [githubErrorMessage, refresh, router, searchParams, toast]);
 
   async function handleConnectGitHub() {
     setConnecting(true);

--- a/signalpilot/web/components/layout/main-content.tsx
+++ b/signalpilot/web/components/layout/main-content.tsx
@@ -15,7 +15,7 @@ export function MainContent({ children }: { children: ReactNode }) {
   const fullWidth = FULL_WIDTH_PREFIXES.some((prefix) => matchesRoutePrefix(pathname, prefix));
 
   return (
-    <main className={`${fullWidth ? "" : "ml-56"} min-h-screen relative z-10`}>
+    <main className={`${fullWidth ? "" : "md:ml-56"} min-h-screen relative z-10`}>
       {children}
     </main>
   );

--- a/signalpilot/web/components/layout/sidebar.tsx
+++ b/signalpilot/web/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState, useMemo } from "react";
 import dynamic from "next/dynamic";
-import { KeyRound, CreditCard, Plug, BarChart3, Shield, Lock, Users, GitBranch, BookOpen } from "lucide-react";
+import { KeyRound, CreditCard, Plug, BarChart3, Shield, Lock, Users, GitBranch, BookOpen, Menu, X } from "lucide-react";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useAppAuth } from "~/lib/auth-context";
 import { getProjects, getWorkspaceProjects } from "~/lib/api";
@@ -142,6 +142,16 @@ function NavIconEvals({ active }: { active: boolean }) {
   );
 }
 
+function NavIconAccuracy({ active }: { active: boolean }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path d="M2 11V8M5.3 11V5M8.7 11V7M12 11V2" stroke="currentColor" strokeWidth="1" />
+      <path d="M1 12.5H13" stroke="currentColor" strokeWidth="1" />
+      {active && <circle cx="12" cy="2" r="1.25" fill="var(--color-success)" />}
+    </svg>
+  );
+}
+
 function NavIconChats({ active }: { active: boolean }) {
   return (
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -195,6 +205,7 @@ const navGroups: { label: string | null; items: NavItem[] }[] = [
       { href: "/projects", label: "Projects", icon: NavIconProject, shortcut: "5" },
       { href: "/knowledge", label: "Knowledge Base", icon: NavIconKnowledge, shortcut: "8" },
       { href: "/evals", label: "Evals", icon: NavIconEvals, shortcut: "" },
+      { href: "/evals/accuracy", label: "Accuracy", icon: NavIconAccuracy, shortcut: "" },
       { href: "/integrations", label: "Integrations", icon: NavIconIntegrations, shortcut: "3" },
     ],
   },
@@ -488,6 +499,7 @@ function GitHubNavLink({ pathname }: { pathname: string }) {
 
 export default function Sidebar() {
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
   const router = useRouter();
   const { isCloudMode, isAuthenticated } = useAppAuth();
   const [projectCount, setProjectCount] = useState(0);
@@ -545,12 +557,24 @@ export default function Sidebar() {
   const tierBranding = useTierBranding();
   const showWordmark = tierBranding.enabled && tierBranding.tier !== "free";
 
+  useEffect(() => setMobileOpen(false), [pathname]);
+
   if (HIDDEN_SIDEBAR_PREFIXES.some((prefix) => matchesRoutePrefix(pathname, prefix))) {
     return null;
   }
 
   return (
-    <aside className="fixed left-0 top-0 h-screen w-56 bg-[var(--color-sidebar)] border-r border-[var(--color-border)] flex flex-col z-50">
+    <>
+      <button
+        onClick={() => setMobileOpen((open) => !open)}
+        className="fixed right-4 top-4 z-[60] flex h-9 w-9 items-center justify-center rounded-[6px] border border-[var(--color-border)] bg-[var(--color-bg-card)] text-[var(--color-text)] md:hidden"
+        aria-label={mobileOpen ? "Close navigation" : "Open navigation"}
+        aria-expanded={mobileOpen}
+      >
+        {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+      </button>
+      {mobileOpen && <button className="fixed inset-0 z-40 bg-black/60 md:hidden" onClick={() => setMobileOpen(false)} aria-label="Close navigation" />}
+      <aside className={`${mobileOpen ? "flex" : "hidden"} fixed left-0 top-0 z-50 h-screen w-56 flex-col border-r border-[var(--color-border)] bg-[var(--color-sidebar)] md:flex`}>
       {/* Logo */}
       <div className="px-5 py-5 border-b border-[var(--color-border)]">
         <Link href="/dashboard" className="flex items-center gap-3 group">
@@ -601,7 +625,7 @@ export default function Sidebar() {
         {navGroups.map((group, gi) => {
           const items = group.items.filter(
             ({ href }) =>
-              !(isCloudMode && href === "/settings") && !(href === "/evals" && !evalsEnabled)
+              !(isCloudMode && href === "/settings") && !(href.startsWith("/evals") && !evalsEnabled)
           );
           if (items.length === 0) return null;
           return (
@@ -613,7 +637,7 @@ export default function Sidebar() {
               )}
               <div className="space-y-0.5">
                 {items.map(({ href, label, icon: Icon, shortcut }) => {
-                  const active = pathname.startsWith(href);
+                  const active = href === "/evals" ? pathname === href : pathname.startsWith(href);
                   const showHealthDot =
                     href === "/connections" && connHealth.total > 0 && connHealth.healthy < connHealth.total;
                   return (
@@ -730,6 +754,7 @@ export default function Sidebar() {
           </Tooltip>
         </div>
       </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/signalpilot/web/e2e-evals-redesign.mjs
+++ b/signalpilot/web/e2e-evals-redesign.mjs
@@ -5,7 +5,7 @@ const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1720, height: 1300 } });
 
 // Capture data from the active service.
-await page.goto("http://localhost:3210/evals", { waitUntil: "networkidle" });
+await page.goto("http://localhost:3260/evals", { waitUntil: "networkidle" });
 await page.waitForTimeout(2500);
 await page.screenshot({ path: "e2e-evals-redesign-real.png", fullPage: false });
 
@@ -63,6 +63,26 @@ const runs = Array.from({ length: 40 }, (_, i) => ({
   traces_pruned: false,
 }));
 
+const martModels = Array.from({ length: 32 }, (_, i) => ({
+  name: `mart_${["revenue", "claims", "orders", "sessions"][i % 4]}_${String(i + 1).padStart(2, "0")}`,
+  layer: "marts",
+  covered: i % 7 !== 0,
+  declared_by: i % 7 === 0 ? [] : [`t-${String((i % 24) + 1).padStart(3, "0")}_${["revenue", "claims", "orders", "sessions"][i % 4]}`],
+  observed_by: i % 3 === 0 && i % 7 !== 0 ? [`t-${String((i % 24) + 1).padStart(3, "0")}_${["revenue", "claims", "orders", "sessions"][i % 4]}`] : [],
+}));
+runs[1].coverage = {
+  declared: martModels.filter((model) => model.declared_by.length).map((model) => model.name),
+  observed: martModels.filter((model) => model.observed_by.length).map((model) => model.name),
+  observed_not_declared: [],
+  per_task_observed: {},
+  models_total: 80,
+  models_covered: 70,
+  pct: 87.5,
+  marts_pct: 84.4,
+  by_layer: { marts: { total: 32, covered: 27 }, staging: { total: 30, covered: 28 }, intermediate: { total: 18, covered: 15 } },
+  models: martModels,
+};
+
 const history = Array.from({ length: 12 }, (_, i) => ({
   run_id: runs[Math.min(i + 1, runs.length - 1)].id,
   created_at: `2026-07-${String(2 + i * 2).padStart(2, "0")}T12:00:00Z`,
@@ -97,6 +117,22 @@ const accuracy = {
       recipients: [],
     },
   ],
+  task_performance: tasks.slice(0, 70).map((task, i) => ({
+    task_id: task.id,
+    title: task.title,
+    kind: task.kind,
+    class: task.class,
+    covers: task.covers,
+    attempts: 8 + (i % 5),
+    correct: i % 9 === 0 ? 3 : 7 + (i % 4),
+    partial: i % 4,
+    off: i % 9 === 0 ? 5 : i % 3,
+    errors: i % 13 === 0 ? 1 : 0,
+    pass_rate_pct: i % 9 === 0 ? 37.5 : 72 + (i % 29),
+    avg_duration_s: 24 + i * 1.8,
+    last_verdict: i % 9 === 0 ? "OFF" : "CORRECT",
+    last_run_id: runs[1].id,
+  })),
 };
 
 await page.route("**/api/evals/tasks", (r) =>
@@ -113,6 +149,13 @@ await page.route("**/api/evals/tasks", (r) =>
   }));
 await page.route("**/api/evals/runs", (r) =>
   r.fulfill({ json: { runs } }));
+await page.route("**/api/evals/runs/*/progress", (r) =>
+  r.fulfill({ json: { run_id: runs[0].id, status: "running", phase: "running", done: 63, total: 180, active: [{ task_id: tasks[63].id, title: tasks[63].title, phase: "agent", started_at: new Date().toISOString() }], started_at: new Date(Date.now() - 90000).toISOString(), elapsed_s: 90, updated_at: new Date().toISOString(), error: null } }));
+await page.route("**/api/evals/runs/*/cancel", (r) => {
+  runs[0].status = "cancelled";
+  runs[0].finished_at = new Date().toISOString();
+  r.fulfill({ json: { ...runs[0], tasks: [] } });
+});
 await page.route("**/api/evals/accuracy", (r) =>
   r.fulfill({ json: accuracy }));
 await page.route("**/api/evals/config", (r) =>
@@ -130,9 +173,14 @@ await page.route("**/api/evals/config", (r) =>
   }));
 await page.route("**/api/evals/availability", (r) => r.fulfill({ json: { enabled: true, reason: "ok" } }));
 
-await page.goto("http://localhost:3210/evals", { waitUntil: "networkidle" });
+await page.goto("http://localhost:3260/evals", { waitUntil: "networkidle" });
 await page.waitForTimeout(2500);
 await page.screenshot({ path: "e2e-evals-redesign-scale-list.png", fullPage: false });
+
+await page.getByRole("button", { name: "Stop run" }).first().click();
+await page.waitForTimeout(700);
+if (await page.getByRole("button", { name: "Stop run" }).count()) throw new Error("Stop control remained after cancellation");
+await page.screenshot({ path: "e2e-evals-cancelled.png", fullPage: false });
 
 // Test the search and task-type filters.
 await page.fill('input[aria-label="search tasks"]', "claims");
@@ -144,6 +192,21 @@ await page.fill('input[aria-label="search tasks"]', "");
 await page.click('button[aria-label="card view"]');
 await page.waitForTimeout(600);
 await page.screenshot({ path: "e2e-evals-redesign-scale-cards.png", fullPage: false });
+
+await page.goto("http://localhost:3260/evals/accuracy", { waitUntil: "networkidle" });
+await page.waitForTimeout(1200);
+await page.screenshot({ path: "e2e-accuracy-overview.png", fullPage: false });
+await page.locator("text=Which tests protect each mart").scrollIntoViewIfNeeded();
+await page.waitForTimeout(500);
+await page.screenshot({ path: "e2e-accuracy-mart-coverage.png", fullPage: false });
+
+await page.setViewportSize({ width: 390, height: 844 });
+await page.goto("http://localhost:3260/evals", { waitUntil: "networkidle" });
+await page.waitForTimeout(700);
+await page.screenshot({ path: "e2e-evals-mobile.png", fullPage: false });
+await page.goto("http://localhost:3260/evals/accuracy", { waitUntil: "networkidle" });
+await page.waitForTimeout(700);
+await page.screenshot({ path: "e2e-accuracy-mobile.png", fullPage: false });
 
 await browser.close();
 console.log("done");

--- a/signalpilot/web/lib/api.ts
+++ b/signalpilot/web/lib/api.ts
@@ -278,6 +278,8 @@ export type EvalConfig = {
   enabled?: boolean;
   runner_image?: string;
   repo_url: string;
+  repo_installation_id?: string | null;
+  repo_id?: number | null;
   model: string;
   max_tasks: number;
   prompt_preamble: string;

--- a/signalpilot/web/lib/api.ts
+++ b/signalpilot/web/lib/api.ts
@@ -309,6 +309,13 @@ export type EvalCaptureResult = {
   stored?: string[];
 } & Record<string, unknown>;
 export type EvalCoverageLayer = { total?: number; covered?: number; pct?: number | null };
+export type EvalCoverageModel = {
+  name: string;
+  layer: string;
+  covered: boolean;
+  declared_by: string[];
+  observed_by: string[];
+};
 export type EvalCoverage = {
   declared: string[];
   observed: string[];
@@ -319,6 +326,7 @@ export type EvalCoverage = {
   pct: number | null;
   by_layer?: Record<string, EvalCoverageLayer>;
   marts_pct?: number | null;
+  models?: EvalCoverageModel[];
 };
 /** The server reports a sandbox as a name or an object. */
 export type EvalSandboxRef =
@@ -340,7 +348,7 @@ export type EvalRunTask = {
   covers: string[];
   builds: string[];
   capture_spec: EvalCaptureSpec | null;
-  status: "pending" | "running" | "done";
+  status: "pending" | "running" | "done" | "cancelled";
   verdict: string | null;
   check_results?: EvalCheckResult[];
   answer?: string;
@@ -363,10 +371,11 @@ export type EvalRunSummary = {
   ungraded?: number;
   error?: number;
   setup_failed?: number;
+  cancelled?: number;
 };
 export type EvalRun = {
   id: string;
-  status: "preparing" | "running" | "completed" | "failed";
+  status: "preparing" | "running" | "cancelling" | "cancelled" | "completed" | "failed";
   trigger: string;
   created_at: string;
   finished_at: string | null;
@@ -408,6 +417,8 @@ export const startEvalRun = (docIds: string[], taskIds?: string[]) =>
   });
 /** Grade the complete set against the stored knowledge base without document overlays. */
 export const startBaselineEvalRun = () => startEvalRun([]);
+export const cancelEvalRun = (runId: string) =>
+  request<EvalRunDetail>(`/api/evals/runs/${runId}/cancel`, { method: "POST" });
 export const listEvalRuns = () => request<{ runs: EvalRun[] }>("/api/evals/runs");
 export const getEvalRun = (runId: string) => request<EvalRunDetail>(`/api/evals/runs/${runId}`);
 
@@ -622,8 +633,28 @@ export type EvalRegression = {
   notified_at: string | null;
   recipients: string[];
 };
+export type EvalTaskPerformance = {
+  task_id: string;
+  title: string;
+  kind: string;
+  class: "read" | "write";
+  covers: string[];
+  attempts: number;
+  correct: number;
+  partial: number;
+  off: number;
+  errors: number;
+  pass_rate_pct: number;
+  avg_duration_s: number | null;
+  last_verdict: string;
+  last_run_id: string;
+};
 export const getEvalAccuracy = () =>
-  request<{ history: EvalAccuracyPoint[]; regressions: EvalRegression[] }>("/api/evals/accuracy");
+  request<{
+    history: EvalAccuracyPoint[];
+    regressions: EvalRegression[];
+    task_performance: EvalTaskPerformance[];
+  }>("/api/evals/accuracy");
 
 // The following types and functions support run artifacts and exports.
 export type EvalArtifact = { path: string; bytes: number };


### PR DESCRIPTION
## Summary
- add cancellable eval run controls and a task execution flight deck
- add an accuracy workspace with performance trends and mart coverage
- add a guided first-run eval onboarding flow backed by live warehouse connections
- hide operational eval surfaces until an eval set is configured
- persist and scope eval coverage, cancellation, and retention state

## Verification
- Next.js production build passes
- Docker web image builds and runs healthy on localhost:3200
- Playwright onboarding flow passes at desktop and mobile widths
- mobile viewport has no horizontal overflow
- no browser console errors during the onboarding flow
- outbound diff credential-pattern scan is clean