### PR TITLE
fix: deploy chat worker from gateway image

### DIFF
--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -25,6 +25,7 @@ services:
   # ─── Gateway: switch to K8s pod orchestration ──────────────────
   gateway:
     network_mode: "service:k3s"
+    networks: !reset []
     ports: !reset []
     environment:
       SP_NOTEBOOK_DIRECT_URL: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
 
   # Gateway API and proxy.
   gateway:
+    # The durable chat worker reuses this exact image with a different command.
+    image: ${GATEWAY_IMAGE:-signalpilot-gateway:latest}
     build:
       context: ./signalpilot/gateway
       dockerfile: ../../Dockerfile.gateway
@@ -78,10 +80,11 @@ services:
       SP_FEATURE_CHAT_RUNTIME_RESULTS: ${SP_FEATURE_CHAT_RUNTIME_RESULTS:-true}
       SP_FEATURE_CHAT_RUNTIME_ARTIFACTS: ${SP_FEATURE_CHAT_RUNTIME_ARTIFACTS:-true}
       SP_FEATURE_CHAT_DATASET_REFS: ${SP_FEATURE_CHAT_DATASET_REFS:-false}
-      SP_CHAT_OBJECTS_BUCKET: sp-chat-runtime
-      SP_CHAT_OBJECTS_S3_ENDPOINT: http://minio:9000
-      SP_CHAT_OBJECTS_S3_ACCESS_KEY: minioadmin
-      SP_CHAT_OBJECTS_S3_SECRET_KEY: minioadmin
+      SP_CHAT_OBJECTS_BUCKET: ${SP_CHAT_OBJECTS_BUCKET:-sp-chat-runtime}
+      SP_CHAT_OBJECTS_S3_ENDPOINT: ${SP_CHAT_OBJECTS_S3_ENDPOINT-http://minio:9000}
+      SP_CHAT_OBJECTS_S3_REGION: ${SP_CHAT_OBJECTS_S3_REGION-}
+      SP_CHAT_OBJECTS_S3_ACCESS_KEY: ${SP_CHAT_OBJECTS_S3_ACCESS_KEY-minioadmin}
+      SP_CHAT_OBJECTS_S3_SECRET_KEY: ${SP_CHAT_OBJECTS_S3_SECRET_KEY-minioadmin}
       SIGNALPILOT_NOTEBOOK_INTERNAL_URL: http://notebook:2718
       SIGNALPILOT_NOTEBOOK_PUBLIC_URL: http://localhost:${SP_WEB_PORT:-3200}/notebook
       SIGNALPILOT_DELIVERY_MODEL: ${SIGNALPILOT_DELIVERY_MODEL:-claude-sonnet-4-5-20250929}
@@ -203,9 +206,8 @@ services:
 
   # ─── Durable standalone-chat worker ───────────────────────────
   gateway-chat-worker:
-    build:
-      context: ./signalpilot/gateway
-      dockerfile: ../../Dockerfile.gateway
+    # Built once by the gateway service; only the process command differs.
+    image: ${GATEWAY_IMAGE:-signalpilot-gateway:latest}
     env_file:
       - path: ./.slack.local.env
         required: false
@@ -224,10 +226,11 @@ services:
       SP_FEATURE_CHAT_RUNTIME_RESULTS: ${SP_FEATURE_CHAT_RUNTIME_RESULTS:-true}
       SP_FEATURE_CHAT_RUNTIME_ARTIFACTS: ${SP_FEATURE_CHAT_RUNTIME_ARTIFACTS:-true}
       SP_FEATURE_CHAT_DATASET_REFS: ${SP_FEATURE_CHAT_DATASET_REFS:-false}
-      SP_CHAT_OBJECTS_BUCKET: sp-chat-runtime
-      SP_CHAT_OBJECTS_S3_ENDPOINT: http://minio:9000
-      SP_CHAT_OBJECTS_S3_ACCESS_KEY: minioadmin
-      SP_CHAT_OBJECTS_S3_SECRET_KEY: minioadmin
+      SP_CHAT_OBJECTS_BUCKET: ${SP_CHAT_OBJECTS_BUCKET:-sp-chat-runtime}
+      SP_CHAT_OBJECTS_S3_ENDPOINT: ${SP_CHAT_OBJECTS_S3_ENDPOINT-http://minio:9000}
+      SP_CHAT_OBJECTS_S3_REGION: ${SP_CHAT_OBJECTS_S3_REGION-}
+      SP_CHAT_OBJECTS_S3_ACCESS_KEY: ${SP_CHAT_OBJECTS_S3_ACCESS_KEY-minioadmin}
+      SP_CHAT_OBJECTS_S3_SECRET_KEY: ${SP_CHAT_OBJECTS_S3_SECRET_KEY-minioadmin}
       CHAT_WORKER_CONCURRENCY: "4"
       SP_NOTEBOOK_DIRECT_URL: http://notebook:2718
       SP_NOTEBOOK_UPSTREAM_MODE: direct

--- a/scripts/deploy-gateway-notebook-eks.sh
+++ b/scripts/deploy-gateway-notebook-eks.sh
@@ -47,6 +47,9 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 
 GATEWAY_DEPLOY_SCRIPT="${GATEWAY_DEPLOY_SCRIPT:-${ROOT_DIR}/../deploy-gateway-eks.sh}"
 GATEWAY_IMAGE="${GATEWAY_IMAGE:-signalpilot-gateway}"
+GATEWAY_CHAT_WORKER_IMAGE="${GATEWAY_CHAT_WORKER_IMAGE:-${GATEWAY_IMAGE}}"
+GATEWAY_CHAT_WORKER_COMMAND="${GATEWAY_CHAT_WORKER_COMMAND:-signalpilot-chat-worker}"
+GATEWAY_CHAT_WORKER_CONTAINER="${GATEWAY_CHAT_WORKER_CONTAINER:-gateway-chat-worker}"
 NOTEBOOK_NAMESPACE_PREFIX="${SP_NOTEBOOK_NAMESPACE_PREFIX:-sp-nb}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-signalpilot}"
 GATEWAY_DEPLOYMENT="${GATEWAY_DEPLOYMENT:-signalpilot-gateway}"
@@ -64,6 +67,13 @@ if [[ "${SKIP_GATEWAY_IMAGE_BUILD:-0}" != "1" ]]; then
 else
   log "Skipping gateway image build because SKIP_GATEWAY_IMAGE_BUILD=1"
 fi
+
+[[ "${GATEWAY_CHAT_WORKER_IMAGE}" == "${GATEWAY_IMAGE}" ]] \
+  || die "gateway and chat worker must use the same image: ${GATEWAY_IMAGE}"
+
+log "Verifying chat worker entrypoint in gateway image: ${GATEWAY_CHAT_WORKER_COMMAND}"
+run docker run --rm --entrypoint sh "$GATEWAY_IMAGE" \
+  -c "command -v '${GATEWAY_CHAT_WORKER_COMMAND}' >/dev/null"
 
 log "Verifying ECR repository exists: ${NOTEBOOK_ECR_REPO} in ${AWS_REGION}"
 if [[ "${DRY_RUN:-0}" == "1" ]]; then
@@ -131,10 +141,21 @@ GATEWAY_DEPLOY_FILE="$(basename "$GATEWAY_DEPLOY_SCRIPT")"
   cd "$GATEWAY_DEPLOY_DIR"
   run env \
     GATEWAY_IMAGE="$GATEWAY_IMAGE" \
+    GATEWAY_CHAT_WORKER_IMAGE="$GATEWAY_CHAT_WORKER_IMAGE" \
+    GATEWAY_CHAT_WORKER_COMMAND="$GATEWAY_CHAT_WORKER_COMMAND" \
+    GATEWAY_CHAT_WORKER_CONTAINER="$GATEWAY_CHAT_WORKER_CONTAINER" \
     NOTEBOOK_IMAGE="$SP_NOTEBOOK_IMAGE" \
     SP_NOTEBOOK_IMAGE="$SP_NOTEBOOK_IMAGE" \
     bash "./$GATEWAY_DEPLOY_FILE"
 )
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  log "DRY_RUN=1: would verify chat worker container: ${GATEWAY_CHAT_WORKER_CONTAINER}"
+elif [[ "$(docker inspect --format '{{.State.Running}}' "$GATEWAY_CHAT_WORKER_CONTAINER" 2>/dev/null || true)" != "true" ]]; then
+  die "chat worker container is not running after deploy: ${GATEWAY_CHAT_WORKER_CONTAINER}"
+else
+  log "Chat worker container is running: ${GATEWAY_CHAT_WORKER_CONTAINER}"
+fi
 
 if [[ "${SKIP_GATEWAY_ROLLOUT_WAIT:-0}" != "1" ]]; then
   if [[ "${DRY_RUN:-0}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- build the gateway image once and reuse it for `gateway-chat-worker`
- make chat object-storage settings environment-overridable for production S3
- pass the worker image/command/container contract to the external EC2 deploy hook
- fail deployment when the external hook does not leave the worker running
- reset inherited Compose networks in the K3s overlay

## Validation
- `bash -n scripts/deploy-gateway-notebook-eks.sh`
- `docker compose -f docker-compose.yml -f docker-compose.k8s.yml config --quiet`
- deployment wrapper dry-run with worker image and post-deploy check
- `git diff --check`

## EC2 follow-up
The local-only `/opt/signalpilot/deploy-gateway-eks.sh` must consume `GATEWAY_CHAT_WORKER_IMAGE`, `GATEWAY_CHAT_WORKER_COMMAND`, and `GATEWAY_CHAT_WORKER_CONTAINER`, add the chat S3/feature environment to the gateway, and start the worker container. That file is intentionally outside this repository.