### PR TITLE
Fix standalone chat DB session lifetime

### DIFF
--- a/signalpilot/gateway/gateway/standalone_chat/execution.py
+++ b/signalpilot/gateway/gateway/standalone_chat/execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -36,6 +37,13 @@ def _join_base_path(base: str, path: str) -> str:
     return f"{base.rstrip('/')}/{path.lstrip('/')}"
 
 
+@dataclass(frozen=True)
+class PreparedExecution:
+    url: str
+    headers: dict[str, str]
+    payload: dict[str, Any]
+
+
 async def ensure_execution_runtime(
     db: AsyncSession,
     *,
@@ -65,7 +73,7 @@ async def ensure_execution_runtime(
     return runtime
 
 
-async def stream_execution(
+async def prepare_execution(
     db: AsyncSession,
     *,
     run: GatewayChatRun,
@@ -76,7 +84,7 @@ async def stream_execution(
     prompt: str,
     messages: list[dict[str, str]],
     warm_context: dict[str, Any],
-) -> AsyncGenerator[dict[str, Any], None]:
+) -> PreparedExecution:
     runtime = await ensure_execution_runtime(
         db,
         run=run,
@@ -93,9 +101,7 @@ async def stream_execution(
     runtime_auth: dict[str, str] | None = None
     if anthropic_api_key:
         runtime_auth = {"type": "api_key", "token": anthropic_api_key}
-    elif oauth_token := (
-        os.getenv("CLAUDE_CODE_OAUTH_TOKEN") or os.getenv("OAUTH_TOKEN")
-    ):
+    elif oauth_token := (os.getenv("CLAUDE_CODE_OAUTH_TOKEN") or os.getenv("OAUTH_TOKEN")):
         runtime_auth = {"type": "oauth", "token": oauth_token}
     elif server_api_key := os.getenv("ANTHROPIC_API_KEY"):
         runtime_auth = {"type": "api_key", "token": server_api_key}
@@ -152,14 +158,22 @@ async def stream_execution(
         "X-Gateway-Connection-Name": connection_name,
         "X-Gateway-Commit-Sha": commit_sha,
     }
+    return PreparedExecution(
+        url=_join_base_path(runtime.internal_base_url, "/api/standalone-chat/execute"),
+        headers=headers,
+        payload=payload,
+    )
+
+
+async def stream_execution(execution: PreparedExecution) -> AsyncGenerator[dict[str, Any], None]:
     timeout = httpx.Timeout(connect=30.0, read=None, write=30.0, pool=30.0)
     async with (
         httpx.AsyncClient(timeout=timeout) as client,
         client.stream(
             "POST",
-            _join_base_path(runtime.internal_base_url, "/api/standalone-chat/execute"),
-            headers=headers,
-            json=payload,
+            execution.url,
+            headers=execution.headers,
+            json=execution.payload,
         ) as response,
     ):
         response.raise_for_status()
@@ -289,9 +303,7 @@ async def cleanup_expired_runtime_objects(db: AsyncSession) -> int:
     cleaned = 0
     expired = list(
         (
-            await db.execute(
-                select(GatewayRuntimeDataset).where(GatewayRuntimeDataset.expires_at <= now).limit(100)
-            )
+            await db.execute(select(GatewayRuntimeDataset).where(GatewayRuntimeDataset.expires_at <= now).limit(100))
         ).scalars()
     )
     for dataset in expired:

--- a/signalpilot/gateway/gateway/standalone_chat/worker.py
+++ b/signalpilot/gateway/gateway/standalone_chat/worker.py
@@ -27,6 +27,7 @@ from gateway.standalone_chat.execution import (
     cleanup_expired_approval_sandboxes,
     cleanup_expired_runtime_objects,
     cleanup_finished_execution,
+    prepare_execution,
     stream_execution,
 )
 from gateway.standalone_chat.projects import project_metadata_context
@@ -327,7 +328,7 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
                     )
                     if active_run is None:
                         return
-                    async for event in stream_execution(
+                    execution = await prepare_execution(
                         db,
                         run=active_run,
                         worker_id=worker_id,
@@ -337,97 +338,98 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
                         prompt=prompt,
                         messages=messages,
                         warm_context=warm_context,
-                    ):
-                        if stop.is_set():
-                            raise asyncio.CancelledError
-                        event_type = str(event.get("type") or "")
-                        content = str(event.get("content") or "")
-                        if event_type == "text_delta":
-                            streamed_text, emitted_content = _merge_text_delta(
-                                streamed_text,
-                                content,
-                                starts_new_block=starts_new_text_block,
-                            )
-                            if emitted_content:
-                                await _append(
-                                    run_id,
-                                    "text_delta",
-                                    {"delta": emitted_content},
-                                )
-                                starts_new_text_block = False
-                        elif event_type == "text":
-                            final_text = content
-                        elif event_type == "tool_use":
-                            starts_new_text_block = bool(streamed_text)
-                            tool_name = str(event.get("tool_name") or "analysis tool")
-                            tool_input = event.get("tool_input") or {}
-                            tool_call_id = str(event.get("tool_call_id") or "")
-                            if tool_call_id:
-                                tool_names_by_id[tool_call_id] = tool_name
+                    )
+                async for event in stream_execution(execution):
+                    if stop.is_set():
+                        raise asyncio.CancelledError
+                    event_type = str(event.get("type") or "")
+                    content = str(event.get("content") or "")
+                    if event_type == "text_delta":
+                        streamed_text, emitted_content = _merge_text_delta(
+                            streamed_text,
+                            content,
+                            starts_new_block=starts_new_text_block,
+                        )
+                        if emitted_content:
                             await _append(
                                 run_id,
-                                "tool_started",
-                                {"tool": tool_name, "input": tool_input},
+                                "text_delta",
+                                {"delta": emitted_content},
                             )
-                            if tool_name.endswith(("query_database", "explain_query", "validate_sql")):
-                                sql = tool_input.get("sql") if isinstance(tool_input, dict) else None
-                                if sql:
-                                    await _append(run_id, "sql", {"sql": sql})
-                            if any(marker in tool_name for marker in ("schema", "table", "relationship", "metric")):
-                                source_refs = {
-                                    key: value
-                                    for key, value in (tool_input.items() if isinstance(tool_input, dict) else [])
-                                    if key
-                                    in {
-                                        "metric_name",
-                                        "model_name",
-                                        "schema_name",
-                                        "source_name",
-                                        "table_name",
-                                    }
+                            starts_new_text_block = False
+                    elif event_type == "text":
+                        final_text = content
+                    elif event_type == "tool_use":
+                        starts_new_text_block = bool(streamed_text)
+                        tool_name = str(event.get("tool_name") or "analysis tool")
+                        tool_input = event.get("tool_input") or {}
+                        tool_call_id = str(event.get("tool_call_id") or "")
+                        if tool_call_id:
+                            tool_names_by_id[tool_call_id] = tool_name
+                        await _append(
+                            run_id,
+                            "tool_started",
+                            {"tool": tool_name, "input": tool_input},
+                        )
+                        if tool_name.endswith(("query_database", "explain_query", "validate_sql")):
+                            sql = tool_input.get("sql") if isinstance(tool_input, dict) else None
+                            if sql:
+                                await _append(run_id, "sql", {"sql": sql})
+                        if any(marker in tool_name for marker in ("schema", "table", "relationship", "metric")):
+                            source_refs = {
+                                key: value
+                                for key, value in (tool_input.items() if isinstance(tool_input, dict) else [])
+                                if key
+                                in {
+                                    "metric_name",
+                                    "model_name",
+                                    "schema_name",
+                                    "source_name",
+                                    "table_name",
                                 }
-                                await _append(
-                                    run_id,
-                                    "source",
-                                    {"tool": tool_name, **source_refs},
-                                )
-                        elif event_type == "tool_result":
-                            starts_new_text_block = bool(streamed_text)
-                            is_error = bool(event.get("is_error"))
-                            tool_call_id = str(event.get("tool_call_id") or "")
-                            completed_tool = tool_names_by_id.get(tool_call_id, "")
+                            }
                             await _append(
                                 run_id,
-                                "tool_completed",
-                                {
-                                    "tool_call_id": event.get("tool_call_id"),
-                                    "summary": (
-                                        "The governed tool returned an error."
-                                        if is_error
-                                        else "The governed tool completed."
-                                    ),
-                                    "error": is_error,
-                                },
+                                "source",
+                                {"tool": tool_name, **source_refs},
                             )
-                            if not is_error and completed_tool.endswith("start_analysis_notebook"):
-                                await _append(run_id, "notebook_started", {"status": "running"})
-                            if completed_tool.endswith("run_cells"):
-                                await _append(
-                                    run_id,
-                                    "cell_executed",
-                                    {"status": "failed" if is_error else "completed"},
-                                )
-                        elif event_type == "error":
-                            raise RuntimeError(content or "Notebook analysis failed")
-                        elif event_type == "final":
-                            final_text = content or final_text or streamed_text
-                            await _persist_artifacts(
-                                run_id=run_id,
-                                worker_id=worker_id,
-                                artifacts=[item for item in event.get("artifacts") or [] if isinstance(item, dict)],
+                    elif event_type == "tool_result":
+                        starts_new_text_block = bool(streamed_text)
+                        is_error = bool(event.get("is_error"))
+                        tool_call_id = str(event.get("tool_call_id") or "")
+                        completed_tool = tool_names_by_id.get(tool_call_id, "")
+                        await _append(
+                            run_id,
+                            "tool_completed",
+                            {
+                                "tool_call_id": event.get("tool_call_id"),
+                                "summary": (
+                                    "The governed tool returned an error."
+                                    if is_error
+                                    else "The governed tool completed."
+                                ),
+                                "error": is_error,
+                            },
+                        )
+                        if not is_error and completed_tool.endswith("start_analysis_notebook"):
+                            await _append(run_id, "notebook_started", {"status": "running"})
+                        if completed_tool.endswith("run_cells"):
+                            await _append(
+                                run_id,
+                                "cell_executed",
+                                {"status": "failed" if is_error else "completed"},
                             )
-                            if event.get("kernel_stopped"):
-                                await _append(run_id, "kernel_stopped", {"status": "stopped"})
+                    elif event_type == "error":
+                        raise RuntimeError(content or "Notebook analysis failed")
+                    elif event_type == "final":
+                        final_text = content or final_text or streamed_text
+                        await _persist_artifacts(
+                            run_id=run_id,
+                            worker_id=worker_id,
+                            artifacts=[item for item in event.get("artifacts") or [] if isinstance(item, dict)],
+                        )
+                        if event.get("kernel_stopped"):
+                            await _append(run_id, "kernel_stopped", {"status": "stopped"})
                 last_error = None
                 break
             except (httpx.HTTPError, OSError) as exc:
@@ -492,7 +494,12 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
                 message="The run was stopped.",
             )
     except Exception as exc:
-        logger.warning("Standalone chat run %s failed: %s", run_id, type(exc).__name__)
+        logger.warning(
+            "Standalone chat run %s failed: %s",
+            run_id,
+            type(exc).__name__,
+            exc_info=True,
+        )
         public_message = "I could not complete this analysis. You can inspect the work and retry."
         with suppress(Exception):
             await _append(

--- a/signalpilot/gateway/tests/test_standalone_chat_worker.py
+++ b/signalpilot/gateway/tests/test_standalone_chat_worker.py
@@ -1,0 +1,94 @@
+"""Focused worker lifecycle contracts for standalone data chat."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from gateway.standalone_chat import worker
+
+
+@pytest.mark.asyncio
+async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    active_sessions = 0
+    completed_runs: list[str] = []
+    failed_runs: list[str] = []
+
+    class FakeSessionContext:
+        async def __aenter__(self) -> object:
+            nonlocal active_sessions
+            active_sessions += 1
+            return object()
+
+        async def __aexit__(self, *_args: object) -> None:
+            nonlocal active_sessions
+            active_sessions -= 1
+
+    def session_factory() -> FakeSessionContext:
+        return FakeSessionContext()
+
+    run = SimpleNamespace(
+        id="run-a",
+        execution_attempt=1,
+        cancellation_requested_at=None,
+    )
+    project = SimpleNamespace(
+        connection_name="production",
+        default_branch="main",
+    )
+    conversation = SimpleNamespace(
+        branch="main",
+        commit_sha="a" * 40,
+    )
+    message = SimpleNamespace(role="user", content="Diagnose revenue")
+
+    async def get_worker_run(*_args: Any, **_kwargs: Any) -> Any:
+        return run
+
+    async def worker_context(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "project": project,
+            "conversation": conversation,
+            "messages": [message],
+        }
+
+    async def stream_execution(*_args: Any, **_kwargs: Any):
+        if active_sessions:
+            raise RuntimeError("database session remained open during notebook execution")
+        yield {"type": "final", "content": "Analysis complete", "artifacts": []}
+
+    async def prepare_execution(*_args: Any, **_kwargs: Any) -> object:
+        return object()
+
+    async def complete_run(*_args: Any, **kwargs: Any) -> None:
+        completed_runs.append(kwargs["run_id"])
+
+    async def fail_run(*_args: Any, **kwargs: Any) -> None:
+        failed_runs.append(kwargs["run_id"])
+
+    async def wait_until_stopped(_run_id: str, _worker_id: str, stop: Any) -> None:
+        await stop.wait()
+
+    async def noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(worker, "get_session_factory", lambda: session_factory)
+    monkeypatch.setattr(worker.chat_store, "get_worker_run", get_worker_run)
+    monkeypatch.setattr(worker.chat_store, "worker_context", worker_context)
+    monkeypatch.setattr(worker.chat_store, "complete_run", complete_run)
+    monkeypatch.setattr(worker.chat_store, "fail_run", fail_run)
+    monkeypatch.setattr(worker, "prepare_execution", prepare_execution)
+    monkeypatch.setattr(worker, "stream_execution", stream_execution)
+    monkeypatch.setattr(worker, "_warm_context", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(worker, "_append", noop)
+    monkeypatch.setattr(worker, "_persist_artifacts", noop)
+    monkeypatch.setattr(worker, "_lease_renewer", wait_until_stopped)
+    monkeypatch.setattr(worker, "_cancellation_monitor", wait_until_stopped)
+    monkeypatch.setattr(worker, "cleanup_finished_execution", noop)
+
+    await worker._execute_claimed_run("run-a", "worker-a")
+
+    assert completed_runs == ["run-a"]
+    assert failed_runs == []


### PR DESCRIPTION
## Summary

- prepare the notebook execution inside a short-lived gateway DB session
- close that session before consuming the long-running notebook HTTP stream
- include exception tracebacks in worker logs for future production diagnosis
- add a regression test proving no DB session remains open during streaming

## Production failure

Two standalone chat runs completed notebook startup and streamed for several minutes, then failed with `InterfaceError`. The worker held a SQLAlchemy session open across the entire HTTP stream, allowing its connection to become stale before context cleanup.

## Validation

- `pytest -q tests/test_standalone_chat.py tests/test_standalone_chat_worker.py` — 29 passed
- `ruff check gateway/standalone_chat/execution.py gateway/standalone_chat/worker.py tests/test_standalone_chat_worker.py` — passed
- `ruff format --check gateway/standalone_chat/execution.py gateway/standalone_chat/worker.py tests/test_standalone_chat_worker.py` — passed
- `git diff --check` — passed

Full gateway collection remains blocked by pre-existing imports of removed symbols in `tests/test_mcp_dbt_security.py` and `tests/test_run_notebook_scoped_jwt.py`.