### PR TITLE
Configure project production data connections

### DIFF
--- a/signalpilot/web/app/projects/[projectId]/settings/page.tsx
+++ b/signalpilot/web/app/projects/[projectId]/settings/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { ProjectConnectionSettings } from "~/components/projects/project-connection-settings";
+
+export default function ProjectSettingsPage() {
+  const params = useParams<{ projectId: string }>();
+  return <ProjectConnectionSettings projectId={params.projectId} />;
+}

--- a/signalpilot/web/components/chat/standalone-data-chat.tsx
+++ b/signalpilot/web/components/chat/standalone-data-chat.tsx
@@ -74,6 +74,7 @@ import {
   upsertStandaloneConversation,
   type OptimisticUserMessage,
 } from "~/lib/standalone-chat-state";
+import { projectSettingsHref } from "~/lib/project-settings-route";
 
 type UiMessage = StandaloneChatMessage & {
   runId?: string;
@@ -1774,7 +1775,7 @@ export function StandaloneDataChat({
                 <ReadinessNotice
                   message={unreadyMessage}
                   showSetup={showSetupCta}
-                  onSetup={() => router.push("/projects")}
+                  onSetup={() => router.push(projectSettingsHref(selectedProjectId))}
                 />
               </div>
             )}
@@ -1804,7 +1805,9 @@ export function StandaloneDataChat({
                     <ReadinessNotice
                       message={unreadyMessage}
                       showSetup={showSetupCta}
-                      onSetup={() => router.push("/projects")}
+                      onSetup={() =>
+                        router.push(projectSettingsHref(selectedProjectId))
+                      }
                     />
                   ) : starters.length === 4 ? (
                     <StarterQuestions

--- a/signalpilot/web/components/projects/project-connection-settings.tsx
+++ b/signalpilot/web/components/projects/project-connection-settings.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  Database,
+  ExternalLink,
+  Loader2,
+  Save,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { PageHeader, TerminalBar } from "~/components/ui/page-header";
+import { StatusDot } from "~/components/ui/data-viz";
+import { useToast } from "~/components/ui/toast";
+import {
+  getConnections,
+  getStandaloneChatProjectReadiness,
+  getWorkspaceProject,
+  testConnection,
+  updateWorkspaceProject,
+} from "~/lib/api";
+import type { ConnectionInfo, WorkspaceProjectInfo } from "~/lib/types";
+
+type ProjectReadiness = Awaited<
+  ReturnType<typeof getStandaloneChatProjectReadiness>
+>;
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function ProjectConnectionSettings({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [project, setProject] = useState<WorkspaceProjectInfo | null>(null);
+  const [connections, setConnections] = useState<ConnectionInfo[]>([]);
+  const [selectedConnection, setSelectedConnection] = useState("");
+  const [readiness, setReadiness] = useState<ProjectReadiness | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState("");
+  const [validationError, setValidationError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setLoadError("");
+
+    void Promise.all([getWorkspaceProject(projectId), getConnections()])
+      .then(async ([nextProject, nextConnections]) => {
+        if (!active) return;
+        setProject(nextProject);
+        setConnections(nextConnections);
+        setSelectedConnection(nextProject.connection_name ?? "");
+        try {
+          const nextReadiness =
+            await getStandaloneChatProjectReadiness(projectId);
+          if (active) setReadiness(nextReadiness);
+        } catch {
+          // Project connection configuration remains available when Data Chat
+          // is disabled or its readiness endpoint is unavailable.
+        }
+      })
+      .catch((error) => {
+        if (active) setLoadError(errorMessage(error));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [projectId]);
+
+  const saveConnection = async () => {
+    if (!selectedConnection || saving) return;
+    setSaving(true);
+    setValidationError("");
+
+    try {
+      const validation = await testConnection(selectedConnection);
+      if (validation.status !== "healthy") {
+        setValidationError(
+          validation.message || "This connection is not ready for production use.",
+        );
+        return;
+      }
+
+      const updated = await updateWorkspaceProject(projectId, {
+        connection_name: selectedConnection,
+      });
+      setProject(updated);
+
+      try {
+        const nextReadiness =
+          await getStandaloneChatProjectReadiness(projectId);
+        setReadiness(nextReadiness);
+      } catch {
+        setReadiness(null);
+      }
+
+      toast("Production connection assigned", "success");
+    } catch (error) {
+      setValidationError(errorMessage(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-[var(--color-text-dim)]" />
+      </div>
+    );
+  }
+
+  if (loadError || !project) {
+    return (
+      <div className="max-w-3xl p-8">
+        <button
+          type="button"
+          onClick={() => router.push("/projects")}
+          className="mb-6 inline-flex items-center gap-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" /> Projects
+        </button>
+        <div className="rounded-xl border border-[var(--color-error)]/30 bg-[var(--color-bg-card)] p-5 text-sm text-[var(--color-error)]">
+          {loadError || "Project not found"}
+        </div>
+      </div>
+    );
+  }
+
+  const connectionChanged = selectedConnection !== (project.connection_name ?? "");
+
+  return (
+    <div className="max-w-3xl animate-fade-in p-8">
+      <button
+        type="button"
+        onClick={() => router.push("/projects")}
+        className="mb-6 inline-flex items-center gap-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Projects
+      </button>
+
+      <PageHeader
+        title={project.display_name || project.name}
+        subtitle="project settings"
+        description="Assign the production data connection used by Data Chat and project runtimes."
+      />
+
+      <TerminalBar
+        path={`projects/${project.name}/settings`}
+        status={
+          <StatusDot
+            status={readiness?.ready ? "healthy" : "warning"}
+            size={4}
+          />
+        }
+      >
+        <span className="text-xs text-[var(--color-text-dim)]">
+          Data Chat: {readiness?.ready ? "ready" : "setup required"}
+        </span>
+      </TerminalBar>
+
+      <section className="mt-8 overflow-hidden rounded-[14px] border border-[var(--color-border)] bg-[var(--color-bg-card)]">
+        <div className="border-b border-[var(--color-border)] p-6">
+          <div className="flex items-start gap-3">
+            <Database className="mt-0.5 h-4 w-4 text-[var(--color-success)]" />
+            <div>
+              <h2 className="text-sm font-medium text-[var(--color-text)]">
+                Production data connection
+              </h2>
+              <p className="mt-1 text-xs leading-5 text-[var(--color-text-dim)]">
+                SignalPilot validates the connection before assigning it to this
+                project. Data Chat only runs when the complete project readiness
+                check passes.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4 p-6">
+          <div>
+            <label
+              htmlFor="project-production-connection"
+              className="mb-1.5 block text-xs text-[var(--color-text-dim)]"
+            >
+              Connection
+            </label>
+            <select
+              id="project-production-connection"
+              value={selectedConnection}
+              onChange={(event) => {
+                setSelectedConnection(event.target.value);
+                setValidationError("");
+              }}
+              disabled={saving}
+              className="w-full rounded-[10px] border border-[var(--color-border)] bg-[var(--color-bg-input)] px-3 py-2.5 text-sm text-[var(--color-text)] focus:border-[var(--color-text-dim)] focus:outline-none disabled:opacity-60"
+            >
+              <option value="" disabled>
+                Select a production connection
+              </option>
+              {connections.map((connection) => (
+                <option key={connection.id} value={connection.name}>
+                  {connection.name} · {connection.db_type}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {connections.length === 0 && (
+            <div className="rounded-lg border border-[var(--color-warning)]/25 p-3 text-xs text-[var(--color-warning)]">
+              No data connections are available. Create and test one before
+              assigning it to this project.
+            </div>
+          )}
+
+          {validationError && (
+            <div
+              role="alert"
+              className="flex items-start gap-2 rounded-lg border border-[var(--color-error)]/25 p-3 text-xs text-[var(--color-error)]"
+            >
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{validationError}</span>
+            </div>
+          )}
+
+          {readiness && !connectionChanged && (
+            <div
+              className={`flex items-start gap-2 rounded-lg border p-3 text-xs ${
+                readiness.ready
+                  ? "border-[var(--color-success)]/25 text-[var(--color-success)]"
+                  : "border-[var(--color-warning)]/25 text-[var(--color-warning)]"
+              }`}
+            >
+              {readiness.ready ? (
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              ) : (
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              )}
+              <span>{readiness.message}</span>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center justify-between gap-3 pt-2">
+            <a
+              href="/connections"
+              className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+            >
+              Manage connections <ExternalLink className="h-3 w-3" />
+            </a>
+            <button
+              type="button"
+              onClick={() => void saveConnection()}
+              disabled={!selectedConnection || saving}
+              className="inline-flex items-center gap-2 rounded-[10px] bg-[var(--color-text)] px-4 py-2 text-xs font-medium text-[var(--color-bg)] hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+              {saving ? "Validating…" : "Validate and save"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/signalpilot/web/components/projects/projects-overview-page.tsx
+++ b/signalpilot/web/components/projects/projects-overview-page.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   Plus,
   RefreshCw,
+  Settings,
   Trash2,
   X,
   type LucideIcon,
@@ -472,6 +473,9 @@ export default function ProjectsOverviewPage() {
               loading={projectsLoading}
               projectCount={overview.projectCount}
               onProjectClick={openProject}
+              onProjectSettings={(project) =>
+                router.push(`/projects/${encodeURIComponent(project.id)}/settings`)
+              }
               onProjectDeleted={loadOverview}
             />
           </div>
@@ -1011,12 +1015,14 @@ function ProjectGrid({
   loading,
   projectCount,
   onProjectClick,
+  onProjectSettings,
   onProjectDeleted,
 }: {
   projects: WorkspaceProjectInfo[];
   loading: boolean;
   projectCount: number;
   onProjectClick: (project: WorkspaceProjectInfo) => void;
+  onProjectSettings: (project: WorkspaceProjectInfo) => void;
   onProjectDeleted: () => void | Promise<void>;
 }) {
   if (loading && projects.length === 0) {
@@ -1050,6 +1056,7 @@ function ProjectGrid({
           key={project.id}
           project={project}
           onClick={onProjectClick}
+          onSettings={onProjectSettings}
           onDeleted={onProjectDeleted}
         />
       ))}
@@ -1060,10 +1067,12 @@ function ProjectGrid({
 function ProjectCard({
   project,
   onClick,
+  onSettings,
   onDeleted,
 }: {
   project: WorkspaceProjectInfo;
   onClick: (project: WorkspaceProjectInfo) => void;
+  onSettings: (project: WorkspaceProjectInfo) => void;
   onDeleted: () => void | Promise<void>;
 }) {
   const [showDelete, setShowDelete] = useState(false);
@@ -1129,6 +1138,24 @@ function ProjectCard({
             )}
           </div>
         </div>
+        <button
+          type="button"
+          className="absolute right-10 top-2 rounded-md p-1.5 text-[var(--color-text-dim)] opacity-0 transition-opacity hover:bg-muted hover:text-[var(--color-text)] focus-visible:opacity-100 group-hover:opacity-100"
+          onClick={(event) => {
+            event.stopPropagation();
+            onSettings(project);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              event.stopPropagation();
+              onSettings(project);
+            }
+          }}
+          aria-label={`Settings for ${projectName}`}
+        >
+          <Settings className="h-3.5 w-3.5" />
+        </button>
         <button
           type="button"
           className="absolute right-2 top-2 rounded-md p-1.5 text-[var(--color-text-dim)] opacity-0 transition-opacity hover:bg-[var(--color-error)]/10 hover:text-[var(--color-error)] group-hover:opacity-100"

--- a/signalpilot/web/lib/project-connection-settings.test.tsx
+++ b/signalpilot/web/lib/project-connection-settings.test.tsx
@@ -1,0 +1,174 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProjectConnectionSettings } from "~/components/projects/project-connection-settings";
+import type { ConnectionInfo, WorkspaceProjectInfo } from "~/lib/types";
+
+const mocks = vi.hoisted(() => ({
+  getConnections: vi.fn(),
+  getReadiness: vi.fn(),
+  getProject: vi.fn(),
+  testConnection: vi.fn(),
+  updateProject: vi.fn(),
+  toast: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+  usePathname: () => "/projects/project-1/settings",
+}));
+
+vi.mock("~/components/ui/toast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock("~/lib/api", () => ({
+  getConnections: mocks.getConnections,
+  getStandaloneChatProjectReadiness: mocks.getReadiness,
+  getWorkspaceProject: mocks.getProject,
+  testConnection: mocks.testConnection,
+  updateWorkspaceProject: mocks.updateProject,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const project: WorkspaceProjectInfo = {
+  id: "project-1",
+  org_id: "org-1",
+  name: "revenue",
+  display_name: "Revenue",
+  description: null,
+  source: "managed",
+  connection_name: null,
+  status: "active",
+  tags: [],
+  settings: null,
+  file_count: 2,
+  total_bytes: 100,
+  default_branch: "main",
+  created_by: "user-1",
+  created_at: 1,
+  updated_at: 1,
+};
+
+const connection = {
+  id: "connection-1",
+  name: "warehouse",
+  db_type: "postgres",
+} as ConnectionInfo;
+
+const unready = {
+  project_id: project.id,
+  ready: false,
+  code: "connection_missing",
+  message: "A production data connection has not been configured.",
+  setup_cta: true,
+  branch: "main",
+  connection_name: null,
+  starter_questions: [],
+};
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("ProjectConnectionSettings", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.getProject.mockResolvedValue(project);
+    mocks.getConnections.mockResolvedValue([connection]);
+    mocks.getReadiness.mockResolvedValue(unready);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<ProjectConnectionSettings projectId={project.id} />);
+    });
+    await settle();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("does not assign a connection that fails validation", async () => {
+    mocks.testConnection.mockResolvedValue({
+      status: "unhealthy",
+      message: "Credentials were rejected",
+    });
+
+    const select = container.querySelector("select")!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLSelectElement.prototype,
+      "value",
+    )?.set;
+    await act(async () => {
+      setter?.call(select, connection.name);
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    const save = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Validate and save"),
+    )!;
+    await act(async () => save.click());
+    await settle();
+
+    expect(mocks.testConnection).toHaveBeenCalledWith(connection.name);
+    expect(mocks.updateProject).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Credentials were rejected",
+    );
+  });
+
+  it("assigns a healthy connection with PUT and refreshes readiness", async () => {
+    const updated = { ...project, connection_name: connection.name };
+    mocks.testConnection.mockResolvedValue({
+      status: "healthy",
+      message: "Connection healthy",
+    });
+    mocks.updateProject.mockResolvedValue(updated);
+    mocks.getReadiness.mockResolvedValue({
+      ...unready,
+      ready: true,
+      code: "ready",
+      message: "Ready",
+      connection_name: connection.name,
+    });
+
+    const select = container.querySelector("select")!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLSelectElement.prototype,
+      "value",
+    )?.set;
+    await act(async () => {
+      setter?.call(select, connection.name);
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    const save = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Validate and save"),
+    )!;
+    await act(async () => save.click());
+    await settle();
+
+    expect(mocks.updateProject).toHaveBeenCalledWith(project.id, {
+      connection_name: connection.name,
+    });
+    expect(mocks.getReadiness).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Ready");
+    expect(mocks.toast).toHaveBeenCalledWith(
+      "Production connection assigned",
+      "success",
+    );
+  });
+});

--- a/signalpilot/web/lib/project-settings-route.test.ts
+++ b/signalpilot/web/lib/project-settings-route.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { projectSettingsHref } from "./project-settings-route";
+
+describe("projectSettingsHref", () => {
+  it("opens the selected project's connection settings directly", () => {
+    expect(projectSettingsHref("project/with spaces")).toBe(
+      "/projects/project%2Fwith%20spaces/settings",
+    );
+  });
+
+  it("falls back to the project overview when no project is selected", () => {
+    expect(projectSettingsHref(null)).toBe("/projects");
+  });
+});

--- a/signalpilot/web/lib/project-settings-route.ts
+++ b/signalpilot/web/lib/project-settings-route.ts
@@ -1,0 +1,5 @@
+export function projectSettingsHref(projectId: string | null | undefined) {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/settings`
+    : "/projects";
+}


### PR DESCRIPTION
## Summary
- add a project settings page with a production connection selector
- validate the selected connection before assigning it through `PUT /api/workspace-projects/{project_id}`
- refresh and display Data Chat readiness after assignment
- route Data Chat setup CTAs and project-card settings actions directly to the selected project configuration
- add focused tests for routing, validation failures, and successful assignment

## Validation
- `pnpm exec vitest run lib/project-settings-route.test.ts lib/project-connection-settings.test.tsx` (4 passed)
- `pnpm build`
- `git diff --check origin/main...HEAD`

## Context
This is the main-based replacement for #246, which was merged into `feature-sprint-7-22`.