### PR TITLE
Guarantee Data Chat notebook execution integrity

### DIFF
--- a/signalpilot/gateway/gateway/standalone_chat/worker.py
+++ b/signalpilot/gateway/gateway/standalone_chat/worker.py
@@ -359,6 +359,12 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
                             starts_new_text_block = False
                     elif event_type == "text":
                         final_text = content
+                    elif event_type == "progress":
+                        await _append(
+                            run_id,
+                            "progress",
+                            {"label": content or "Analysis is continuing"},
+                        )
                     elif event_type == "tool_use":
                         starts_new_text_block = bool(streamed_text)
                         tool_name = str(event.get("tool_name") or "analysis tool")

--- a/signalpilot/gateway/gateway/store/standalone_chat.py
+++ b/signalpilot/gateway/gateway/store/standalone_chat.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1194,7 +1194,14 @@ async def append_event(
     event_type: str,
     payload: dict[str, Any],
 ) -> GatewayChatRunEvent:
-    run = (await db.execute(select(GatewayChatRun).where(GatewayChatRun.id == run_id).with_for_update())).scalar_one()
+    run = (
+        await db.execute(
+            select(GatewayChatRun)
+            .where(GatewayChatRun.id == run_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
     event = _stage_run_event(
         db,
         run=run,
@@ -1916,7 +1923,25 @@ async def fail_run(
         payload={"status": target},
     )
     await _retain_runtime_datasets_after_terminal_run(db, run=run)
+    artifact_object_keys = list(
+        (
+            await db.execute(
+                select(
+                    GatewayChatArtifact.object_key,
+                    GatewayChatArtifact.source_object_key,
+                ).where(GatewayChatArtifact.run_id == run.id)
+            )
+        ).all()
+    )
+    await db.execute(delete(GatewayChatArtifact).where(GatewayChatArtifact.run_id == run.id))
     await db.commit()
+    if artifact_object_keys:
+        storage = chat_object_storage()
+        for object_key, source_object_key in artifact_object_keys:
+            for key in (object_key, source_object_key):
+                if key:
+                    with suppress(Exception):
+                        await storage.delete(key)
     return True
 
 

--- a/signalpilot/gateway/tests/test_standalone_chat.py
+++ b/signalpilot/gateway/tests/test_standalone_chat.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -913,6 +915,35 @@ async def test_event_ordering_redaction_and_replay(db_session):
 
 
 @pytest.mark.asyncio
+async def test_event_ordering_refreshes_a_stale_locked_run(db_session):
+    _, run = await _conversation_and_run(db_session)
+    factory = async_sessionmaker(
+        db_session.bind,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+    async with factory() as stale_session:
+        stale_run = await stale_session.get(GatewayChatRun, run.id)
+        assert stale_run is not None
+        assert stale_run.last_event_sequence == 0
+
+        first = await chat_store.append_event(
+            db_session,
+            run_id=run.id,
+            event_type="tool_completed",
+            payload={"error": False},
+        )
+        second = await chat_store.append_event(
+            stale_session,
+            run_id=run.id,
+            event_type="artifact_created",
+            payload={"artifact_id": "artifact-a"},
+        )
+
+    assert (first.sequence, second.sequence) == (1, 2)
+
+
+@pytest.mark.asyncio
 async def test_claim_completion_and_final_message_are_idempotent(db_session):
     conversation_id, run = await _conversation_and_run(db_session)
     claimed = await chat_store.claim_runs(
@@ -996,7 +1027,10 @@ async def test_expired_lease_is_reclaimed(db_session):
 
 
 @pytest.mark.asyncio
-async def test_cancelled_and_failed_runs_leave_inspectable_status_messages(db_session):
+async def test_cancelled_and_failed_runs_leave_inspectable_status_messages(
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+):
     conversation_id, queued_run = await _conversation_and_run(db_session)
     cancelled = await chat_store.request_cancellation(
         db_session,
@@ -1035,6 +1069,29 @@ async def test_cancelled_and_failed_runs_leave_inspectable_status_messages(db_se
         limit=1,
         lease_seconds=45,
     )
+    failed_artifact = await chat_store.persist_artifact(
+        db_session,
+        run=failed_run,
+        payload={
+            "kind": "table",
+            "filename": "unvalidated.csv",
+            "mime_type": "text/csv",
+            "snapshot": {
+                "columns": [{"name": "value"}],
+                "rows": [{"value": 1}],
+            },
+        },
+    )
+    failed_artifact.storage_kind = "object"
+    failed_artifact.object_key = "artifacts/unvalidated.csv"
+    failed_artifact.source_object_key = "artifact-sources/unvalidated.csv"
+    await db_session.commit()
+    delete_object = AsyncMock()
+    monkeypatch.setattr(
+        chat_store,
+        "chat_object_storage",
+        lambda: SimpleNamespace(delete=delete_object),
+    )
     assert await chat_store.fail_run(
         db_session,
         run_id=failed_run.id,
@@ -1050,6 +1107,12 @@ async def test_cancelled_and_failed_runs_leave_inspectable_status_messages(db_se
     )
     assert detail is not None
     assert detail.messages[-1].metadata["status"] == "failed"
+    assert all(artifact.id != failed_artifact.id for artifact in detail.artifacts)
+    assert await db_session.get(GatewayChatArtifact, failed_artifact.id) is None
+    assert [call.args[0] for call in delete_object.await_args_list] == [
+        "artifacts/unvalidated.csv",
+        "artifact-sources/unvalidated.csv",
+    ]
     failed_events = await chat_store.list_run_events(
         db_session,
         org_id="org-a",

--- a/signalpilot/gateway/tests/test_standalone_chat_worker.py
+++ b/signalpilot/gateway/tests/test_standalone_chat_worker.py
@@ -15,6 +15,7 @@ async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pyt
     active_sessions = 0
     completed_runs: list[str] = []
     failed_runs: list[str] = []
+    appended_events: list[tuple[str, dict[str, Any]]] = []
 
     class FakeSessionContext:
         async def __aenter__(self) -> object:
@@ -57,6 +58,21 @@ async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pyt
     async def stream_execution(*_args: Any, **_kwargs: Any):
         if active_sessions:
             raise RuntimeError("database session remained open during notebook execution")
+        yield {
+            "type": "tool_use",
+            "tool_name": "mcp__signalpilot-notebook__run_cells",
+            "tool_call_id": "failed-run",
+            "tool_input": {"cell_ids": ["cell-a"]},
+        }
+        yield {
+            "type": "tool_result",
+            "tool_call_id": "failed-run",
+            "is_error": True,
+        }
+        yield {
+            "type": "progress",
+            "content": "Restarting analysis in a clean notebook",
+        }
         yield {"type": "final", "content": "Analysis complete", "artifacts": []}
 
     async def prepare_execution(*_args: Any, **_kwargs: Any) -> object:
@@ -74,6 +90,13 @@ async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pyt
     async def noop(*_args: Any, **_kwargs: Any) -> None:
         return None
 
+    async def append_event(
+        _run_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
+        appended_events.append((event_type, payload))
+
     monkeypatch.setattr(worker, "get_session_factory", lambda: session_factory)
     monkeypatch.setattr(worker.chat_store, "get_worker_run", get_worker_run)
     monkeypatch.setattr(worker.chat_store, "worker_context", worker_context)
@@ -82,7 +105,7 @@ async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pyt
     monkeypatch.setattr(worker, "prepare_execution", prepare_execution)
     monkeypatch.setattr(worker, "stream_execution", stream_execution)
     monkeypatch.setattr(worker, "_warm_context", lambda *_args, **_kwargs: {})
-    monkeypatch.setattr(worker, "_append", noop)
+    monkeypatch.setattr(worker, "_append", append_event)
     monkeypatch.setattr(worker, "_persist_artifacts", noop)
     monkeypatch.setattr(worker, "_lease_renewer", wait_until_stopped)
     monkeypatch.setattr(worker, "_cancellation_monitor", wait_until_stopped)
@@ -92,3 +115,97 @@ async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pyt
 
     assert completed_runs == ["run-a"]
     assert failed_runs == []
+    assert ("cell_executed", {"status": "failed"}) in appended_events
+    assert (
+        "progress",
+        {"label": "Restarting analysis in a clean notebook"},
+    ) in appended_events
+
+
+@pytest.mark.asyncio
+async def test_terminal_notebook_validation_error_persists_no_answer_or_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed_runs: list[str] = []
+    failed_runs: list[str] = []
+    persisted_artifacts: list[str] = []
+
+    class FakeSessionContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    run = SimpleNamespace(
+        id="run-dirty",
+        execution_attempt=1,
+        cancellation_requested_at=None,
+    )
+    context = {
+        "project": SimpleNamespace(
+            connection_name="production",
+            default_branch="main",
+        ),
+        "conversation": SimpleNamespace(
+            branch="main",
+            commit_sha="a" * 40,
+            internal_summary=None,
+        ),
+        "messages": [SimpleNamespace(role="user", content="Diagnose revenue")],
+        "artifacts": [],
+        "query_approvals": [],
+        "query_proposals": [],
+        "query_executions": [],
+        "query_results": [],
+    }
+
+    async def get_worker_run(*_args: Any, **_kwargs: Any) -> Any:
+        return run
+
+    async def worker_context(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return context
+
+    async def stream_execution(*_args: Any, **_kwargs: Any):
+        yield {
+            "type": "error",
+            "content": "Notebook validation failed after one clean retry; the answer was rejected.",
+        }
+
+    async def prepare_execution(*_args: Any, **_kwargs: Any) -> object:
+        return object()
+
+    async def complete_run(*_args: Any, **kwargs: Any) -> None:
+        completed_runs.append(kwargs["run_id"])
+
+    async def fail_run(*_args: Any, **kwargs: Any) -> None:
+        failed_runs.append(kwargs["run_id"])
+
+    async def persist_artifacts(*_args: Any, **kwargs: Any) -> None:
+        persisted_artifacts.append(kwargs["run_id"])
+
+    async def wait_until_stopped(_run_id: str, _worker_id: str, stop: Any) -> None:
+        await stop.wait()
+
+    async def noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(worker, "get_session_factory", lambda: FakeSessionContext)
+    monkeypatch.setattr(worker.chat_store, "get_worker_run", get_worker_run)
+    monkeypatch.setattr(worker.chat_store, "worker_context", worker_context)
+    monkeypatch.setattr(worker.chat_store, "complete_run", complete_run)
+    monkeypatch.setattr(worker.chat_store, "fail_run", fail_run)
+    monkeypatch.setattr(worker, "prepare_execution", prepare_execution)
+    monkeypatch.setattr(worker, "stream_execution", stream_execution)
+    monkeypatch.setattr(worker, "_warm_context", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(worker, "_append", noop)
+    monkeypatch.setattr(worker, "_persist_artifacts", persist_artifacts)
+    monkeypatch.setattr(worker, "_lease_renewer", wait_until_stopped)
+    monkeypatch.setattr(worker, "_cancellation_monitor", wait_until_stopped)
+    monkeypatch.setattr(worker, "cleanup_finished_execution", noop)
+
+    await worker._execute_claimed_run("run-dirty", "worker-a")
+
+    assert completed_runs == []
+    assert persisted_artifacts == []
+    assert failed_runs == ["run-dirty"]

--- a/signalpilot/notebook-server/signalpilot/_server/ai/notebook_mcp.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/notebook_mcp.py
@@ -139,6 +139,9 @@ def _record_notebook_failure(
     dirty: bool,
 ) -> None:
     session._signalpilot_last_notebook_failure = payload
+    recorded = list(getattr(session, "_signalpilot_notebook_failures", ()))
+    recorded.append(payload)
+    session._signalpilot_notebook_failures = recorded[-20:]
     if dirty:
         session._signalpilot_notebook_dirty = True
     error = payload.get("error") or {}
@@ -261,6 +264,10 @@ def build_notebook_mcp_server(
             description=(
                 "Edit cells in a notebook. Supports adding, updating, and deleting cells. "
                 "Each edit needs a session_id (from get_active_notebooks or the system prompt). "
+                "This is a marimo notebook: every non-private top-level name, including imports "
+                "and loop targets, may be defined by only one live cell. Inspect the current cell "
+                "map first; use underscore-prefixed names for disposable cell-local variables, "
+                "and delete or update old definitions in the same atomic edit batch. "
                 "Operations: update_cell (modify existing cell code), "
                 "add_cell (add a new cell with generated ID), "
                 "delete_cell (remove a cell). "

--- a/signalpilot/notebook-server/signalpilot/_server/ai/notebook_mcp.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/notebook_mcp.py
@@ -267,7 +267,8 @@ def build_notebook_mcp_server(
                 "This is a marimo notebook: every non-private top-level name, including imports "
                 "and loop targets, may be defined by only one live cell. Inspect the current cell "
                 "map first; use underscore-prefixed names for disposable cell-local variables, "
-                "and delete or update old definitions in the same atomic edit batch. "
+                "never reference those private names from another cell, and delete or update old "
+                "definitions in the same atomic edit batch. "
                 "Operations: update_cell (modify existing cell code), "
                 "add_cell (add a new cell with generated ID), "
                 "delete_cell (remove a cell). "
@@ -880,6 +881,8 @@ def _handle_run_cells(
     try:
         import requests as _requests
 
+        from signalpilot._messaging.cell_output import CellOutput
+
         hdrs = _server_headers(context, str(session_id))
 
         instantiate_response = _requests.post(
@@ -892,6 +895,18 @@ def _handle_run_cells(
             raise RuntimeError(
                 f"Kernel instantiate returned HTTP {instantiate_response.status_code}"
             )
+
+        # A successful no-output execution broadcasts CellOutput.empty(). The
+        # session-view merge intentionally treats an omitted output as
+        # unchanged, and older runtimes also retained an explicit empty output
+        # over a previous error. Clear the cached output before queueing so the
+        # notification for this execution cannot inherit a stale exception.
+        # The timestamp remains unchanged, so polling still requires a fresh
+        # terminal notification from the kernel.
+        for cell_id in run_ids:
+            notification = session.session_view.cell_notifications.get(cell_id)
+            if notification is not None:
+                notification.output = CellOutput.empty()
 
         resp = _requests.post(
             _local_server_url(context, "/api/kernel/run"),

--- a/signalpilot/notebook-server/signalpilot/_server/ai/notebook_mcp.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/notebook_mcp.py
@@ -9,13 +9,14 @@ so every connected browser sees real-time updates.
 Multi-notebook: every mutating tool accepts a session_id parameter.
 Use get_active_notebooks to discover available sessions.
 """
+
 from __future__ import annotations
 
 import ast
 import json
 import uuid
 from dataclasses import asdict, is_dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 from urllib.parse import urlunsplit
 
 from signalpilot import _loggers
@@ -36,18 +37,132 @@ from signalpilot._server.ai.chat_runtime_output import (
     notebook_server_headers,
     redact_chat_runtime_text,
 )
-from signalpilot._server.ai.tools.base import ToolBase, ToolContext
 from signalpilot._server.ai.tools.exceptions import ToolExecutionError
-from signalpilot._server.ai.tools.registry import (
-    SUPPORTED_BACKEND_AND_MCP_TOOLS,
-)
 from signalpilot._types.ids import CellId_t
 from signalpilot._utils.dataclass_to_openapi import PythonTypeToOpenAPI
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from signalpilot._server.ai.tools.base import ToolBase, ToolContext
+
 LOGGER = _loggers.sp_logger()
+
+
+class NotebookToolError(ValueError):
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        super().__init__(json.dumps(payload, default=str, sort_keys=True))
+
+
+def _graph_error_payload(
+    *,
+    error_type: str,
+    cell_ids: list[str],
+    variable: str | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    error: dict[str, Any] = {
+        "type": error_type,
+        "variable": variable,
+        "cell_ids": sorted(set(cell_ids)),
+    }
+    if message:
+        error["message"] = message[:500]
+    return {"status": "rejected", "has_errors": True, "error": error}
+
+
+def _validate_candidate_graph(cells: list[tuple[CellId_t, str]]) -> None:
+    import linecache
+
+    from signalpilot._ast.compiler import compile_cell, get_filename
+    from signalpilot._lint.validate_graph import check_for_errors
+    from signalpilot._runtime.dataflow import DirectedGraph
+
+    filenames = {get_filename(cell_id) for cell_id, _code in cells}
+    previous_cache = {
+        filename: linecache.cache.get(filename) for filename in filenames
+    }
+    try:
+        graph = DirectedGraph()
+        for cell_id, code in cells:
+            try:
+                graph.register_cell(
+                    cell_id, compile_cell(code, cell_id=cell_id)
+                )
+            except SyntaxError as exc:
+                raise NotebookToolError(
+                    _graph_error_payload(
+                        error_type="SyntaxError",
+                        cell_ids=[str(cell_id)],
+                        message=exc.msg,
+                    )
+                ) from exc
+
+        graph_errors = check_for_errors(graph)
+        for cell_id in sorted(graph_errors, key=str):
+            for error in graph_errors[cell_id]:
+                error_type = type(error).__name__
+                variable = str(getattr(error, "name", "") or "") or None
+                involved = {str(cell_id)}
+                involved.update(
+                    str(value) for value in getattr(error, "cells", ())
+                )
+                edge_variables: set[str] = set()
+                for source, variables, target in getattr(
+                    error, "edges_with_vars", ()
+                ):
+                    involved.update((str(source), str(target)))
+                    edge_variables.update(str(value) for value in variables)
+                if variable is None and edge_variables:
+                    variable = sorted(edge_variables)[0]
+                raise NotebookToolError(
+                    _graph_error_payload(
+                        error_type=error_type,
+                        variable=variable,
+                        cell_ids=sorted(involved),
+                        message=error.describe(),
+                    )
+                )
+    finally:
+        for filename, cached in previous_cache.items():
+            if cached is None:
+                linecache.cache.pop(filename, None)
+            else:
+                linecache.cache[filename] = cached
+
+
+def _record_notebook_failure(
+    session: Any,
+    payload: dict[str, Any],
+    *,
+    dirty: bool,
+) -> None:
+    session._signalpilot_last_notebook_failure = payload
+    if dirty:
+        session._signalpilot_notebook_dirty = True
+    error = payload.get("error") or {}
+    LOGGER.error(
+        "Notebook operation failed run_id=%s session_id=%s attempt=%s "
+        "error_type=%s variable=%s cell_ids=%s dirty=%s",
+        getattr(session, "_signalpilot_chat_run_id", ""),
+        getattr(session, "_signalpilot_chat_session_id", ""),
+        getattr(session, "_signalpilot_chat_attempt", ""),
+        error.get("type"),
+        error.get("variable"),
+        error.get("cell_ids"),
+        dirty,
+    )
+
+
+def _raise_notebook_failure(
+    session: Any,
+    payload: dict[str, Any],
+    *,
+    dirty: bool,
+) -> NoReturn:
+    _record_notebook_failure(session, payload, dirty=dirty)
+    raise NotebookToolError(payload)
 
 
 def _is_markdown_call(value: ast.AST) -> bool:
@@ -55,7 +170,10 @@ def _is_markdown_call(value: ast.AST) -> bool:
         return False
     func = value.func
     if isinstance(func, ast.Attribute) and func.attr == "md":
-        return isinstance(func.value, ast.Name) and func.value.id in {"sp", "mo"}
+        return isinstance(func.value, ast.Name) and func.value.id in {
+            "sp",
+            "mo",
+        }
     return False
 
 
@@ -114,6 +232,10 @@ def build_notebook_mcp_server(
     from mcp.server import Server
     from mcp.types import TextContent, Tool
 
+    from signalpilot._server.ai.tools.registry import (
+        SUPPORTED_BACKEND_AND_MCP_TOOLS,
+    )
+
     server = Server("signalpilot-notebook", version="1.0.0")
 
     tool_instances: dict[str, ToolBase[Any, Any]] = {}
@@ -158,7 +280,11 @@ def build_notebook_mcp_server(
                             "properties": {
                                 "type": {
                                     "type": "string",
-                                    "enum": ["update_cell", "add_cell", "delete_cell"],
+                                    "enum": [
+                                        "update_cell",
+                                        "add_cell",
+                                        "delete_cell",
+                                    ],
                                 },
                                 "cell_id": {
                                     "type": "string",
@@ -286,7 +412,9 @@ def build_notebook_mcp_server(
         return tool_definitions
 
     @server.call_tool()
-    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    async def call_tool(
+        name: str, arguments: dict[str, Any]
+    ) -> list[TextContent]:
         authorize_chat_runtime_session(name, arguments, session_authorizer)
         if name in tool_instances:
             return await _invoke_backend_tool(tool_instances, name, arguments)
@@ -342,135 +470,285 @@ def _handle_save_data_snapshot(
 def _handle_edit_notebook(
     context: ToolContext, arguments: dict[str, Any]
 ) -> list[Any]:
-    """Edit notebook cells via Document Transaction system.
-
-    Uses session.document.apply() + session.notify() to update both
-    the backend document model and all connected frontends in real-time.
-    """
+    """Apply a graph-safe notebook edit transaction."""
     from mcp.types import TextContent
 
     session_id = arguments.get("session_id", "")
     edits = arguments.get("edits", [])
 
     if not session_id:
-        return [TextContent(type="text", text="Error: session_id is required. Call get_active_notebooks first.")]
+        raise NotebookToolError(
+            _graph_error_payload(
+                error_type="InvalidRequest",
+                cell_ids=[],
+                message="session_id is required",
+            )
+        )
     if not edits:
-        return [TextContent(type="text", text="Error: edits list is empty")]
+        raise NotebookToolError(
+            _graph_error_payload(
+                error_type="InvalidRequest",
+                cell_ids=[],
+                message="edits list is empty",
+            )
+        )
 
     try:
         session = context.get_session(session_id)
     except ToolExecutionError as e:
-        return [TextContent(type="text", text=f"Error: {e.message}")]
+        raise NotebookToolError(
+            _graph_error_payload(
+                error_type="SessionNotFound",
+                cell_ids=[],
+                message=e.message,
+            )
+        ) from e
 
     cell_manager = session.app_file_manager.app.cell_manager
     existing_cells = list(cell_manager.cell_data())
     existing_ids = {str(cd.cell_id) for cd in existing_cells}
     existing_by_id = {str(cd.cell_id): cd for cd in existing_cells}
+    candidate_codes = {str(cd.cell_id): cd.code for cd in existing_cells}
+    candidate_order = [str(cd.cell_id) for cd in existing_cells]
     last_cell_id = str(existing_cells[-1].cell_id) if existing_cells else None
 
-    LOGGER.info(f"[edit_notebook] session={session_id}, cells={sorted(existing_ids)}, edits={len(edits)}")
+    LOGGER.info(
+        "[edit_notebook] session=%s cells=%s edits=%s",
+        session_id,
+        sorted(existing_ids),
+        len(edits),
+    )
 
-    # Build document changes and track results
-    doc_changes = []
-    results = []
+    doc_changes: list[Any] = []
+    results: list[dict[str, Any]] = []
+    delete_ids: list[CellId_t] = []
     execute_ids: list[CellId_t] = []
     execute_codes: list[str] = []
+    touched_ids: set[str] = set()
 
     for edit in edits:
         op = edit.get("type", "")
-        cell_id = edit.get("cell_id", "")
-        code = edit.get("code", "")
+        cell_id = str(edit.get("cell_id") or "")
+        code = edit.get("code")
 
         if op == "add_cell":
+            if not isinstance(code, str):
+                _raise_notebook_failure(
+                    session,
+                    _graph_error_payload(
+                        error_type="InvalidRequest",
+                        cell_ids=[],
+                        message="code is required for add_cell",
+                    ),
+                    dirty=False,
+                )
             new_id = CellId_t(str(uuid.uuid4()).replace("-", "")[:8])
             hide_code = _is_markdown_only_cell(code)
-            doc_changes.append(CreateCell(
-                cell_id=new_id,
-                code=code,
-                name="_",
-                config=CellConfig(hide_code=hide_code),
-                after=CellId_t(last_cell_id) if last_cell_id else None,
-            ))
+            doc_changes.append(
+                CreateCell(
+                    cell_id=new_id,
+                    code=code,
+                    name="_",
+                    config=CellConfig(hide_code=hide_code),
+                    after=CellId_t(last_cell_id) if last_cell_id else None,
+                )
+            )
             execute_ids.append(new_id)
             execute_codes.append(code)
             last_cell_id = str(new_id)
-            results.append({"op": "add_cell", "cell_id": str(new_id), "status": "ok", "hide_code": hide_code})
+            candidate_codes[str(new_id)] = code
+            candidate_order.append(str(new_id))
+            results.append(
+                {
+                    "op": "add_cell",
+                    "cell_id": str(new_id),
+                    "status": "ok",
+                    "hide_code": hide_code,
+                }
+            )
 
         elif op == "update_cell":
             if not cell_id or cell_id not in existing_ids:
-                results.append({"op": op, "cell_id": cell_id,
-                                "error": f"cell_id not found. Available: {sorted(existing_ids)}"})
-                continue
+                _raise_notebook_failure(
+                    session,
+                    _graph_error_payload(
+                        error_type="CellNotFound",
+                        cell_ids=[cell_id] if cell_id else [],
+                        message=f"Available cells: {sorted(existing_ids)}",
+                    ),
+                    dirty=False,
+                )
+            if cell_id in touched_ids:
+                _raise_notebook_failure(
+                    session,
+                    _graph_error_payload(
+                        error_type="DuplicateEdit",
+                        cell_ids=[cell_id],
+                        message="A cell may be updated or deleted only once per batch",
+                    ),
+                    dirty=False,
+                )
+            if not isinstance(code, str):
+                _raise_notebook_failure(
+                    session,
+                    _graph_error_payload(
+                        error_type="InvalidRequest",
+                        cell_ids=[cell_id],
+                        message="code is required for update_cell",
+                    ),
+                    dirty=False,
+                )
+            touched_ids.add(cell_id)
             doc_changes.append(SetCode(cell_id=CellId_t(cell_id), code=code))
             if _is_markdown_only_cell(code):
                 existing = existing_by_id[cell_id]
                 if not existing.config.hide_code:
-                    doc_changes.append(SetConfig(
-                        cell_id=CellId_t(cell_id),
-                        column=existing.config.column,
-                        disabled=existing.config.disabled,
-                        hide_code=True,
-                    ))
+                    doc_changes.append(
+                        SetConfig(
+                            cell_id=CellId_t(cell_id),
+                            column=existing.config.column,
+                            disabled=existing.config.disabled,
+                            hide_code=True,
+                        )
+                    )
             execute_ids.append(CellId_t(cell_id))
             execute_codes.append(code)
-            results.append({"op": "update_cell", "cell_id": cell_id, "status": "ok", "hide_code": _is_markdown_only_cell(code)})
+            candidate_codes[cell_id] = code
+            results.append(
+                {
+                    "op": "update_cell",
+                    "cell_id": cell_id,
+                    "status": "ok",
+                    "hide_code": _is_markdown_only_cell(code),
+                }
+            )
 
         elif op == "delete_cell":
             if not cell_id or cell_id not in existing_ids:
-                results.append({"op": op, "cell_id": cell_id,
-                                "error": f"cell_id not found. Available: {sorted(existing_ids)}"})
-                continue
+                _raise_notebook_failure(
+                    session,
+                    _graph_error_payload(
+                        error_type="CellNotFound",
+                        cell_ids=[cell_id] if cell_id else [],
+                        message=f"Available cells: {sorted(existing_ids)}",
+                    ),
+                    dirty=False,
+                )
+            if cell_id in touched_ids:
+                _raise_notebook_failure(
+                    session,
+                    _graph_error_payload(
+                        error_type="DuplicateEdit",
+                        cell_ids=[cell_id],
+                        message="A cell may be updated or deleted only once per batch",
+                    ),
+                    dirty=False,
+                )
+            touched_ids.add(cell_id)
             doc_changes.append(DeleteCell(cell_id=CellId_t(cell_id)))
+            delete_ids.append(CellId_t(cell_id))
             existing_ids.discard(cell_id)
-            results.append({"op": "delete_cell", "cell_id": cell_id, "status": "ok"})
+            candidate_codes.pop(cell_id)
+            candidate_order.remove(cell_id)
+            results.append(
+                {"op": "delete_cell", "cell_id": cell_id, "status": "ok"}
+            )
 
         else:
-            results.append({"op": op, "error": f"Unknown operation: {op}"})
+            _raise_notebook_failure(
+                session,
+                _graph_error_payload(
+                    error_type="InvalidRequest",
+                    cell_ids=[cell_id] if cell_id else [],
+                    message=f"Unknown operation: {op}",
+                ),
+                dirty=False,
+            )
 
-    if not doc_changes:
-        return [TextContent(type="text", text=json.dumps({"edits": results}, default=str))]
+    try:
+        _validate_candidate_graph(
+            [
+                (CellId_t(cell_id), candidate_codes[cell_id])
+                for cell_id in candidate_order
+            ]
+        )
+    except NotebookToolError as exc:
+        _record_notebook_failure(session, exc.payload, dirty=False)
+        raise
 
-    # 1. Apply document transaction — updates backend document model
     try:
         transaction = Transaction(changes=tuple(doc_changes), source="kernel")
         applied = session.document.apply(transaction)
-        LOGGER.info(f"[edit_notebook] Transaction applied: {len(doc_changes)} changes, version={applied.version}")
+        LOGGER.info(
+            "[edit_notebook] Transaction applied changes=%s version=%s",
+            len(doc_changes),
+            applied.version,
+        )
     except Exception as e:
-        LOGGER.error(f"[edit_notebook] Transaction failed: {e}")
-        return [TextContent(type="text", text=json.dumps({
-            "error": f"Transaction failed: {e}",
-            "edits": results,
-        }, default=str))]
+        _raise_notebook_failure(
+            session,
+            _graph_error_payload(
+                error_type="DocumentTransactionError",
+                cell_ids=[
+                    str(cell_id) for cell_id in execute_ids + delete_ids
+                ],
+                message=type(e).__name__,
+            ),
+            dirty=False,
+        )
 
-    # 2. Notify ALL WebSocket consumers (from_consumer_id=None = no exclusion)
     try:
         session.notify(
             NotebookDocumentTransactionNotification(transaction=applied),
             from_consumer_id=None,
         )
-        LOGGER.info("[edit_notebook] Notification broadcast to all consumers")
+        LOGGER.info("[edit_notebook] Notification broadcast")
     except Exception as e:
-        LOGGER.error(f"[edit_notebook] Notify failed: {e}")
+        LOGGER.warning("[edit_notebook] Notify failed: %s", type(e).__name__)
 
-    # 3. Execute updated/new cells via HTTP (put_control_request doesn't work from MCP thread)
-    if execute_ids:
-        try:
-            import requests as _requests
+    try:
+        import requests as _requests
 
-            resp = _requests.post(
+        headers = _server_headers(context, str(session_id))
+        for cell_id in delete_ids:
+            response = _requests.post(
+                _local_server_url(context, "/api/kernel/delete"),
+                headers=headers,
+                json={"cellId": str(cell_id)},
+                timeout=15,
+            )
+            if response.status_code != 200:
+                raise RuntimeError(
+                    f"Kernel deletion returned HTTP {response.status_code}"
+                )
+
+        if execute_ids:
+            response = _requests.post(
                 _local_server_url(context, "/api/kernel/run"),
-                headers=_server_headers(context, str(session_id)),
+                headers=headers,
                 json={
                     "cellIds": [str(c) for c in execute_ids],
                     "codes": execute_codes,
                 },
                 timeout=15,
             )
-            LOGGER.info(f"[edit_notebook] Executed {len(execute_ids)} cells via HTTP: {resp.status_code}")
-        except Exception as e:
-            LOGGER.warning(f"[edit_notebook] Execution failed: {e}")
+            if response.status_code != 200:
+                raise RuntimeError(
+                    f"Kernel execution returned HTTP {response.status_code}"
+                )
+    except Exception as exc:
+        _raise_notebook_failure(
+            session,
+            _graph_error_payload(
+                error_type="DocumentKernelSynchronizationError",
+                cell_ids=[
+                    str(cell_id) for cell_id in delete_ids + execute_ids
+                ],
+                message=type(exc).__name__,
+            ),
+            dirty=True,
+        )
 
-    # 4. Auto-save to disk
     try:
         from signalpilot._server.models.models import SaveNotebookRequest
 
@@ -492,25 +770,33 @@ def _handle_edit_notebook(
                 persist=True,
             )
             session.app_file_manager.save(save_req)
-            LOGGER.info(f"[edit_notebook] Saved to {filename}")
+            LOGGER.info("[edit_notebook] Saved to %s", filename)
     except Exception as e:
-        LOGGER.warning(f"[edit_notebook] Auto-save failed: {e}")
+        LOGGER.warning(
+            "[edit_notebook] Auto-save failed: %s", type(e).__name__
+        )
 
-    return [TextContent(type="text", text=json.dumps({
-        "edits": results,
-        "cells_before": len(existing_cells),
-        "changes_applied": len(doc_changes),
-    }, default=str))]
+    return [
+        TextContent(
+            type="text",
+            text=json.dumps(
+                {
+                    "status": "completed",
+                    "has_errors": False,
+                    "edits": results,
+                    "cells_before": len(existing_cells),
+                    "changes_applied": len(doc_changes),
+                },
+                default=str,
+            ),
+        )
+    ]
 
 
 def _handle_run_cells(
     context: ToolContext, arguments: dict[str, Any]
 ) -> list[Any]:
-    """Run cells and wait for completion, returning outputs.
-
-    Blocks until all cells finish executing (idle or error),
-    then returns their outputs and any errors.
-    """
+    """Run cells and report every non-successful terminal state as an error."""
     import time
 
     from mcp.types import TextContent
@@ -520,36 +806,85 @@ def _handle_run_cells(
     timeout_secs = arguments.get("timeout", 120)
 
     if not session_id:
-        return [TextContent(type="text", text="Error: session_id is required")]
+        raise NotebookToolError(
+            _graph_error_payload(
+                error_type="InvalidRequest",
+                cell_ids=[],
+                message="session_id is required",
+            )
+        )
+    try:
+        timeout_secs = max(0.0, min(float(timeout_secs), 600.0))
+    except (TypeError, ValueError) as exc:
+        raise NotebookToolError(
+            _graph_error_payload(
+                error_type="InvalidRequest",
+                cell_ids=[],
+                message="timeout must be a number",
+            )
+        ) from exc
 
     try:
         session = context.get_session(session_id)
     except ToolExecutionError as e:
-        return [TextContent(type="text", text=f"Error: {e.message}")]
+        raise NotebookToolError(
+            _graph_error_payload(
+                error_type="SessionNotFound",
+                cell_ids=[],
+                message=e.message,
+            )
+        ) from e
 
     cell_manager = session.app_file_manager.app.cell_manager
+    cell_data_map = {cd.cell_id: cd for cd in cell_manager.cell_data()}
 
     if cell_ids_raw:
         run_ids = [CellId_t(cid) for cid in cell_ids_raw]
     else:
-        run_ids = [cd.cell_id for cd in cell_manager.cell_data()]
+        run_ids = list(cell_data_map)
 
-    cell_data_map = {cd.cell_id: cd for cd in cell_manager.cell_data()}
-    run_codes = [cell_data_map[cid].code if cid in cell_data_map else "" for cid in run_ids]
+    missing_ids = [
+        str(cell_id) for cell_id in run_ids if cell_id not in cell_data_map
+    ]
+    if missing_ids:
+        _raise_notebook_failure(
+            session,
+            _graph_error_payload(
+                error_type="CellNotFound",
+                cell_ids=missing_ids,
+                message="Requested cells are not present in the notebook",
+            ),
+            dirty=False,
+        )
 
-    # Execute via HTTP API (put_control_request doesn't work from MCP thread)
+    run_codes = [cell_data_map[cid].code for cid in run_ids]
+    baseline_timestamps = {
+        cell_id: float(
+            getattr(
+                session.session_view.cell_notifications.get(cell_id),
+                "timestamp",
+                0.0,
+            )
+            or 0.0
+        )
+        for cell_id in run_ids
+    }
+
     try:
         import requests as _requests
 
         hdrs = _server_headers(context, str(session_id))
 
-        # Ensure kernel is instantiated first
-        _requests.post(
+        instantiate_response = _requests.post(
             _local_server_url(context, "/api/kernel/instantiate"),
             headers=hdrs,
             json={"objectIds": [], "values": [], "autoRun": False},
             timeout=10,
         )
+        if instantiate_response.status_code != 200:
+            raise RuntimeError(
+                f"Kernel instantiate returned HTTP {instantiate_response.status_code}"
+            )
 
         resp = _requests.post(
             _local_server_url(context, "/api/kernel/run"),
@@ -558,101 +893,207 @@ def _handle_run_cells(
             timeout=15,
         )
         if resp.status_code != 200:
-            return [TextContent(type="text", text=f"Error running cells: HTTP {resp.status_code}: {resp.text[:200]}")]
-    except Exception as e:
-        return [TextContent(type="text", text=f"Error queuing cells: {e}")]
+            raise RuntimeError(
+                f"Kernel execution returned HTTP {resp.status_code}"
+            )
+    except Exception as exc:
+        _raise_notebook_failure(
+            session,
+            _graph_error_payload(
+                error_type="KernelQueueError",
+                cell_ids=[str(cell_id) for cell_id in run_ids],
+                message=type(exc).__name__,
+            ),
+            dirty=False,
+        )
 
-    # Poll until all cells are idle/error or timeout
-    run_id_set = {str(cid) for cid in run_ids}
     start = time.monotonic()
+    completed = not run_ids
     while time.monotonic() - start < timeout_secs:
         time.sleep(0.5)
         all_done = True
-        for cid in run_id_set:
-            notif = session.session_view.cell_notifications.get(CellId_t(cid))
-            if notif is None:
+        for cell_id in run_ids:
+            notification = session.session_view.cell_notifications.get(cell_id)
+            if (
+                notification is None
+                or float(getattr(notification, "timestamp", 0.0) or 0.0)
+                <= baseline_timestamps[cell_id]
+            ):
                 all_done = False
                 break
-            status = getattr(notif, "status", None) or getattr(notif, "runtime_state", None)
-            status_str = str(status) if status else ""
-            if "running" in status_str.lower() or "queued" in status_str.lower():
+            status = str(getattr(notification, "status", "") or "")
+            if status in {"running", "queued"}:
                 all_done = False
                 break
         if all_done:
+            completed = True
             break
 
-    # Collect results
-    cell_results = []
-    for cid in run_ids:
-        cid_str = str(cid)
-        notif = session.session_view.cell_notifications.get(cid)
-        result: dict[str, Any] = {"cell_id": cid_str}
+    elapsed = round(time.monotonic() - start, 3)
+    timed_out = not completed
+    cell_results: list[dict[str, Any]] = []
+    failed_cell_ids: list[str] = []
+    failure_errors: list[dict[str, Any]] = []
+    chat_runtime = bool(getattr(session, "_signalpilot_chat_runtime", False))
+    redactions = tuple(
+        getattr(session, "_signalpilot_chat_redactions", ()) or ()
+    )
 
-        if notif is None:
-            result["status"] = "unknown"
-            result["output"] = None
+    for cell_id in run_ids:
+        cell_id_string = str(cell_id)
+        notification = session.session_view.cell_notifications.get(cell_id)
+        result: dict[str, Any] = {
+            "cell_id": cell_id_string,
+            "status": "completed",
+            "runtime_state": "unknown",
+        }
+        error_details: list[dict[str, Any]] = []
+
+        if timed_out:
+            error_details.append(
+                {
+                    "type": "TimeoutError",
+                    "message": "Cell execution did not reach a terminal state",
+                }
+            )
+        elif (
+            notification is None
+            or float(getattr(notification, "timestamp", 0.0) or 0.0)
+            <= baseline_timestamps[cell_id]
+        ):
+            error_details.append(
+                {
+                    "type": "UnknownStateError",
+                    "message": "No current execution state was reported",
+                }
+            )
         else:
-            status = getattr(notif, "status", None) or getattr(notif, "runtime_state", None)
-            result["status"] = str(status) if status else "unknown"
+            runtime_state = str(getattr(notification, "status", "") or "")
+            result["runtime_state"] = runtime_state or "unknown"
+            if runtime_state != "idle":
+                error_details.append(
+                    {
+                        "type": "UnknownStateError",
+                        "message": f"Unexpected terminal state: {runtime_state or 'unknown'}",
+                    }
+                )
 
-            # Get output
-            output = getattr(notif, "output", None)
+            output = getattr(notification, "output", None)
             if output:
                 mimetype = getattr(output, "mimetype", "")
                 data = getattr(output, "data", "")
-                if getattr(session, "_signalpilot_chat_runtime", False):
+                if chat_runtime:
                     data = compact_chat_runtime_output(
                         data,
                         mimetype=str(mimetype),
-                        redactions=getattr(session, "_signalpilot_chat_redactions", ()),
+                        redactions=redactions,
                     )
                 elif isinstance(data, str) and len(data) > 2000:
                     data = data[:2000] + "... (truncated)"
-                result["output"] = {"mimetype": str(mimetype), "data": str(data)}
+                output_channel = getattr(output, "channel", None)
+                if (
+                    getattr(output_channel, "value", output_channel)
+                    == "sp-error"
+                ):
+                    raw_errors = getattr(output, "data", None)
+                    if not isinstance(raw_errors, list):
+                        raw_errors = []
+                    for error in raw_errors:
+                        error_type = type(error).__name__
+                        message = str(
+                            error.describe()
+                            if hasattr(error, "describe")
+                            else getattr(error, "msg", "Cell execution failed")
+                        )
+                        if chat_runtime:
+                            message = redact_chat_runtime_text(
+                                message, redactions
+                            )
+                        detail: dict[str, Any] = {
+                            "type": error_type,
+                            "message": message[:500],
+                        }
+                        if exception_type := getattr(
+                            error, "exception_type", None
+                        ):
+                            detail["exception_type"] = str(exception_type)[
+                                :100
+                            ]
+                        if variable := getattr(error, "name", None):
+                            detail["variable"] = str(variable)[:100]
+                        involved = {
+                            str(value) for value in getattr(error, "cells", ())
+                        }
+                        involved.add(cell_id_string)
+                        for source, _variables, target in getattr(
+                            error, "edges_with_vars", ()
+                        ):
+                            involved.update((str(source), str(target)))
+                        if involved:
+                            detail["cell_ids"] = sorted(involved)
+                        error_details.append(detail)
+                else:
+                    result["output"] = {
+                        "mimetype": str(mimetype),
+                        "data": str(data),
+                    }
 
-            # Get console output
-            console = getattr(notif, "console", None)
+            console = getattr(notification, "console", None)
             if console:
                 console_items = []
                 for item in console:
                     channel = getattr(item, "channel", "")
-                    text = getattr(item, "data", "") or getattr(item, "text", "")
+                    text = getattr(item, "data", "") or getattr(
+                        item, "text", ""
+                    )
                     if text:
                         rendered = str(text)
-                        if getattr(session, "_signalpilot_chat_runtime", False):
+                        if chat_runtime:
                             rendered = redact_chat_runtime_text(
                                 rendered,
-                                getattr(session, "_signalpilot_chat_redactions", ()),
+                                redactions,
                             )
-                        console_items.append({"channel": str(channel), "text": rendered[:1000]})
+                        console_items.append(
+                            {"channel": str(channel), "text": rendered[:1000]}
+                        )
                 if console_items:
                     result["console"] = console_items
 
-            # Get errors
-            errors = getattr(notif, "errors", None) or []
-            if errors:
-                error_list = []
-                for err in errors:
-                    msg = getattr(err, "msg", "") or str(err)
-                    rendered = str(msg)
-                    if getattr(session, "_signalpilot_chat_runtime", False):
-                        rendered = redact_chat_runtime_text(
-                            rendered,
-                            getattr(session, "_signalpilot_chat_redactions", ()),
-                        )
-                    error_list.append(rendered[:500])
-                result["errors"] = error_list
-
+        if error_details:
+            result["status"] = "failed"
+            result["errors"] = error_details
+            failed_cell_ids.append(cell_id_string)
+            failure_errors.extend(error_details)
         cell_results.append(result)
 
-    elapsed = round(time.monotonic() - start, 1)
-    timed_out = elapsed >= timeout_secs
-
-    return [TextContent(type="text", text=json.dumps({
+    payload = {
+        "status": "failed" if failed_cell_ids else "completed",
+        "has_errors": bool(failed_cell_ids),
+        "cell_ids": [str(cell_id) for cell_id in run_ids],
+        "failed_cell_ids": failed_cell_ids,
         "cells": cell_results,
         "elapsed_seconds": elapsed,
         "timed_out": timed_out,
-    }, default=str))]
+    }
+    if failed_cell_ids:
+        first_error = failure_errors[0]
+        failure_payload = {
+            **payload,
+            "error": {
+                "type": first_error["type"],
+                "variable": first_error.get("variable"),
+                "cell_ids": failed_cell_ids,
+                "message": first_error.get("message"),
+            },
+        }
+        _raise_notebook_failure(session, failure_payload, dirty=False)
+
+    return [
+        TextContent(
+            type="text",
+            text=json.dumps(payload, default=str),
+        )
+    ]
 
 
 def _handle_start_notebook_session(
@@ -668,11 +1109,16 @@ def _handle_start_notebook_session(
         return [TextContent(type="text", text="Error: file_path is required")]
 
     import os
+
     if not os.path.isabs(file_path):
         file_path = os.path.abspath(file_path)
 
     if not os.path.exists(file_path):
-        return [TextContent(type="text", text=f"Error: File not found: {file_path}")]
+        return [
+            TextContent(
+                type="text", text=f"Error: File not found: {file_path}"
+            )
+        ]
 
     try:
         sm = context.session_manager
@@ -680,15 +1126,28 @@ def _handle_start_notebook_session(
         # Check if a session already exists for this file
         for sid, sess in sm.sessions.items():
             sess_path = sess.app_file_manager.path
-            if sess_path and os.path.normpath(str(sess_path)) == os.path.normpath(file_path):
-                LOGGER.info(f"[start_session] Existing session {sid} for {file_path}")
-                cell_data = list(sess.app_file_manager.app.cell_manager.cell_data())
-                return [TextContent(type="text", text=json.dumps({
-                    "session_id": str(sid),
-                    "status": "already_running",
-                    "file": file_path,
-                    "cells": len(cell_data),
-                }))]
+            if sess_path and os.path.normpath(
+                str(sess_path)
+            ) == os.path.normpath(file_path):
+                LOGGER.info(
+                    f"[start_session] Existing session {sid} for {file_path}"
+                )
+                cell_data = list(
+                    sess.app_file_manager.app.cell_manager.cell_data()
+                )
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "session_id": str(sid),
+                                "status": "already_running",
+                                "file": file_path,
+                                "cells": len(cell_data),
+                            }
+                        ),
+                    )
+                ]
 
         # Create a headless consumer for the session
         from signalpilot._session.consumer import SessionConsumer
@@ -731,7 +1190,9 @@ def _handle_start_notebook_session(
             auto_instantiate=True,
         )
 
-        LOGGER.info(f"[start_session] Created session {new_session_id} for {file_path}")
+        LOGGER.info(
+            f"[start_session] Created session {new_session_id} for {file_path}"
+        )
 
         # Wait for kernel to be ready, then instantiate via HTTP
         import time
@@ -742,9 +1203,11 @@ def _handle_start_notebook_session(
 
         # Wait for kernel process to be alive
         for attempt in range(10):
-            km = getattr(session, '_kernel_manager', None)
+            km = getattr(session, "_kernel_manager", None)
             if km and km.is_alive():
-                LOGGER.info(f"[start_session] Kernel alive after {attempt * 0.5}s")
+                LOGGER.info(
+                    f"[start_session] Kernel alive after {attempt * 0.5}s"
+                )
                 break
             time.sleep(0.5)
         else:
@@ -760,31 +1223,48 @@ def _handle_start_notebook_session(
                     json={"objectIds": [], "values": [], "autoRun": auto_run},
                     timeout=15,
                 )
-                LOGGER.info(f"[start_session] Instantiate attempt {attempt + 1}: HTTP {resp.status_code} {resp.text[:100]}")
+                LOGGER.info(
+                    f"[start_session] Instantiate attempt {attempt + 1}: HTTP {resp.status_code} {resp.text[:100]}"
+                )
                 if resp.status_code == 200:
                     instantiate_ok = True
                     break
             except Exception as e:
-                LOGGER.warning(f"[start_session] Instantiate attempt {attempt + 1} failed: {e}")
+                LOGGER.warning(
+                    f"[start_session] Instantiate attempt {attempt + 1} failed: {e}"
+                )
             time.sleep(1.0)
 
         if not instantiate_ok:
             LOGGER.error("[start_session] All instantiate attempts failed")
 
         cell_data = list(session.app_file_manager.app.cell_manager.cell_data())
-        return [TextContent(type="text", text=json.dumps({
-            "session_id": str(new_session_id),
-            "status": "started",
-            "file": file_path,
-            "cells": len(cell_data),
-            "cell_ids": [str(cd.cell_id) for cd in cell_data],
-            "auto_run": auto_run,
-        }))]
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "session_id": str(new_session_id),
+                        "status": "started",
+                        "file": file_path,
+                        "cells": len(cell_data),
+                        "cell_ids": [str(cd.cell_id) for cd in cell_data],
+                        "auto_run": auto_run,
+                    }
+                ),
+            )
+        ]
 
     except Exception as e:
         LOGGER.error(f"[start_session] Failed: {e}")
         import traceback
-        return [TextContent(type="text", text=f"Error starting session: {e}\n{traceback.format_exc()[:500]}")]
+
+        return [
+            TextContent(
+                type="text",
+                text=f"Error starting session: {e}\n{traceback.format_exc()[:500]}",
+            )
+        ]
 
 
 async def _invoke_backend_tool(
@@ -801,8 +1281,12 @@ async def _invoke_backend_tool(
     if session_id:
         try:
             session = t.context.get_session(session_id)
-            chat_runtime = bool(getattr(session, "_signalpilot_chat_runtime", False))
-            runtime_redactions = tuple(getattr(session, "_signalpilot_chat_redactions", ()) or ())
+            chat_runtime = bool(
+                getattr(session, "_signalpilot_chat_runtime", False)
+            )
+            runtime_redactions = tuple(
+                getattr(session, "_signalpilot_chat_redactions", ()) or ()
+            )
         except Exception:
             pass
 
@@ -822,7 +1306,9 @@ async def _invoke_backend_tool(
             )
         return [TextContent(type="text", text=text)]
     except ToolExecutionError as e:
-        error_text = f"Error: {e.message}\nSuggested fix: {e.suggested_fix or 'N/A'}"
+        error_text = (
+            f"Error: {e.message}\nSuggested fix: {e.suggested_fix or 'N/A'}"
+        )
         return [
             TextContent(
                 type="text",
@@ -834,6 +1320,8 @@ async def _invoke_backend_tool(
         return [
             TextContent(
                 type="text",
-                text=redact_chat_runtime_text(f"Error: {e}", runtime_redactions),
+                text=redact_chat_runtime_text(
+                    f"Error: {e}", runtime_redactions
+                ),
             )
         ]

--- a/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tools.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tools.py
@@ -443,7 +443,7 @@ def _run_restricted_python(source: str, data: Any) -> dict[str, Any]:
     }
     # The parsed tree is bounded and rejects imports, dunder access, dynamic
     # execution, file access, and other unsafe calls before this point.
-    exec(  # nosec B102
+    exec(  # nosec B102  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
         compile(tree, "<standalone-chat-scratch>", "exec"),
         namespace,
         namespace,

--- a/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tools.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tools.py
@@ -441,7 +441,9 @@ def _run_restricted_python(source: str, data: Any) -> dict[str, Any]:
         "math": math,
         "statistics": statistics,
     }
-    exec(
+    # The parsed tree is bounded and rejects imports, dunder access, dynamic
+    # execution, file access, and other unsafe calls before this point.
+    exec(  # nosec B102
         compile(tree, "<standalone-chat-scratch>", "exec"),
         namespace,
         namespace,

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
@@ -202,7 +202,10 @@ def _scoped_gateway_mcp_config(
 
 def _scratch_directory(run_id: str) -> Path:
     root = Path(
-        os.getenv("SP_CHAT_SCRATCH_ROOT", "/tmp/signalpilot-chat-runs")
+        os.getenv(
+            "SP_CHAT_SCRATCH_ROOT",
+            "/tmp/signalpilot-chat-runs",  # nosec B108 - container-local scratch
+        )
     ).resolve()
     scratch = (root / run_id).resolve()
     if root not in scratch.parents:

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
@@ -87,6 +87,9 @@ Rules:
 - Call plan_query before every execution. Obey its route exactly.
 - Use query_database with the returned plan_id only when the plan route is mcp.
 - If the route is notebook_sdk or dataset_ref, call start_analysis_notebook with that plan_id, then use only the seeded notebook and the plan-bound SDK.
+- The analysis notebook is a marimo reactive notebook, not a Jupyter notebook. Before editing it, inspect the current cell map. Every non-private top-level name may be defined by exactly one live cell across the entire notebook. Imports, assignments, function and class names, and top-level loop targets all define names.
+- Define shared imports and reusable DataFrames once, then reference them from downstream cells. Prefix disposable cell-local names with one underscore (for example `_fig`, `_ax`, `_i`, `_row`, or `_segment`), or place scratch work inside a uniquely named function. Never repeat public helper names across cells.
+- If edit_notebook returns MultipleDefinitionError, use its variable and cell_ids to update, rename, or delete the conflicting definitions in one atomic edit batch. Do not add a replacement definition in a separate transaction while the old defining cell remains live.
 - Never edit, remove, or redefine the seeded hidden context/import cell or the seeded SDK setup cell. They already run `sp.init(...)` and define the plan-bound `db = sp.connect(...)` connection. `sp.init()` returns None, and there is no `signalpilot.db` export.
 - For notebook_sdk, first define `plan_id` from the exact ID returned by plan_query, then execute the exact planned SQL with `source = db.query_result(sql, plan_id=plan_id)` and build the in-kernel DataFrame from `source["rows"]`; retain `source["result_id"]` for publication. There is no `db.read_plan` method.
 - If the route is aggregate_required, rewrite the work as a bounded warehouse aggregate. If it is refuse, stop.
@@ -295,10 +298,40 @@ def _is_error_output(output: Any) -> bool:
     return getattr(channel, "value", channel) == "sp-error"
 
 
+def _safe_notebook_error(error: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": str(error.get("type") or "NotebookValidationError")[:100],
+        "variable": str(error.get("variable") or "")[:100] or None,
+        "cell_ids": [
+            str(value)[:100] for value in error.get("cell_ids") or []
+        ][:20],
+    }
+
+
+def _with_recorded_notebook_errors(
+    session: Any, failure: dict[str, Any]
+) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    recorded = getattr(session, "_signalpilot_notebook_failures", ())
+    candidates = [
+        *(item.get("error") or {} for item in recorded),
+        failure.get("error") or {},
+    ]
+    for candidate in candidates:
+        safe = _safe_notebook_error(candidate)
+        key = json.dumps(safe, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        errors.append(safe)
+    return {**failure, "errors": errors[-20:]}
+
+
 def _notebook_failure(app: Any, session_id: str) -> dict[str, Any] | None:
     session = _analysis_session(app, session_id)
     if getattr(session, "_signalpilot_notebook_dirty", False):
-        return dict(
+        failure = dict(
             getattr(session, "_signalpilot_last_notebook_failure", None)
             or {
                 "error": {
@@ -308,27 +341,34 @@ def _notebook_failure(app: Any, session_id: str) -> dict[str, Any] | None:
                 }
             }
         )
+        return _with_recorded_notebook_errors(session, failure)
 
     for cell in session.app_file_manager.app.cell_manager.cell_data():
         cell_id = cell.cell_id
         notification = session.session_view.cell_notifications.get(cell_id)
         if notification is None:
-            return {
-                "error": {
-                    "type": "UnknownStateError",
-                    "variable": None,
-                    "cell_ids": [str(cell_id)],
-                }
-            }
+            return _with_recorded_notebook_errors(
+                session,
+                {
+                    "error": {
+                        "type": "UnknownStateError",
+                        "variable": None,
+                        "cell_ids": [str(cell_id)],
+                    }
+                },
+            )
         status = str(getattr(notification, "status", "") or "")
         if status != "idle":
-            return {
-                "error": {
-                    "type": "UnknownStateError",
-                    "variable": None,
-                    "cell_ids": [str(cell_id)],
-                }
-            }
+            return _with_recorded_notebook_errors(
+                session,
+                {
+                    "error": {
+                        "type": "UnknownStateError",
+                        "variable": None,
+                        "cell_ids": [str(cell_id)],
+                    }
+                },
+            )
         output = getattr(notification, "output", None)
         if _is_error_output(output):
             raw_errors = getattr(output, "data", None)
@@ -350,15 +390,18 @@ def _notebook_failure(app: Any, session_id: str) -> dict[str, Any] | None:
             variable = getattr(error, "name", None)
             if variable is None and edge_variables:
                 variable = sorted(edge_variables)[0]
-            return {
-                "error": {
-                    "type": type(error).__name__
-                    if error
-                    else "CellExecutionError",
-                    "variable": variable,
-                    "cell_ids": sorted(involved),
-                }
-            }
+            return _with_recorded_notebook_errors(
+                session,
+                {
+                    "error": {
+                        "type": type(error).__name__
+                        if error
+                        else "CellExecutionError",
+                        "variable": variable,
+                        "cell_ids": sorted(involved),
+                    }
+                },
+            )
     return None
 
 
@@ -367,21 +410,16 @@ def _notebook_has_errors(app: Any, session_id: str) -> bool:
 
 
 def _recovery_context(failure: dict[str, Any]) -> str:
-    error = failure.get("error") or {}
-    safe = {
-        "error_type": str(error.get("type") or "NotebookValidationError")[
-            :100
-        ],
-        "variable": str(error.get("variable") or "")[:100] or None,
-        "cell_ids": [
-            str(value)[:100] for value in error.get("cell_ids") or []
-        ][:20],
-    }
+    raw_errors = failure.get("errors") or [failure.get("error") or {}]
+    safe_errors = [_safe_notebook_error(error) for error in raw_errors][:20]
     return (
         "The first notebook attempt was rejected and its notebook and artifacts "
         "were discarded. Start the newly seeded notebook, execute the evidence "
         "again, validate every requested cell, and answer only from this clean "
-        f"attempt. Recovery reason: {json.dumps(safe, sort_keys=True)}"
+        "attempt. Treat every listed graph error as an explicit instruction not "
+        "to recreate those duplicate globals; use unique public names, private "
+        "underscore-prefixed scratch names, or uniquely named functions. "
+        f"Recovery errors: {json.dumps(safe_errors, sort_keys=True)}"
     )
 
 
@@ -881,6 +919,13 @@ async def execute(*, request: Request) -> StreamingResponse:
                                 "cell_ids": [],
                             }
                         }
+                    if notebook_failure is not None:
+                        notebook_failure = _with_recorded_notebook_errors(
+                            _analysis_session(
+                                request.app, lifecycle.session_id
+                            ),
+                            notebook_failure,
+                        )
                 elif recovery_failure is not None:
                     notebook_failure = {
                         "error": {

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
@@ -520,6 +520,30 @@ def _close_analysis_kernel(app: Any, session_id: str) -> bool:
     )
 
 
+def _start_analysis_kernel(app: Any, notebook_path: Path) -> str:
+    from signalpilot._server.ai.notebook_mcp import (
+        _handle_start_notebook_session,
+    )
+    from signalpilot._server.ai.tools.base import ToolContext
+
+    result = _handle_start_notebook_session(
+        ToolContext(app=app),
+        {"file_path": str(notebook_path), "auto_run": True},
+    )
+    if not result:
+        raise RuntimeError("Clean notebook kernel did not start")
+    try:
+        started = json.loads(str(getattr(result[0], "text", "")))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Clean notebook kernel returned an invalid response"
+        ) from exc
+    session_id = str(started.get("session_id") or "")
+    if not session_id or str(started.get("status") or "").startswith("error"):
+        raise RuntimeError("Clean notebook kernel did not start")
+    return session_id
+
+
 def _frozen_project_directory(project_id: str) -> Path | None:
     parent = project_sync.PROJECTS_ROOT / project_id
     if not parent.exists():
@@ -733,6 +757,7 @@ async def execute(*, request: Request) -> StreamingResponse:
         try:
             recovery_failure: dict[str, Any] | None = None
             previous_notebook_session_id: str | None = None
+            recovery_plan_id: str | None = None
             for attempt in (1, 2):
                 collector = StandaloneArtifactCollector()
                 lifecycle = StandaloneNotebookLifecycle()
@@ -760,6 +785,52 @@ async def execute(*, request: Request) -> StreamingResponse:
                     )
                     runtime_session._signalpilot_chat_attempt = attempt
 
+                if recovery_failure is not None:
+                    if not recovery_plan_id:
+                        yield (
+                            json.dumps(
+                                {
+                                    "type": "error",
+                                    "content": "The failed notebook did not retain a governed recovery plan.",
+                                    "is_error": True,
+                                }
+                            )
+                            + "\n"
+                        ).encode("utf-8")
+                        return
+                    try:
+                        lifecycle.session_id = _start_analysis_kernel(
+                            request.app, analysis_notebook_path
+                        )
+                    except Exception:
+                        LOGGER.exception(
+                            "Clean notebook kernel start failed run_id=%s attempt=%s",
+                            run_id,
+                            attempt,
+                        )
+                        yield (
+                            json.dumps(
+                                {
+                                    "type": "error",
+                                    "content": "The failed notebook kernel could not be restarted safely.",
+                                    "is_error": True,
+                                }
+                            )
+                            + "\n"
+                        ).encode("utf-8")
+                        return
+                    lifecycle.plan_id = recovery_plan_id
+                    clean_session = _analysis_session(
+                        request.app, lifecycle.session_id
+                    )
+                    clean_session._signalpilot_chat_runtime = True
+                    clean_session._signalpilot_chat_redactions = (
+                        scoped_token,
+                    )
+                    await lifecycle_event(
+                        "notebook_started", {"plan_id": recovery_plan_id}
+                    )
+
                 artifact_server = build_standalone_chat_mcp_server(
                     collector,
                     result_loader=load_result,
@@ -779,6 +850,9 @@ async def execute(*, request: Request) -> StreamingResponse:
                     attempt_prompt = (
                         f"{prompt}\n\n<notebook_recovery>\n"
                         f"{_recovery_context(recovery_failure)}\n"
+                        "The clean notebook kernel is already running. Use "
+                        f"session_id `{lifecycle.session_id}` and governed plan_id "
+                        f"`{recovery_plan_id}`; do not create a different session.\n"
                         "</notebook_recovery>"
                     )
 
@@ -945,6 +1019,7 @@ async def execute(*, request: Request) -> StreamingResponse:
                     )
                     if attempt == 1 and lifecycle.session_id:
                         previous_notebook_session_id = lifecycle.session_id
+                        recovery_plan_id = lifecycle.plan_id
                         kernel_closed = _close_analysis_kernel(
                             request.app, lifecycle.session_id
                         )

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import html as html_lib
 import json
 import os
 import re
@@ -18,6 +19,9 @@ from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse, StreamingResponse
 
 from signalpilot import _loggers
+from signalpilot._server.ai.chat_runtime_output import (
+    compact_chat_runtime_output,
+)
 from signalpilot._server.ai.claude_agent import (
     clear_chat_session,
     run_notebook_agent,
@@ -88,15 +92,15 @@ Rules:
 - Use query_database with the returned plan_id only when the plan route is mcp.
 - If the route is notebook_sdk or dataset_ref, call start_analysis_notebook with that plan_id, then use only the seeded notebook and the plan-bound SDK.
 - The analysis notebook is a marimo reactive notebook, not a Jupyter notebook. Before editing it, inspect the current cell map. Every non-private top-level name may be defined by exactly one live cell across the entire notebook. Imports, assignments, function and class names, and top-level loop targets all define names.
-- Define shared imports and reusable DataFrames once, then reference them from downstream cells. Prefix disposable cell-local names with one underscore (for example `_fig`, `_ax`, `_i`, `_row`, or `_segment`), or place scratch work inside a uniquely named function. Never repeat public helper names across cells.
+- Define shared imports and reusable DataFrames once, then reference them from downstream cells. Prefix disposable cell-local names with one underscore (for example `_fig`, `_ax`, `_i`, `_row`, or `_segment`), or place scratch work inside a uniquely named function. Underscore-prefixed names are cell-local and must never be referenced from another cell; any cross-cell value needs one unique public name. Never repeat public helper names across cells.
 - If edit_notebook returns MultipleDefinitionError, use its variable and cell_ids to update, rename, or delete the conflicting definitions in one atomic edit batch. Do not add a replacement definition in a separate transaction while the old defining cell remains live.
 - Never edit, remove, or redefine the seeded hidden context/import cell or the seeded SDK setup cell. They already run `sp.init(...)` and define the plan-bound `db = sp.connect(...)` connection. `sp.init()` returns None, and there is no `signalpilot.db` export.
-- For notebook_sdk, first define `plan_id` from the exact ID returned by plan_query, then execute the exact planned SQL with `source = db.query_result(sql, plan_id=plan_id)` and build the in-kernel DataFrame from `source["rows"]`; retain `source["result_id"]` for publication. There is no `db.read_plan` method.
+- For notebook_sdk, first define `plan_id` from the exact ID returned by plan_query, then execute the exact planned SQL with `source = db.query_result(sql, plan_id=plan_id)` and build the in-kernel DataFrame from `source["rows"]`; retain `source["result_id"]` for publication. A plan ID authorizes only its exact planned SQL and execution scope. If you change the SQL, call plan_query again and use its new plan ID. There is no `db.read_plan` method.
 - If the route is aggregate_required, rewrite the work as a bounded warehouse aggregate. If it is refuse, stop.
-- Never copy MCP previews into notebook DataFrames. MCP previews are model context, not a data transport.
+- Never copy MCP previews into notebook DataFrames, including as a fallback during recovery. MCP previews are model context, not a data transport.
 - Keep complete bounded DataFrames inside the kernel. Notebook cells may display only schema, completeness, statistics, checks, and a small preview.
 - Publish derived rows from the kernel with exactly `derived = sp.publish_result(dataframe, name="...", source_result_ids=[source["result_id"]], completeness="complete" | "truncated" | "unknown", reconciliation="...")`. The SDK computes the notebook code hash; do not pass `result=`, `code_hash=`, or `metadata=`.
-- Publish a runtime file with exactly `artifact = sp.publish_artifact(path, kind="table" | "chart" | "report", result_id=derived.id, assumptions=[...], exclusions=[...], caveats=[...])`. Create chart PNGs and other artifacts only under `SP_CHAT_SCRATCH_DIRECTORY`.
+- Publish a runtime file with exactly `artifact = sp.publish_artifact(path, kind="table" | "chart" | "report", result_id=derived.id, assumptions=[...], exclusions=[...], caveats=[...])`. Create chart PNGs and other artifacts only under `SP_CHAT_SCRATCH_DIRECTORY`. Finalize every notebook cell before executing publication: the result and artifact must be published from the same unchanged notebook code hash. Do not edit the notebook between `sp.publish_result` and `sp.publish_artifact`; after any edit, publish both again from the final notebook version.
 - PublishedResult exposes only `id`, `name`, `row_count`, `byte_size`, and `completeness`. PublishedArtifact exposes only `id`, `filename`, `kind`, and `byte_size`.
 - Do not catch or suppress publication exceptions. A failed `sp.publish_result` or `sp.publish_artifact` means the analysis is incomplete and must not be reported as successful.
 - Ask for clarification only when exploration leaves a material ambiguity that would change the answer. If needed, return exactly `CLARIFICATION_REQUESTED: <one conversational question>`.
@@ -418,7 +422,11 @@ def _recovery_context(failure: dict[str, Any]) -> str:
         "again, validate every requested cell, and answer only from this clean "
         "attempt. Treat every listed graph error as an explicit instruction not "
         "to recreate those duplicate globals; use unique public names, private "
-        "underscore-prefixed scratch names, or uniquely named functions. "
+        "underscore-prefixed scratch names, or uniquely named functions. Private "
+        "underscore-prefixed names are cell-local and cannot be read from another "
+        "cell. A governed plan ID can be reused only with its exact original SQL; "
+        "changed SQL requires a new plan_query result. Never replace SDK query "
+        "evidence with copied MCP preview rows. "
         f"Recovery errors: {json.dumps(safe_errors, sort_keys=True)}"
     )
 
@@ -460,17 +468,33 @@ async def _archive_analysis_notebook(
         raise RuntimeError(
             "Refusing to archive notebook source containing a runtime token"
         )
-    html, _ = Exporter().export_as_html(
-        app=session.app_file_manager.app,
-        filename="analysis.py",
-        session_view=session.session_view,
-        display_config=session.config_manager.get_config()["display"],
-        request=ExportAsHTMLRequest(
-            download=False,
-            files=[],
-            include_code=False,
-        ),
-    )
+    try:
+        html, _ = Exporter().export_as_html(
+            app=session.app_file_manager.app,
+            filename="analysis.py",
+            session_view=session.session_view,
+            display_config=session.config_manager.get_config()["display"],
+            request=ExportAsHTMLRequest(
+                download=False,
+                files=[],
+                include_code=False,
+            ),
+        )
+    except FileNotFoundError:
+        # The slim runtime image intentionally omits the notebook frontend
+        # bundle. Preserve the validated evidence in a bounded, code-free HTML
+        # archive instead of rejecting an otherwise clean analysis.
+        LOGGER.warning(
+            "Notebook frontend assets unavailable; using safe archive fallback "
+            "run_id=%s session_id=%s",
+            run_id,
+            session_id,
+        )
+        html = _fallback_archive_html(
+            session,
+            run_id=run_id,
+            redactions=(scoped_token,),
+        )
     cells = []
     for cell in session.app_file_manager.app.cell_manager.cell_data():
         notification = session.session_view.cell_notifications.get(
@@ -509,6 +533,51 @@ async def _archive_analysis_notebook(
         )
     response.raise_for_status()
     return str(response.json()["archive_id"])
+
+
+def _fallback_archive_html(
+    session: Any,
+    *,
+    run_id: str,
+    redactions: tuple[str, ...],
+) -> str:
+    """Render validated cell outputs without notebook code or active markup."""
+    sections: list[str] = []
+    for index, cell in enumerate(
+        session.app_file_manager.app.cell_manager.cell_data(), start=1
+    ):
+        notification = session.session_view.cell_notifications.get(
+            cell.cell_id
+        )
+        status = str(getattr(notification, "status", "unknown") or "unknown")
+        output = getattr(notification, "output", None)
+        mimetype = str(getattr(output, "mimetype", "") or "")
+        rendered_output = "No displayed output."
+        if output is not None:
+            rendered_output = compact_chat_runtime_output(
+                getattr(output, "data", ""),
+                mimetype=mimetype,
+                redactions=redactions,
+            )
+        sections.append(
+            "<section>"
+            f"<h2>Cell {index}</h2>"
+            f"<p>Status: {html_lib.escape(status)}</p>"
+            f"<p>Output type: {html_lib.escape(mimetype or 'none')}</p>"
+            f"<pre>{html_lib.escape(rendered_output)}</pre>"
+            "</section>"
+        )
+    return (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        "<title>Validated analysis notebook</title>"
+        "<style>body{font-family:system-ui,sans-serif;max-width:960px;margin:40px auto;"
+        "padding:0 20px;background:#141416;color:#ededed}section{border:1px solid #333;"
+        "border-radius:8px;padding:16px;margin:16px 0}pre{white-space:pre-wrap;"
+        "overflow-wrap:anywhere;background:#1d1d20;padding:12px;border-radius:6px}</style>"
+        "</head><body><h1>Validated analysis notebook</h1>"
+        f"<p>Run {html_lib.escape(run_id)}</p>{''.join(sections)}</body></html>"
+    )
 
 
 def _close_analysis_kernel(app: Any, session_id: str) -> bool:

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
@@ -17,6 +17,7 @@ import httpx
 from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse, StreamingResponse
 
+from signalpilot import _loggers
 from signalpilot._server.ai.claude_agent import (
     clear_chat_session,
     run_notebook_agent,
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
 router = APIRouter()
+LOGGER = _loggers.sp_logger()
 _RUN_ID_RE = re.compile(r"^[a-zA-Z0-9-]{8,80}$")
 _ANALYSIS_SESSIONS_BY_RUN: dict[str, str] = {}
 
@@ -106,7 +108,9 @@ Rules:
 """
 
 
-def _require_execution_scope(body: dict[str, Any]) -> tuple[str, str, str, str, str]:
+def _require_execution_scope(
+    body: dict[str, Any],
+) -> tuple[str, str, str, str, str]:
     run_id = str(body.get("run_id") or "")
     project_id = str(body.get("project_id") or "")
     branch = str(body.get("branch") or "")
@@ -132,7 +136,9 @@ def _require_execution_scope(body: dict[str, Any]) -> tuple[str, str, str, str, 
     }
     for key, value in expected.items():
         if value and supplied[key] != value:
-            raise HTTPException(status_code=403, detail="Execution scope mismatch")
+            raise HTTPException(
+                status_code=403, detail="Execution scope mismatch"
+            )
     return run_id, project_id, branch, connection_name, commit_sha
 
 
@@ -147,13 +153,19 @@ def _scoped_gateway_mcp_config(
 ) -> dict[str, Any]:
     token = str(body.get("gateway_session_token") or "").strip()
     if not token:
-        raise HTTPException(status_code=403, detail="Scoped gateway identity required")
+        raise HTTPException(
+            status_code=403, detail="Scoped gateway identity required"
+        )
     try:
         payload_segment = token.split(".")[1]
         padding = "=" * (-len(payload_segment) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload_segment + padding))
+        claims = json.loads(
+            base64.urlsafe_b64decode(payload_segment + padding)
+        )
     except Exception as exc:
-        raise HTTPException(status_code=403, detail="Invalid scoped gateway identity") from exc
+        raise HTTPException(
+            status_code=403, detail="Invalid scoped gateway identity"
+        ) from exc
     expected_claims = {
         "execution_identity": f"chat:{run_id}",
         "project_id": project_id,
@@ -162,9 +174,13 @@ def _scoped_gateway_mcp_config(
         "commit_sha": commit_sha,
     }
     if any(claims.get(key) != value for key, value in expected_claims.items()):
-        raise HTTPException(status_code=403, detail="Scoped gateway identity mismatch")
+        raise HTTPException(
+            status_code=403, detail="Scoped gateway identity mismatch"
+        )
     if "write" in list(claims.get("scopes") or []):
-        raise HTTPException(status_code=403, detail="Scoped gateway identity permits writes")
+        raise HTTPException(
+            status_code=403, detail="Scoped gateway identity permits writes"
+        )
 
     gateway_url = str(
         os.getenv("SP_GATEWAY_INTERNAL_URL")
@@ -185,7 +201,9 @@ def _scoped_gateway_mcp_config(
 
 
 def _scratch_directory(run_id: str) -> Path:
-    root = Path(os.getenv("SP_CHAT_SCRATCH_ROOT", "/tmp/signalpilot-chat-runs")).resolve()
+    root = Path(
+        os.getenv("SP_CHAT_SCRATCH_ROOT", "/tmp/signalpilot-chat-runs")
+    ).resolve()
     scratch = (root / run_id).resolve()
     if root not in scratch.parents:
         raise HTTPException(status_code=400, detail="Invalid scratch path")
@@ -206,9 +224,15 @@ def _seed_analysis_notebook(
     token_file.write_text(scoped_token, encoding="utf-8")
     token_file.chmod(0o600)
     notebook_path = scratch / "analysis.py"
-    context = json.dumps({"run_id": run_id, "project_id": project_id, "connection_name": connection_name})
+    context = json.dumps(
+        {
+            "run_id": run_id,
+            "project_id": project_id,
+            "connection_name": connection_name,
+        }
+    )
     notebook_path.write_text(
-        f'''import signalpilot as sp
+        f"""import signalpilot as sp
 
 __generated_with = "0.1.0"
 app = sp.App()
@@ -251,7 +275,7 @@ def _(analysis_checks, analysis_summary, sp):
 
 if __name__ == "__main__":
     app.run()
-''',
+""",
         encoding="utf-8",
     )
     return notebook_path
@@ -263,16 +287,119 @@ def _analysis_session(app: Any, session_id: str) -> Any:
     return ToolContext(app=app).get_session(session_id)
 
 
-def _notebook_has_errors(app: Any, session_id: str) -> bool:
+def _is_error_output(output: Any) -> bool:
+    channel = getattr(output, "channel", None)
+    return getattr(channel, "value", channel) == "sp-error"
+
+
+def _notebook_failure(app: Any, session_id: str) -> dict[str, Any] | None:
     session = _analysis_session(app, session_id)
-    for notification in session.session_view.cell_notifications.values():
-        if getattr(notification, "errors", None):
-            return True
+    if getattr(session, "_signalpilot_notebook_dirty", False):
+        return dict(
+            getattr(session, "_signalpilot_last_notebook_failure", None)
+            or {
+                "error": {
+                    "type": "DocumentKernelSynchronizationError",
+                    "variable": None,
+                    "cell_ids": [],
+                }
+            }
+        )
+
+    for cell in session.app_file_manager.app.cell_manager.cell_data():
+        cell_id = cell.cell_id
+        notification = session.session_view.cell_notifications.get(cell_id)
+        if notification is None:
+            return {
+                "error": {
+                    "type": "UnknownStateError",
+                    "variable": None,
+                    "cell_ids": [str(cell_id)],
+                }
+            }
+        status = str(getattr(notification, "status", "") or "")
+        if status != "idle":
+            return {
+                "error": {
+                    "type": "UnknownStateError",
+                    "variable": None,
+                    "cell_ids": [str(cell_id)],
+                }
+            }
         output = getattr(notification, "output", None)
-        channel = str(getattr(output, "channel", "") or "").lower()
-        if "error" in channel:
-            return True
-    return False
+        if _is_error_output(output):
+            raw_errors = getattr(output, "data", None)
+            error = (
+                raw_errors[0]
+                if isinstance(raw_errors, list) and raw_errors
+                else None
+            )
+            involved = {str(cell_id)}
+            involved.update(
+                str(value) for value in getattr(error, "cells", ())
+            )
+            edge_variables: set[str] = set()
+            for source, variables, target in getattr(
+                error, "edges_with_vars", ()
+            ):
+                involved.update((str(source), str(target)))
+                edge_variables.update(str(value) for value in variables)
+            variable = getattr(error, "name", None)
+            if variable is None and edge_variables:
+                variable = sorted(edge_variables)[0]
+            return {
+                "error": {
+                    "type": type(error).__name__
+                    if error
+                    else "CellExecutionError",
+                    "variable": variable,
+                    "cell_ids": sorted(involved),
+                }
+            }
+    return None
+
+
+def _notebook_has_errors(app: Any, session_id: str) -> bool:
+    return _notebook_failure(app, session_id) is not None
+
+
+def _recovery_context(failure: dict[str, Any]) -> str:
+    error = failure.get("error") or {}
+    safe = {
+        "error_type": str(error.get("type") or "NotebookValidationError")[
+            :100
+        ],
+        "variable": str(error.get("variable") or "")[:100] or None,
+        "cell_ids": [
+            str(value)[:100] for value in error.get("cell_ids") or []
+        ][:20],
+    }
+    return (
+        "The first notebook attempt was rejected and its notebook and artifacts "
+        "were discarded. Start the newly seeded notebook, execute the evidence "
+        "again, validate every requested cell, and answer only from this clean "
+        f"attempt. Recovery reason: {json.dumps(safe, sort_keys=True)}"
+    )
+
+
+def _log_notebook_failure(
+    *,
+    run_id: str,
+    session_id: str,
+    attempt: int,
+    failure: dict[str, Any],
+) -> None:
+    error = failure.get("error") or {}
+    LOGGER.error(
+        "Standalone notebook validation failed run_id=%s session_id=%s "
+        "attempt=%s error_type=%s variable=%s cell_ids=%s",
+        run_id,
+        session_id,
+        attempt,
+        error.get("type"),
+        error.get("variable"),
+        error.get("cell_ids"),
+    )
 
 
 async def _archive_analysis_notebook(
@@ -289,7 +416,9 @@ async def _archive_analysis_notebook(
     session = _analysis_session(app, session_id)
     source = session.app_file_manager.app.to_py().encode("utf-8")
     if scoped_token.encode("utf-8") in source:
-        raise RuntimeError("Refusing to archive notebook source containing a runtime token")
+        raise RuntimeError(
+            "Refusing to archive notebook source containing a runtime token"
+        )
     html, _ = Exporter().export_as_html(
         app=session.app_file_manager.app,
         filename="analysis.py",
@@ -303,13 +432,22 @@ async def _archive_analysis_notebook(
     )
     cells = []
     for cell in session.app_file_manager.app.cell_manager.cell_data():
-        notification = session.session_view.cell_notifications.get(cell.cell_id)
+        notification = session.session_view.cell_notifications.get(
+            cell.cell_id
+        )
         cells.append(
             {
                 "cell_id": str(cell.cell_id),
-                "code_hash": hashlib.sha256(cell.code.encode("utf-8")).hexdigest(),
-                "status": str(getattr(notification, "status", "unknown") or "unknown"),
-                "has_errors": bool(getattr(notification, "errors", None)),
+                "code_hash": hashlib.sha256(
+                    cell.code.encode("utf-8")
+                ).hexdigest(),
+                "status": str(
+                    getattr(notification, "status", "unknown") or "unknown"
+                ),
+                "has_errors": bool(
+                    notification is not None
+                    and _is_error_output(getattr(notification, "output", None))
+                ),
             }
         )
     manifest = json.dumps(
@@ -322,7 +460,9 @@ async def _archive_analysis_notebook(
             headers={"Authorization": f"Bearer {scoped_token}"},
             json={
                 "source_base64": base64.b64encode(source).decode("ascii"),
-                "html_base64": base64.b64encode(html.encode("utf-8")).decode("ascii"),
+                "html_base64": base64.b64encode(html.encode("utf-8")).decode(
+                    "ascii"
+                ),
                 "manifest_base64": base64.b64encode(manifest).decode("ascii"),
             },
         )
@@ -334,7 +474,9 @@ def _close_analysis_kernel(app: Any, session_id: str) -> bool:
     from signalpilot._server.ai.tools.base import ToolContext
     from signalpilot._types.ids import SessionId
 
-    return ToolContext(app=app).session_manager.close_session(SessionId(session_id))
+    return ToolContext(app=app).session_manager.close_session(
+        SessionId(session_id)
+    )
 
 
 def _frozen_project_directory(project_id: str) -> Path | None:
@@ -357,10 +499,15 @@ async def _execution_project_directory(
     gateway_token: str,
 ) -> tuple[Path, bool]:
     project_directory = _frozen_project_directory(project_id)
-    if project_directory is not None and _project_is_unchanged(project_directory, commit_sha):
+    if project_directory is not None and _project_is_unchanged(
+        project_directory, commit_sha
+    ):
         return project_directory, False
     if os.getenv("SP_CHAT_RUN_ID"):
-        raise HTTPException(status_code=409, detail="Frozen project workspace is not reproducible")
+        raise HTTPException(
+            status_code=409,
+            detail="Frozen project workspace is not reproducible",
+        )
     try:
         project_directory = await asyncio.to_thread(
             project_sync.materialize_frozen_checkout,
@@ -370,14 +517,22 @@ async def _execution_project_directory(
             checkout_id=run_id,
             gateway_token=gateway_token,
         )
-    except (OSError, subprocess.SubprocessError, ValueError, httpx.HTTPError) as exc:
+    except (
+        OSError,
+        subprocess.SubprocessError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
         raise HTTPException(
             status_code=409,
             detail="Frozen project workspace could not be prepared",
         ) from exc
     if not _project_is_unchanged(project_directory, commit_sha):
         shutil.rmtree(project_directory, ignore_errors=True)
-        raise HTTPException(status_code=409, detail="Frozen project workspace is not reproducible")
+        raise HTTPException(
+            status_code=409,
+            detail="Frozen project workspace is not reproducible",
+        )
     return project_directory, True
 
 
@@ -413,15 +568,23 @@ def _runtime_auth_override(body: dict[str, Any]) -> dict[str, str] | None:
         return None
     auth_type = str(value.get("type") or "")
     token = str(value.get("token") or "").strip()
-    if auth_type not in {"api_key", "oauth"} or not token or len(token) > 20_000:
-        raise HTTPException(status_code=400, detail="Invalid runtime credential")
+    if (
+        auth_type not in {"api_key", "oauth"}
+        or not token
+        or len(token) > 20_000
+    ):
+        raise HTTPException(
+            status_code=400, detail="Invalid runtime credential"
+        )
     return {"type": auth_type, "token": token}
 
 
 @router.post("/execute")
 async def execute(*, request: Request) -> StreamingResponse:
     body = await request.json()
-    run_id, project_id, branch, connection_name, commit_sha = _require_execution_scope(body)
+    run_id, project_id, branch, connection_name, commit_sha = (
+        _require_execution_scope(body)
+    )
     mcp_config = _scoped_gateway_mcp_config(
         body,
         run_id=run_id,
@@ -432,14 +595,23 @@ async def execute(*, request: Request) -> StreamingResponse:
     )
     prompt = str(body.get("prompt") or "").strip()
     if not prompt or len(prompt) > 50_000:
-        raise HTTPException(status_code=400, detail="Prompt is empty or too large")
+        raise HTTPException(
+            status_code=400, detail="Prompt is empty or too large"
+        )
     history = [
-        {"role": str(item.get("role") or "user"), "content": str(item.get("content") or "")}
+        {
+            "role": str(item.get("role") or "user"),
+            "content": str(item.get("content") or ""),
+        }
         for item in list(body.get("messages") or [])[-40:]
         if isinstance(item, dict)
     ]
-    warm_context = json.dumps(body.get("warm_context") or {}, default=str)[:120_000]
-    feature_values = body.get("features") if isinstance(body.get("features"), dict) else {}
+    warm_context = json.dumps(body.get("warm_context") or {}, default=str)[
+        :120_000
+    ]
+    feature_values = (
+        body.get("features") if isinstance(body.get("features"), dict) else {}
+    )
     notebook_analysis_enabled = bool(feature_values.get("notebook_analysis"))
     system_prompt = (
         f"{STANDALONE_SYSTEM_PROMPT}\n\n"
@@ -447,8 +619,6 @@ async def execute(*, request: Request) -> StreamingResponse:
         f"Selected connection: {connection_name}\n\n"
         f"<governed_project_context>\n{warm_context}\n</governed_project_context>"
     )
-    collector = StandaloneArtifactCollector()
-    lifecycle = StandaloneNotebookLifecycle()
     scoped_token = str(body.get("gateway_session_token") or "")
     gateway_api_url = str(
         os.getenv("SP_GATEWAY_INTERNAL_URL")
@@ -467,6 +637,7 @@ async def execute(*, request: Request) -> StreamingResponse:
         gateway_url=gateway_api_url,
         scoped_token=scoped_token,
     )
+    seeded_notebook_source = analysis_notebook_path.read_text(encoding="utf-8")
 
     async def load_result(result_id: str) -> dict[str, Any]:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -498,138 +669,336 @@ async def execute(*, request: Request) -> StreamingResponse:
             raise ValueError("Invalid governed query plan")
         return value
 
-    async def lifecycle_event(event_type: str, payload: dict[str, Any]) -> None:
-        del payload
-        if event_type == "notebook_started" and lifecycle.session_id:
-            _ANALYSIS_SESSIONS_BY_RUN[run_id] = lifecycle.session_id
-
     auth_config_override = _runtime_auth_override(body)
     session_id = SessionId(f"standalone-{run_id}")
     remove_project_directory = False
     try:
-        project_directory, remove_project_directory = await _execution_project_directory(
+        (
+            project_directory,
+            remove_project_directory,
+        ) = await _execution_project_directory(
             run_id=run_id,
             project_id=project_id,
             branch=branch,
             commit_sha=commit_sha,
             gateway_token=scoped_token,
         )
-        artifact_server = build_standalone_chat_mcp_server(
-            collector,
-            result_loader=load_result,
-            project_directory=project_directory,
-            scratch_directory=scratch,
-            notebook_mcp_app=request.app if notebook_analysis_enabled else None,
-            analysis_notebook_path=analysis_notebook_path,
-            plan_checker=check_plan,
-            event_sink=lifecycle_event,
-            notebook_lifecycle=lifecycle,
-            runtime_redactions=(scoped_token,),
-        )
     except Exception:
         shutil.rmtree(scratch, ignore_errors=True)
         raise
 
     async def stream() -> AsyncGenerator[bytes, None]:
+        current_lifecycle: StandaloneNotebookLifecycle | None = None
         try:
-            final_text = ""
-            async for event in run_notebook_agent(
-                prompt,
-                session_id,
-                model=str(
-                    body.get("model")
-                    or os.getenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL")
-                    or "claude-sonnet-4-5-20250929"
-                ),
-                max_turns=40,
-                new_chat=bool(body.get("new_execution", False)),
-                message_history=history,
-                system_prompt_override=system_prompt,
-                mcp_config=mcp_config,
-                thread_id=f"standalone:{run_id}",
-                notebook_mcp_app=request.app if notebook_analysis_enabled else None,
-                cwd=str(project_directory),
-                disallow_file_edits=True,
-                additional_disallowed_tools=["WebFetch", "WebSearch"],
-                allowed_tools=(
-                    STANDALONE_ALLOWED_TOOLS
-                    if notebook_analysis_enabled
-                    else [
-                        tool
-                        for tool in STANDALONE_ALLOWED_TOOLS
-                        if "signalpilot-notebook" not in tool
-                        and not tool.endswith("start_analysis_notebook")
-                    ]
-                ),
-                additional_mcp_servers={"standalone-chat": artifact_server},
-                persist_session_mapping=False,
-                auth_config_override=auth_config_override,
-                notebook_session_authorizer=lambda candidate: lifecycle.session_id == candidate,
-            ):
-                if event.type in {"thinking", "thinking_delta", "block_start"}:
-                    continue
-                if event.type == "text":
-                    final_text = event.content
-                payload = {
-                    "type": event.type,
-                    "content": event.content,
-                    "tool_name": event.tool_name,
-                    "tool_input": event.tool_input,
-                    "tool_call_id": event.tool_call_id,
-                    "is_error": event.is_error,
-                }
-                yield (json.dumps(payload, default=str) + "\n").encode("utf-8")
-            if project_directory is not None and not _project_is_unchanged(
-                project_directory, commit_sha
-            ):
-                yield (
-                    json.dumps(
-                        {
-                            "type": "error",
-                            "content": "The frozen project workspace changed; the run was rejected.",
-                            "is_error": True,
-                        }
+            recovery_failure: dict[str, Any] | None = None
+            previous_notebook_session_id: str | None = None
+            for attempt in (1, 2):
+                collector = StandaloneArtifactCollector()
+                lifecycle = StandaloneNotebookLifecycle()
+                current_lifecycle = lifecycle
+
+                async def lifecycle_event(
+                    event_type: str,
+                    payload: dict[str, Any],
+                    lifecycle: StandaloneNotebookLifecycle = lifecycle,
+                    attempt: int = attempt,
+                ) -> None:
+                    del payload
+                    if (
+                        event_type != "notebook_started"
+                        or not lifecycle.session_id
+                    ):
+                        return
+                    _ANALYSIS_SESSIONS_BY_RUN[run_id] = lifecycle.session_id
+                    runtime_session = _analysis_session(
+                        request.app, lifecycle.session_id
                     )
-                    + "\n"
-                ).encode("utf-8")
-                return
-            archive_id = None
-            kernel_stopped = False
-            if lifecycle.session_id:
-                if _notebook_has_errors(request.app, lifecycle.session_id):
+                    runtime_session._signalpilot_chat_run_id = run_id
+                    runtime_session._signalpilot_chat_session_id = (
+                        lifecycle.session_id
+                    )
+                    runtime_session._signalpilot_chat_attempt = attempt
+
+                artifact_server = build_standalone_chat_mcp_server(
+                    collector,
+                    result_loader=load_result,
+                    project_directory=project_directory,
+                    scratch_directory=scratch,
+                    notebook_mcp_app=(
+                        request.app if notebook_analysis_enabled else None
+                    ),
+                    analysis_notebook_path=analysis_notebook_path,
+                    plan_checker=check_plan,
+                    event_sink=lifecycle_event,
+                    notebook_lifecycle=lifecycle,
+                    runtime_redactions=(scoped_token,),
+                )
+                attempt_prompt = prompt
+                if recovery_failure is not None:
+                    attempt_prompt = (
+                        f"{prompt}\n\n<notebook_recovery>\n"
+                        f"{_recovery_context(recovery_failure)}\n"
+                        "</notebook_recovery>"
+                    )
+
+                final_text = ""
+                streamed_text = ""
+                tool_names_by_id: dict[str, str] = {}
+                successful_run_cells = False
+                agent_failed = False
+                async for event in run_notebook_agent(
+                    attempt_prompt,
+                    session_id,
+                    model=str(
+                        body.get("model")
+                        or os.getenv("SIGNALPILOT_ANALYSIS_AGENT_MODEL")
+                        or "claude-sonnet-4-5-20250929"
+                    ),
+                    max_turns=40,
+                    new_chat=bool(body.get("new_execution", False))
+                    or attempt > 1,
+                    message_history=history,
+                    system_prompt_override=system_prompt,
+                    mcp_config=mcp_config,
+                    thread_id=f"standalone:{run_id}",
+                    notebook_mcp_app=(
+                        request.app if notebook_analysis_enabled else None
+                    ),
+                    cwd=str(project_directory),
+                    disallow_file_edits=True,
+                    additional_disallowed_tools=["WebFetch", "WebSearch"],
+                    allowed_tools=(
+                        STANDALONE_ALLOWED_TOOLS
+                        if notebook_analysis_enabled
+                        else [
+                            tool
+                            for tool in STANDALONE_ALLOWED_TOOLS
+                            if "signalpilot-notebook" not in tool
+                            and not tool.endswith("start_analysis_notebook")
+                        ]
+                    ),
+                    additional_mcp_servers={
+                        "standalone-chat": artifact_server
+                    },
+                    persist_session_mapping=False,
+                    auth_config_override=auth_config_override,
+                    notebook_session_authorizer=(
+                        lambda candidate, lifecycle=lifecycle: (
+                            lifecycle.session_id == candidate
+                        )
+                    ),
+                ):
+                    if event.type in {
+                        "thinking",
+                        "thinking_delta",
+                        "block_start",
+                    }:
+                        continue
+                    if event.type == "text_delta":
+                        streamed_text += event.content
+                        continue
+                    if event.type == "text":
+                        final_text = event.content
+                        continue
+                    if event.type == "error":
+                        agent_failed = True
+                        yield (
+                            json.dumps(
+                                {
+                                    "type": "error",
+                                    "content": "The analysis agent failed before validation.",
+                                    "is_error": True,
+                                }
+                            )
+                            + "\n"
+                        ).encode("utf-8")
+                        break
+                    if event.type == "tool_use" and event.tool_call_id:
+                        tool_names_by_id[event.tool_call_id] = event.tool_name
+                    if event.type == "tool_result":
+                        completed_tool = tool_names_by_id.get(
+                            event.tool_call_id, ""
+                        )
+                        if (
+                            completed_tool.endswith("run_cells")
+                            and not event.is_error
+                        ):
+                            successful_run_cells = True
+                    payload = {
+                        "type": event.type,
+                        "content": event.content,
+                        "tool_name": event.tool_name,
+                        "tool_input": event.tool_input,
+                        "tool_call_id": event.tool_call_id,
+                        "is_error": event.is_error,
+                    }
+                    yield (json.dumps(payload, default=str) + "\n").encode(
+                        "utf-8"
+                    )
+                if agent_failed:
+                    return
+
+                if project_directory is not None and not _project_is_unchanged(
+                    project_directory, commit_sha
+                ):
                     yield (
                         json.dumps(
                             {
                                 "type": "error",
-                                "content": "The analysis notebook contains a cell error; the answer was rejected.",
+                                "content": "The frozen project workspace changed; the run was rejected.",
                                 "is_error": True,
                             }
                         )
                         + "\n"
                     ).encode("utf-8")
                     return
-                archive_id = await _archive_analysis_notebook(
-                    app=request.app,
-                    session_id=lifecycle.session_id,
-                    run_id=run_id,
-                    gateway_api_url=gateway_api_url,
-                    scoped_token=scoped_token,
+
+                notebook_failure: dict[str, Any] | None = None
+                if lifecycle.session_id:
+                    notebook_failure = _notebook_failure(
+                        request.app, lifecycle.session_id
+                    )
+                    if (
+                        recovery_failure is not None
+                        and lifecycle.session_id
+                        == previous_notebook_session_id
+                    ):
+                        notebook_failure = {
+                            "error": {
+                                "type": "NotebookSessionReuseError",
+                                "variable": None,
+                                "cell_ids": [],
+                            }
+                        }
+                    elif not successful_run_cells:
+                        notebook_failure = {
+                            "error": {
+                                "type": "NotebookEvidenceNotValidatedError",
+                                "variable": None,
+                                "cell_ids": [],
+                            }
+                        }
+                elif recovery_failure is not None:
+                    notebook_failure = {
+                        "error": {
+                            "type": "NotebookNotRestartedError",
+                            "variable": None,
+                            "cell_ids": [],
+                        }
+                    }
+
+                if notebook_failure is not None:
+                    active_session_id = str(lifecycle.session_id or "")
+                    _log_notebook_failure(
+                        run_id=run_id,
+                        session_id=active_session_id,
+                        attempt=attempt,
+                        failure=notebook_failure,
+                    )
+                    if attempt == 1 and lifecycle.session_id:
+                        previous_notebook_session_id = lifecycle.session_id
+                        kernel_closed = _close_analysis_kernel(
+                            request.app, lifecycle.session_id
+                        )
+                        _ANALYSIS_SESSIONS_BY_RUN.pop(run_id, None)
+                        lifecycle.session_id = None
+                        if not kernel_closed:
+                            yield (
+                                json.dumps(
+                                    {
+                                        "type": "error",
+                                        "content": "The failed notebook kernel could not be reset safely.",
+                                        "is_error": True,
+                                    }
+                                )
+                                + "\n"
+                            ).encode("utf-8")
+                            return
+                        clear_chat_session(
+                            f"standalone:{run_id}", persist=False
+                        )
+                        analysis_notebook_path.write_text(
+                            seeded_notebook_source, encoding="utf-8"
+                        )
+                        recovery_failure = notebook_failure
+                        yield (
+                            json.dumps(
+                                {
+                                    "type": "progress",
+                                    "content": "Restarting analysis in a clean notebook",
+                                    "is_error": False,
+                                }
+                            )
+                            + "\n"
+                        ).encode("utf-8")
+                        continue
+                    yield (
+                        json.dumps(
+                            {
+                                "type": "error",
+                                "content": "Notebook validation failed after one clean retry; the answer was rejected.",
+                                "is_error": True,
+                            }
+                        )
+                        + "\n"
+                    ).encode("utf-8")
+                    return
+
+                archive_id = None
+                kernel_stopped = False
+                if lifecycle.session_id:
+                    try:
+                        archive_id = await _archive_analysis_notebook(
+                            app=request.app,
+                            session_id=lifecycle.session_id,
+                            run_id=run_id,
+                            gateway_api_url=gateway_api_url,
+                            scoped_token=scoped_token,
+                        )
+                    except Exception as exc:
+                        LOGGER.error(
+                            "Standalone notebook archive failed run_id=%s "
+                            "session_id=%s attempt=%s error_type=%s",
+                            run_id,
+                            lifecycle.session_id,
+                            attempt,
+                            type(exc).__name__,
+                        )
+                        yield (
+                            json.dumps(
+                                {
+                                    "type": "error",
+                                    "content": "The validated notebook could not be archived; the answer was rejected.",
+                                    "is_error": True,
+                                }
+                            )
+                            + "\n"
+                        ).encode("utf-8")
+                        return
+                    kernel_stopped = _close_analysis_kernel(
+                        request.app, lifecycle.session_id
+                    )
+                    _ANALYSIS_SESSIONS_BY_RUN.pop(run_id, None)
+                    lifecycle.session_id = None
+                accepted_text = (final_text or streamed_text).strip()
+                final_payload = {
+                    "type": "final",
+                    "content": accepted_text,
+                    "artifacts": collector.artifacts,
+                }
+                if archive_id is not None:
+                    final_payload["archive_id"] = archive_id
+                    final_payload["kernel_stopped"] = kernel_stopped
+                yield (json.dumps(final_payload, default=str) + "\n").encode(
+                    "utf-8"
                 )
-                kernel_stopped = _close_analysis_kernel(request.app, lifecycle.session_id)
-                _ANALYSIS_SESSIONS_BY_RUN.pop(run_id, None)
-            final_payload = {
-                "type": "final",
-                "content": final_text,
-                "artifacts": collector.artifacts,
-            }
-            if archive_id is not None:
-                final_payload["archive_id"] = archive_id
-                final_payload["kernel_stopped"] = kernel_stopped
-            yield (json.dumps(final_payload, default=str) + "\n").encode("utf-8")
+                return
         finally:
-            if lifecycle.session_id:
+            if current_lifecycle and current_lifecycle.session_id:
                 try:
-                    _close_analysis_kernel(request.app, lifecycle.session_id)
+                    _close_analysis_kernel(
+                        request.app, current_lifecycle.session_id
+                    )
                 except Exception:
                     pass
             _ANALYSIS_SESSIONS_BY_RUN.pop(run_id, None)
@@ -653,7 +1022,9 @@ async def cancel(*, request: Request) -> JSONResponse:
     kernel_stopped = False
     if analysis_session_id := _ANALYSIS_SESSIONS_BY_RUN.pop(run_id, None):
         try:
-            kernel_stopped = _close_analysis_kernel(request.app, analysis_session_id)
+            kernel_stopped = _close_analysis_kernel(
+                request.app, analysis_session_id
+            )
         except Exception:
             kernel_stopped = False
     return JSONResponse({"stopped": stopped, "kernel_stopped": kernel_stopped})

--- a/signalpilot/notebook-server/tests/_server/ai/test_notebook_mcp_runtime_safety.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_notebook_mcp_runtime_safety.py
@@ -155,6 +155,14 @@ async def test_duplicate_definition_is_an_mcp_error_before_document_mutation(
     assert response.root.isError is True
     assert session.document.transactions == []
     assert '"type": "MultipleDefinitionError"' in response.root.content[0].text
+    assert session._signalpilot_notebook_failures[-1]["error"] == {
+        "cell_ids": ["a", "b"],
+        "message": session._signalpilot_notebook_failures[-1]["error"][
+            "message"
+        ],
+        "type": "MultipleDefinitionError",
+        "variable": "df",
+    }
 
 
 def test_delete_then_add_removes_the_old_kernel_definition_before_running(

--- a/signalpilot/notebook-server/tests/_server/ai/test_notebook_mcp_runtime_safety.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_notebook_mcp_runtime_safety.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import json
+import sys
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from mcp.types import CallToolRequest, CallToolRequestParams
+
+from signalpilot._ast.cell import CellConfig
+from signalpilot._server.ai.notebook_mcp import (
+    NotebookToolError,
+    _handle_edit_notebook,
+    _handle_run_cells,
+    _validate_candidate_graph,
+    build_notebook_mcp_server,
+)
+from signalpilot._types.ids import CellId_t
+
+
+class _Document:
+    def __init__(self) -> None:
+        self.transactions: list[Any] = []
+
+    def apply(self, transaction: Any) -> Any:
+        self.transactions.append(transaction)
+        return type(transaction)(
+            changes=transaction.changes,
+            source=transaction.source,
+            version=1,
+        )
+
+
+class _Context:
+    def __init__(self, session: Any) -> None:
+        self._session = session
+        self.session_manager = SimpleNamespace(
+            auth_token="auth-token",
+            skew_protection_token="server-token",
+        )
+        self._app = SimpleNamespace(
+            state=SimpleNamespace(host="127.0.0.1", port=2718, base_url="")
+        )
+
+    def get_session(self, _session_id: str) -> Any:
+        return self._session
+
+    def get_app(self) -> Any:
+        return self._app
+
+
+def _session(cells: list[tuple[str, str]]) -> Any:
+    cell_data = [
+        SimpleNamespace(
+            cell_id=CellId_t(cell_id),
+            code=code,
+            name="_",
+            config=CellConfig(),
+        )
+        for cell_id, code in cells
+    ]
+    manager = SimpleNamespace(cell_data=lambda: list(cell_data))
+    file_manager = SimpleNamespace(
+        app=SimpleNamespace(cell_manager=manager),
+        path=None,
+    )
+    return SimpleNamespace(
+        app_file_manager=file_manager,
+        document=_Document(),
+        notify=lambda *_args, **_kwargs: None,
+        session_view=SimpleNamespace(cell_notifications={}),
+    )
+
+
+def _payload(error: NotebookToolError) -> dict[str, Any]:
+    return json.loads(str(error))
+
+
+@pytest.mark.parametrize(
+    ("cells", "error_type", "variable", "cell_ids"),
+    [
+        (
+            [(CellId_t("a"), "df = 1"), (CellId_t("b"), "df = 2")],
+            "MultipleDefinitionError",
+            "df",
+            ["a", "b"],
+        ),
+        (
+            [(CellId_t("a"), "if True print('broken')")],
+            "SyntaxError",
+            None,
+            ["a"],
+        ),
+        (
+            [
+                (CellId_t("a"), "left = right + 1"),
+                (CellId_t("b"), "right = left + 1"),
+            ],
+            "CycleError",
+            "left",
+            ["a", "b"],
+        ),
+    ],
+)
+def test_candidate_graph_rejects_invalid_batches(
+    cells: list[tuple[CellId_t, str]],
+    error_type: str,
+    variable: str | None,
+    cell_ids: list[str],
+) -> None:
+    with pytest.raises(NotebookToolError) as raised:
+        _validate_candidate_graph(cells)
+
+    assert _payload(raised.value)["error"] == {
+        "cell_ids": cell_ids,
+        "message": _payload(raised.value)["error"]["message"],
+        "type": error_type,
+        "variable": variable,
+    }
+
+
+@pytest.mark.asyncio
+async def test_duplicate_definition_is_an_mcp_error_before_document_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("a", "df = 1"), ("b", "answer = 2")])
+    monkeypatch.setitem(
+        sys.modules,
+        "signalpilot._server.ai.tools.registry",
+        SimpleNamespace(SUPPORTED_BACKEND_AND_MCP_TOOLS=[]),
+    )
+    config = build_notebook_mcp_server(_Context(session))
+    server = config["instance"]
+
+    response = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            params=CallToolRequestParams(
+                name="edit_notebook",
+                arguments={
+                    "session_id": "session-a",
+                    "edits": [
+                        {
+                            "type": "update_cell",
+                            "cell_id": "b",
+                            "code": "df = 2",
+                        }
+                    ],
+                },
+            )
+        )
+    )
+
+    assert response.root.isError is True
+    assert session.document.transactions == []
+    assert '"type": "MultipleDefinitionError"' in response.root.content[0].text
+
+
+def test_delete_then_add_removes_the_old_kernel_definition_before_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("old", "df = 1"), ("consumer", "answer = df + 1")])
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def post(url: str, **kwargs: Any) -> Any:
+        calls.append((url, kwargs["json"]))
+        return SimpleNamespace(status_code=200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    result = _handle_edit_notebook(
+        _Context(session),
+        {
+            "session_id": "session-a",
+            "edits": [
+                {"type": "delete_cell", "cell_id": "old"},
+                {"type": "add_cell", "code": "df = 3"},
+            ],
+        },
+    )
+
+    assert json.loads(result[0].text)["status"] == "completed"
+    assert [(url.rsplit("/", 1)[-1], body) for url, body in calls] == [
+        ("delete", {"cellId": "old"}),
+        (
+            "run",
+            {
+                "cellIds": [json.loads(result[0].text)["edits"][1]["cell_id"]],
+                "codes": ["df = 3"],
+            },
+        ),
+    ]
+
+
+def test_kernel_sync_failure_marks_the_mutated_notebook_dirty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("old", "df = 1")])
+
+    import requests
+
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: SimpleNamespace(status_code=500),
+    )
+    with pytest.raises(NotebookToolError) as raised:
+        _handle_edit_notebook(
+            _Context(session),
+            {
+                "session_id": "session-a",
+                "edits": [{"type": "delete_cell", "cell_id": "old"}],
+            },
+        )
+
+    assert session._signalpilot_notebook_dirty is True
+    assert len(session.document.transactions) == 1
+    assert _payload(raised.value)["error"] == {
+        "cell_ids": ["old"],
+        "message": "RuntimeError",
+        "type": "DocumentKernelSynchronizationError",
+        "variable": None,
+    }
+
+
+class SpExceptionRaisedError:
+    exception_type = "ValueError"
+
+    def describe(self) -> str:
+        return "The cell raised an exception"
+
+
+class MultipleDefinitionError:
+    name = "df"
+    cells = (CellId_t("other"),)
+
+    def describe(self) -> str:
+        return "The variable was defined by another cell"
+
+
+class SpInterruptionError:
+    def describe(self) -> str:
+        return "The cell was interrupted"
+
+
+@pytest.mark.asyncio
+async def test_run_cells_failure_is_an_mcp_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("cell", "answer = 1")])
+    session.session_view.cell_notifications[CellId_t("cell")] = (
+        SimpleNamespace(
+            timestamp=1.0,
+            status="idle",
+            output=None,
+            console=[],
+        )
+    )
+
+    def post(url: str, **_kwargs: Any) -> Any:
+        if url.endswith("/run"):
+            session.session_view.cell_notifications[CellId_t("cell")] = (
+                SimpleNamespace(
+                    timestamp=2.0,
+                    status="idle",
+                    output=SimpleNamespace(
+                        channel=SimpleNamespace(value="sp-error"),
+                        mimetype="application/vnd.sp+error",
+                        data=[SpExceptionRaisedError()],
+                    ),
+                    console=[],
+                )
+            )
+        return SimpleNamespace(status_code=200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "signalpilot._server.ai.tools.registry",
+        SimpleNamespace(SUPPORTED_BACKEND_AND_MCP_TOOLS=[]),
+    )
+    server = build_notebook_mcp_server(_Context(session))["instance"]
+    response = await server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            params=CallToolRequestParams(
+                name="run_cells",
+                arguments={"session_id": "session-a", "cell_ids": ["cell"]},
+            )
+        )
+    )
+
+    assert response.root.isError is True
+    assert '"status": "failed"' in response.root.content[0].text
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        SpExceptionRaisedError(),
+        MultipleDefinitionError(),
+        SpInterruptionError(),
+    ],
+)
+def test_run_cells_rejects_python_graph_and_cancellation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Any,
+) -> None:
+    session = _session([("cell", "answer = 1")])
+    session.session_view.cell_notifications[CellId_t("cell")] = (
+        SimpleNamespace(
+            timestamp=1.0,
+            status="idle",
+            output=None,
+            console=[],
+        )
+    )
+
+    def post(url: str, **_kwargs: Any) -> Any:
+        if url.endswith("/run"):
+            session.session_view.cell_notifications[CellId_t("cell")] = (
+                SimpleNamespace(
+                    timestamp=2.0,
+                    status="idle",
+                    output=SimpleNamespace(
+                        channel=SimpleNamespace(value="sp-error"),
+                        mimetype="application/vnd.sp+error",
+                        data=[error],
+                    ),
+                    console=[],
+                )
+            )
+        return SimpleNamespace(status_code=200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    with pytest.raises(NotebookToolError) as raised:
+        _handle_run_cells(
+            _Context(session),
+            {"session_id": "session-a", "cell_ids": ["cell"]},
+        )
+
+    payload = _payload(raised.value)
+    assert payload["status"] == "failed"
+    assert payload["has_errors"] is True
+    assert payload["failed_cell_ids"] == ["cell"]
+    assert payload["cells"][0]["errors"][0]["type"] == type(error).__name__
+
+
+def test_run_cells_rejects_unknown_state_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("cell", "answer = 1")])
+    session.session_view.cell_notifications[CellId_t("cell")] = (
+        SimpleNamespace(
+            timestamp=1.0,
+            status="idle",
+            output=None,
+            console=[],
+        )
+    )
+
+    def post(url: str, **_kwargs: Any) -> Any:
+        if url.endswith("/run"):
+            session.session_view.cell_notifications[CellId_t("cell")] = (
+                SimpleNamespace(
+                    timestamp=2.0,
+                    status="disabled-transitively",
+                    output=None,
+                    console=[],
+                )
+            )
+        return SimpleNamespace(status_code=200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    with pytest.raises(NotebookToolError) as unknown:
+        _handle_run_cells(_Context(session), {"session_id": "session-a"})
+    assert _payload(unknown.value)["cells"][0]["errors"] == [
+        {
+            "message": "Unexpected terminal state: disabled-transitively",
+            "type": "UnknownStateError",
+        }
+    ]
+
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: SimpleNamespace(status_code=200),
+    )
+    with pytest.raises(NotebookToolError) as timed_out:
+        _handle_run_cells(
+            _Context(session),
+            {"session_id": "session-a", "timeout": 0},
+        )
+    assert _payload(timed_out.value)["cells"][0]["errors"] == [
+        {
+            "message": "Cell execution did not reach a terminal state",
+            "type": "TimeoutError",
+        }
+    ]
+
+
+def test_run_cells_returns_a_structured_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("cell", "answer = 1")])
+    session.session_view.cell_notifications[CellId_t("cell")] = (
+        SimpleNamespace(
+            timestamp=1.0,
+            status="idle",
+            output=None,
+            console=[],
+        )
+    )
+
+    def post(url: str, **_kwargs: Any) -> Any:
+        if url.endswith("/run"):
+            session.session_view.cell_notifications[CellId_t("cell")] = (
+                SimpleNamespace(
+                    timestamp=2.0,
+                    status="idle",
+                    output=SimpleNamespace(
+                        channel=SimpleNamespace(value="output"),
+                        mimetype="text/plain",
+                        data="1",
+                    ),
+                    console=[],
+                )
+            )
+        return SimpleNamespace(status_code=200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    result = _handle_run_cells(
+        _Context(session),
+        {"session_id": "session-a", "cell_ids": ["cell"]},
+    )
+    payload = json.loads(result[0].text)
+    payload.pop("elapsed_seconds")
+
+    assert payload == {
+        "cell_ids": ["cell"],
+        "cells": [
+            {
+                "cell_id": "cell",
+                "output": {"data": "1", "mimetype": "text/plain"},
+                "runtime_state": "idle",
+                "status": "completed",
+            }
+        ],
+        "failed_cell_ids": [],
+        "has_errors": False,
+        "status": "completed",
+        "timed_out": False,
+    }

--- a/signalpilot/notebook-server/tests/_server/ai/test_notebook_mcp_runtime_safety.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_notebook_mcp_runtime_safety.py
@@ -472,3 +472,43 @@ def test_run_cells_returns_a_structured_success(
         "status": "completed",
         "timed_out": False,
     }
+
+
+def test_run_cells_clears_a_stale_error_before_a_successful_rerun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session([("cell", "answer = 1")])
+    notification = SimpleNamespace(
+        timestamp=1.0,
+        status="idle",
+        output=SimpleNamespace(
+            channel=SimpleNamespace(value="sp-error"),
+            mimetype="application/vnd.sp+error",
+            data=[SpExceptionRaisedError()],
+        ),
+        console=[],
+    )
+    session.session_view.cell_notifications[CellId_t("cell")] = notification
+
+    def post(url: str, **_kwargs: Any) -> Any:
+        if url.endswith("/run"):
+            # A successful no-output execution updates the cell lifecycle, but
+            # the session-view merge used to retain its previous error output.
+            notification.timestamp = 2.0
+            notification.status = "idle"
+        return SimpleNamespace(status_code=200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    result = _handle_run_cells(
+        _Context(session),
+        {"session_id": "session-a", "cell_ids": ["cell"]},
+    )
+    payload = json.loads(result[0].text)
+
+    assert payload["status"] == "completed"
+    assert payload["has_errors"] is False
+    assert payload["failed_cell_ids"] == []

--- a/signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py
@@ -435,6 +435,10 @@ def test_agent_contract_excludes_mutating_and_external_tools():
     assert "marimo reactive notebook, not a Jupyter notebook" in STANDALONE_SYSTEM_PROMPT
     assert "top-level loop targets all define names" in STANDALONE_SYSTEM_PROMPT
     assert "Prefix disposable cell-local names with one underscore" in STANDALONE_SYSTEM_PROMPT
+    assert "must never be referenced from another cell" in STANDALONE_SYSTEM_PROMPT
+    assert "If you change the SQL, call plan_query again" in STANDALONE_SYSTEM_PROMPT
+    assert "including as a fallback during recovery" in STANDALONE_SYSTEM_PROMPT
+    assert "same unchanged notebook code hash" in STANDALONE_SYSTEM_PROMPT
     assert "MultipleDefinitionError" in STANDALONE_SYSTEM_PROMPT
     assert all(
         "notion" not in tool.lower() for tool in STANDALONE_ALLOWED_TOOLS

--- a/signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py
@@ -432,6 +432,10 @@ def test_agent_contract_excludes_mutating_and_external_tools():
     assert "Do not catch or suppress publication exceptions" in STANDALONE_SYSTEM_PROMPT
     assert "Never edit, remove, or redefine the seeded" in STANDALONE_SYSTEM_PROMPT
     assert "sp.init()` returns None" in STANDALONE_SYSTEM_PROMPT
+    assert "marimo reactive notebook, not a Jupyter notebook" in STANDALONE_SYSTEM_PROMPT
+    assert "top-level loop targets all define names" in STANDALONE_SYSTEM_PROMPT
+    assert "Prefix disposable cell-local names with one underscore" in STANDALONE_SYSTEM_PROMPT
+    assert "MultipleDefinitionError" in STANDALONE_SYSTEM_PROMPT
     assert all(
         "notion" not in tool.lower() for tool in STANDALONE_ALLOWED_TOOLS
     )

--- a/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
+++ b/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
@@ -5,6 +5,8 @@ import json
 import stat
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import httpx
 import pytest
@@ -41,9 +43,16 @@ def test_seeded_analysis_notebooks_keep_run_tokens_out_of_source_and_isolated(
 
     assert "token-a-secret" not in first.read_text(encoding="utf-8")
     assert "token-b-secret" not in second.read_text(encoding="utf-8")
-    assert (first_scratch / ".gateway-token").read_text(encoding="utf-8") == "token-a-secret"
-    assert (second_scratch / ".gateway-token").read_text(encoding="utf-8") == "token-b-secret"
-    assert stat.S_IMODE((first_scratch / ".gateway-token").stat().st_mode) == 0o600
+    assert (first_scratch / ".gateway-token").read_text(
+        encoding="utf-8"
+    ) == "token-a-secret"
+    assert (second_scratch / ".gateway-token").read_text(
+        encoding="utf-8"
+    ) == "token-b-secret"
+    assert (
+        stat.S_IMODE((first_scratch / ".gateway-token").stat().st_mode)
+        == 0o600
+    )
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -93,7 +102,7 @@ def _scoped_token(*, run_id: str, project_id: str, commit_sha: str) -> str:
     return f"header.{payload}.signature"
 
 
-def _request(body: dict[str, object]) -> Request:
+def _request(body: dict[str, object], *, app: object | None = None) -> Request:
     encoded = json.dumps(body).encode()
     delivered = False
 
@@ -104,15 +113,67 @@ def _request(body: dict[str, object]) -> Request:
         delivered = True
         return {"type": "http.request", "body": encoded, "more_body": False}
 
-    return Request(
-        {
-            "type": "http",
-            "method": "POST",
-            "path": "/execute",
-            "headers": [(b"content-type", b"application/json")],
-        },
-        receive,
+    scope: dict[str, Any] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/execute",
+        "headers": [(b"content-type", b"application/json")],
+    }
+    if app is not None:
+        scope["app"] = app
+    return Request(scope, receive)
+
+
+def _runtime_session(*, dirty: bool = False) -> Any:
+    cell_id = "current"
+    notification = SimpleNamespace(
+        status="idle",
+        output=None,
     )
+    session = SimpleNamespace(
+        app_file_manager=SimpleNamespace(
+            app=SimpleNamespace(
+                cell_manager=SimpleNamespace(
+                    cell_data=lambda: [
+                        SimpleNamespace(cell_id=cell_id, code="answer = 1")
+                    ]
+                )
+            )
+        ),
+        session_view=SimpleNamespace(
+            cell_notifications={cell_id: notification}
+        ),
+    )
+    if dirty:
+        session._signalpilot_notebook_dirty = True
+        session._signalpilot_last_notebook_failure = {
+            "error": {
+                "type": "MultipleDefinitionError",
+                "variable": "df",
+                "cell_ids": ["old", "new"],
+            }
+        }
+    return session
+
+
+def test_terminal_validation_ignores_deleted_cell_notifications(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _runtime_session()
+    session.session_view.cell_notifications["deleted"] = SimpleNamespace(
+        status="idle",
+        output=SimpleNamespace(
+            channel=SimpleNamespace(value="sp-error"),
+            data=[SimpleNamespace()],
+        ),
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "_analysis_session",
+        lambda _app, _session_id: session,
+    )
+
+    assert standalone_chat._notebook_failure(object(), "session-a") is None
 
 
 @pytest.mark.asyncio
@@ -185,3 +246,256 @@ async def test_execute_materializes_the_frozen_project_before_starting_the_agent
     }
     assert captured["head"] == commit_sha
     assert Path(captured["cwd"]).is_relative_to(projects_root)
+
+
+@pytest.mark.asyncio
+async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "run-retry-1234"
+    project_id = "1dbf5492-81e6-4683-835f-f1785c9cfe78"
+    commit_sha = "a" * 40
+    app = SimpleNamespace()
+    sessions: dict[str, Any] = {}
+    lifecycles: list[Any] = []
+    collectors: list[Any] = []
+    seeded_paths: list[Path] = []
+    event_sinks: list[Any] = []
+    closed: list[str] = []
+    cleared: list[str] = []
+    archived: list[str] = []
+
+    async def execution_directory(**_kwargs: Any) -> tuple[Path, bool]:
+        return tmp_path, False
+
+    def build_server(collector: Any, **kwargs: Any) -> object:
+        collectors.append(collector)
+        lifecycles.append(kwargs["notebook_lifecycle"])
+        seeded_paths.append(kwargs["analysis_notebook_path"])
+        event_sinks.append(kwargs["event_sink"])
+        return object()
+
+    async def run_agent(prompt: str, _session_id: object, **_kwargs: Any):
+        attempt = len(sessions) + 1
+        lifecycle = lifecycles[-1]
+        lifecycle.session_id = f"kernel-{attempt}"
+        sessions[lifecycle.session_id] = _runtime_session(dirty=attempt == 1)
+        await event_sinks[-1]("notebook_started", {})
+        if attempt == 1:
+            collectors[-1].artifacts.append({"filename": "rejected.csv"})
+            seeded_paths[-1].write_text("corrupted notebook", encoding="utf-8")
+            yield AgentEvent(type="text_delta", content="REJECTED LEAK")
+            yield AgentEvent(type="text", content="Rejected answer")
+            return
+        assert "corrupted notebook" not in seeded_paths[-1].read_text(
+            encoding="utf-8"
+        )
+        assert "notebook_recovery" in prompt
+        collectors[-1].artifacts.append({"filename": "accepted.csv"})
+        yield AgentEvent(
+            type="tool_use",
+            tool_name="mcp__signalpilot-notebook__run_cells",
+            tool_call_id="run-cells-2",
+        )
+        yield AgentEvent(
+            type="tool_result",
+            tool_call_id="run-cells-2",
+            is_error=False,
+        )
+        yield AgentEvent(type="text_delta", content="Accepted streamed text")
+        yield AgentEvent(type="text", content="Accepted answer")
+
+    async def archive(**kwargs: Any) -> str:
+        archived.append(kwargs["session_id"])
+        return "archive-clean"
+
+    monkeypatch.setenv("SP_CHAT_SCRATCH_ROOT", str(tmp_path / "scratch"))
+    monkeypatch.setattr(
+        standalone_chat, "_execution_project_directory", execution_directory
+    )
+    monkeypatch.setattr(
+        standalone_chat, "build_standalone_chat_mcp_server", build_server
+    )
+    monkeypatch.setattr(standalone_chat, "run_notebook_agent", run_agent)
+    monkeypatch.setattr(
+        standalone_chat,
+        "_analysis_session",
+        lambda _app, session_id: sessions[session_id],
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "_close_analysis_kernel",
+        lambda _app, session_id: closed.append(session_id) or True,
+    )
+    monkeypatch.setattr(standalone_chat, "_archive_analysis_notebook", archive)
+    monkeypatch.setattr(
+        standalone_chat, "_project_is_unchanged", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "clear_chat_session",
+        lambda session_id, **_kwargs: cleared.append(session_id),
+    )
+
+    token = _scoped_token(
+        run_id=run_id,
+        project_id=project_id,
+        commit_sha=commit_sha,
+    )
+    response = await standalone_chat.execute(
+        request=_request(
+            {
+                "run_id": run_id,
+                "project_id": project_id,
+                "branch": "main",
+                "connection_name": "production",
+                "commit_sha": commit_sha,
+                "gateway_session_token": token,
+                "prompt": "Analyze revenue",
+                "features": {"notebook_analysis": True},
+            },
+            app=app,
+        )
+    )
+    events = [
+        json.loads(line)
+        for line in (
+            b"".join([chunk async for chunk in response.body_iterator])
+        ).splitlines()
+    ]
+
+    assert [event["type"] for event in events] == [
+        "progress",
+        "tool_use",
+        "tool_result",
+        "final",
+    ]
+    assert events[0]["content"] == "Restarting analysis in a clean notebook"
+    assert events[-1] == {
+        "archive_id": "archive-clean",
+        "artifacts": [{"filename": "accepted.csv"}],
+        "content": "Accepted answer",
+        "kernel_stopped": True,
+        "type": "final",
+    }
+    assert "REJECTED LEAK" not in json.dumps(events)
+    assert closed == ["kernel-1", "kernel-2"]
+    assert archived == ["kernel-2"]
+    assert cleared.count(f"standalone:{run_id}") >= 2
+
+
+@pytest.mark.asyncio
+async def test_two_dirty_attempts_emit_one_validation_error_and_no_final(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "run-dirty-1234"
+    project_id = "1dbf5492-81e6-4683-835f-f1785c9cfe78"
+    commit_sha = "b" * 40
+    sessions: dict[str, Any] = {}
+    lifecycles: list[Any] = []
+    event_sinks: list[Any] = []
+    archive_calls: list[bool] = []
+
+    async def execution_directory(**_kwargs: Any) -> tuple[Path, bool]:
+        return tmp_path, False
+
+    def build_server(_collector: Any, **kwargs: Any) -> object:
+        lifecycles.append(kwargs["notebook_lifecycle"])
+        event_sinks.append(kwargs["event_sink"])
+        return object()
+
+    async def run_agent(_prompt: str, _session_id: object, **_kwargs: Any):
+        attempt = len(sessions) + 1
+        lifecycle = lifecycles[-1]
+        lifecycle.session_id = f"dirty-kernel-{attempt}"
+        sessions[lifecycle.session_id] = _runtime_session(dirty=True)
+        await event_sinks[-1]("notebook_started", {})
+        if attempt == 2:
+            yield AgentEvent(
+                type="tool_use",
+                tool_name="mcp__signalpilot-notebook__run_cells",
+                tool_call_id="run-cells-2",
+            )
+            yield AgentEvent(
+                type="tool_result",
+                tool_call_id="run-cells-2",
+                is_error=False,
+            )
+        yield AgentEvent(type="text_delta", content=f"dirty answer {attempt}")
+        yield AgentEvent(type="text", content=f"Dirty answer {attempt}")
+
+    async def archive(**_kwargs: Any) -> str:
+        archive_calls.append(True)
+        return "unexpected"
+
+    monkeypatch.setenv("SP_CHAT_SCRATCH_ROOT", str(tmp_path / "scratch"))
+    monkeypatch.setattr(
+        standalone_chat, "_execution_project_directory", execution_directory
+    )
+    monkeypatch.setattr(
+        standalone_chat, "build_standalone_chat_mcp_server", build_server
+    )
+    monkeypatch.setattr(standalone_chat, "run_notebook_agent", run_agent)
+    monkeypatch.setattr(
+        standalone_chat,
+        "_analysis_session",
+        lambda _app, session_id: sessions[session_id],
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "_close_analysis_kernel",
+        lambda _app, _session_id: True,
+    )
+    monkeypatch.setattr(standalone_chat, "_archive_analysis_notebook", archive)
+    monkeypatch.setattr(
+        standalone_chat, "_project_is_unchanged", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        standalone_chat, "clear_chat_session", lambda *_args, **_kwargs: None
+    )
+
+    token = _scoped_token(
+        run_id=run_id,
+        project_id=project_id,
+        commit_sha=commit_sha,
+    )
+    response = await standalone_chat.execute(
+        request=_request(
+            {
+                "run_id": run_id,
+                "project_id": project_id,
+                "branch": "main",
+                "connection_name": "production",
+                "commit_sha": commit_sha,
+                "gateway_session_token": token,
+                "prompt": "Analyze revenue",
+                "features": {"notebook_analysis": True},
+            },
+            app=SimpleNamespace(),
+        )
+    )
+    events = [
+        json.loads(line)
+        for line in (
+            b"".join([chunk async for chunk in response.body_iterator])
+        ).splitlines()
+    ]
+
+    assert [event["type"] for event in events] == [
+        "progress",
+        "tool_use",
+        "tool_result",
+        "error",
+    ]
+    assert events[-1] == {
+        "content": "Notebook validation failed after one clean retry; the answer was rejected.",
+        "is_error": True,
+        "type": "error",
+    }
+    assert all(
+        event["type"] not in {"final", "text", "text_delta"}
+        for event in events
+    )
+    assert archive_calls == []

--- a/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
+++ b/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
@@ -176,6 +176,53 @@ def test_terminal_validation_ignores_deleted_cell_notifications(
     assert standalone_chat._notebook_failure(object(), "session-a") is None
 
 
+def test_recovery_context_keeps_prior_graph_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _runtime_session()
+    session._signalpilot_notebook_failures = [
+        {
+            "error": {
+                "type": "MultipleDefinitionError",
+                "variable": "segment",
+                "cell_ids": ["summary", "chart"],
+            }
+        }
+    ]
+    session.session_view.cell_notifications[
+        "current"
+    ].output = SimpleNamespace(
+        channel=SimpleNamespace(value="sp-error"),
+        data=[SimpleNamespace()],
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "_analysis_session",
+        lambda _app, _session_id: session,
+    )
+
+    failure = standalone_chat._notebook_failure(object(), "session-a")
+
+    assert failure is not None
+    assert failure["errors"] == [
+        {
+            "type": "MultipleDefinitionError",
+            "variable": "segment",
+            "cell_ids": ["summary", "chart"],
+        },
+        {
+            "type": "SimpleNamespace",
+            "variable": None,
+            "cell_ids": ["current"],
+        },
+    ]
+    recovery = standalone_chat._recovery_context(failure)
+    assert "MultipleDefinitionError" in recovery
+    assert '"variable": "segment"' in recovery
+    assert '"summary"' in recovery
+    assert "underscore-prefixed scratch names" in recovery
+
+
 @pytest.mark.asyncio
 async def test_execute_materializes_the_frozen_project_before_starting_the_agent(
     tmp_path: Path,
@@ -281,6 +328,23 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
         lifecycle = lifecycles[-1]
         lifecycle.session_id = f"kernel-{attempt}"
         sessions[lifecycle.session_id] = _runtime_session(dirty=attempt == 1)
+        if attempt == 1:
+            sessions[lifecycle.session_id]._signalpilot_notebook_failures = [
+                {
+                    "error": {
+                        "type": "MultipleDefinitionError",
+                        "variable": "segment",
+                        "cell_ids": ["summary", "chart"],
+                    }
+                },
+                {
+                    "error": {
+                        "type": "SpExceptionRaisedError",
+                        "variable": None,
+                        "cell_ids": ["output"],
+                    }
+                },
+            ]
         await event_sinks[-1]("notebook_started", {})
         if attempt == 1:
             collectors[-1].artifacts.append({"filename": "rejected.csv"})
@@ -292,6 +356,9 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
             encoding="utf-8"
         )
         assert "notebook_recovery" in prompt
+        assert "MultipleDefinitionError" in prompt
+        assert '"variable": "segment"' in prompt
+        assert "SpExceptionRaisedError" in prompt
         collectors[-1].artifacts.append({"filename": "accepted.csv"})
         yield AgentEvent(
             type="tool_use",

--- a/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
+++ b/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
@@ -4,9 +4,10 @@ import base64
 import json
 import stat
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Self
 
 import httpx
 import pytest
@@ -221,6 +222,100 @@ def test_recovery_context_keeps_prior_graph_errors(
     assert '"variable": "segment"' in recovery
     assert '"summary"' in recovery
     assert "underscore-prefixed scratch names" in recovery
+    assert "cell-local and cannot be read from another cell" in recovery
+    assert "changed SQL requires a new plan_query result" in recovery
+    assert "Never replace SDK query evidence" in recovery
+
+
+@pytest.mark.asyncio
+async def test_archive_uses_a_safe_fallback_without_frontend_assets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scoped_token = "runtime-secret-token"
+    cell_id = "cell-a"
+    app = SimpleNamespace(
+        to_py=lambda: "answer = 1",
+        cell_manager=SimpleNamespace(
+            cell_data=lambda: [
+                SimpleNamespace(cell_id=cell_id, code="answer = 1")
+            ]
+        ),
+    )
+    session = SimpleNamespace(
+        app_file_manager=SimpleNamespace(app=app),
+        config_manager=SimpleNamespace(get_config=lambda: {"display": {}}),
+        session_view=SimpleNamespace(
+            cell_notifications={
+                cell_id: SimpleNamespace(
+                    status="idle",
+                    output=SimpleNamespace(
+                        mimetype="text/html",
+                        data=f"<script>{scoped_token}</script><b>safe result</b>",
+                    ),
+                )
+            }
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    class MissingAssetsExporter:
+        def export_as_html(self, **_kwargs: Any) -> tuple[str, str]:
+            raise FileNotFoundError("frontend index missing")
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"archive_id": "archive-fallback"}
+
+    class FakeClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def post(self, _url: str, **kwargs: Any) -> FakeResponse:
+            captured.update(kwargs["json"])
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        standalone_chat,
+        "_analysis_session",
+        lambda _app, _session_id: session,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "signalpilot._server.export.exporter",
+        SimpleNamespace(Exporter=MissingAssetsExporter),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "signalpilot._server.models.export",
+        SimpleNamespace(ExportAsHTMLRequest=lambda **kwargs: kwargs),
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    archive_id = await standalone_chat._archive_analysis_notebook(
+        app=object(),
+        session_id="session-a",
+        run_id="run-fallback",
+        gateway_api_url="http://gateway:3300",
+        scoped_token=scoped_token,
+    )
+    archived_html = base64.b64decode(captured["html_base64"]).decode()
+    archived_source = base64.b64decode(captured["source_base64"]).decode()
+
+    assert archive_id == "archive-fallback"
+    assert "Validated analysis notebook" in archived_html
+    assert "&lt;script&gt;[REDACTED]&lt;/script&gt;" in archived_html
+    assert scoped_token not in archived_html
+    assert "answer = 1" not in archived_html
+    assert archived_source == "answer = 1"
 
 
 @pytest.mark.asyncio

--- a/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
+++ b/signalpilot/notebook-server/tests/_server/api/endpoints/test_standalone_chat_execution.py
@@ -312,6 +312,8 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
     closed: list[str] = []
     cleared: list[str] = []
     archived: list[str] = []
+    clean_starts: list[Path] = []
+    agent_attempts = 0
 
     async def execution_directory(**_kwargs: Any) -> tuple[Path, bool]:
         return tmp_path, False
@@ -324,11 +326,14 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
         return object()
 
     async def run_agent(prompt: str, _session_id: object, **_kwargs: Any):
-        attempt = len(sessions) + 1
+        nonlocal agent_attempts
+        agent_attempts += 1
+        attempt = agent_attempts
         lifecycle = lifecycles[-1]
-        lifecycle.session_id = f"kernel-{attempt}"
-        sessions[lifecycle.session_id] = _runtime_session(dirty=attempt == 1)
         if attempt == 1:
+            lifecycle.session_id = "kernel-1"
+            lifecycle.plan_id = "plan-1"
+            sessions[lifecycle.session_id] = _runtime_session(dirty=True)
             sessions[lifecycle.session_id]._signalpilot_notebook_failures = [
                 {
                     "error": {
@@ -345,6 +350,9 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
                     }
                 },
             ]
+        else:
+            assert lifecycle.session_id == "kernel-2"
+            assert lifecycle.plan_id == "plan-1"
         await event_sinks[-1]("notebook_started", {})
         if attempt == 1:
             collectors[-1].artifacts.append({"filename": "rejected.csv"})
@@ -359,6 +367,8 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
         assert "MultipleDefinitionError" in prompt
         assert '"variable": "segment"' in prompt
         assert "SpExceptionRaisedError" in prompt
+        assert "session_id `kernel-2`" in prompt
+        assert "plan_id `plan-1`" in prompt
         collectors[-1].artifacts.append({"filename": "accepted.csv"})
         yield AgentEvent(
             type="tool_use",
@@ -394,6 +404,15 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
         standalone_chat,
         "_close_analysis_kernel",
         lambda _app, session_id: closed.append(session_id) or True,
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "_start_analysis_kernel",
+        lambda _app, notebook_path: (
+            clean_starts.append(notebook_path),
+            sessions.setdefault("kernel-2", _runtime_session()),
+            "kernel-2",
+        )[-1],
     )
     monkeypatch.setattr(standalone_chat, "_archive_analysis_notebook", archive)
     monkeypatch.setattr(
@@ -448,6 +467,7 @@ async def test_dirty_notebook_is_reset_and_only_clean_retry_answer_is_emitted(
     }
     assert "REJECTED LEAK" not in json.dumps(events)
     assert closed == ["kernel-1", "kernel-2"]
+    assert clean_starts == [seeded_paths[0]]
     assert archived == ["kernel-2"]
     assert cleared.count(f"standalone:{run_id}") >= 2
 
@@ -464,6 +484,7 @@ async def test_two_dirty_attempts_emit_one_validation_error_and_no_final(
     lifecycles: list[Any] = []
     event_sinks: list[Any] = []
     archive_calls: list[bool] = []
+    agent_attempts = 0
 
     async def execution_directory(**_kwargs: Any) -> tuple[Path, bool]:
         return tmp_path, False
@@ -474,10 +495,17 @@ async def test_two_dirty_attempts_emit_one_validation_error_and_no_final(
         return object()
 
     async def run_agent(_prompt: str, _session_id: object, **_kwargs: Any):
-        attempt = len(sessions) + 1
+        nonlocal agent_attempts
+        agent_attempts += 1
+        attempt = agent_attempts
         lifecycle = lifecycles[-1]
-        lifecycle.session_id = f"dirty-kernel-{attempt}"
-        sessions[lifecycle.session_id] = _runtime_session(dirty=True)
+        if attempt == 1:
+            lifecycle.session_id = "dirty-kernel-1"
+            lifecycle.plan_id = "plan-dirty"
+            sessions[lifecycle.session_id] = _runtime_session(dirty=True)
+        else:
+            assert lifecycle.session_id == "dirty-kernel-2"
+            assert lifecycle.plan_id == "plan-dirty"
         await event_sinks[-1]("notebook_started", {})
         if attempt == 2:
             yield AgentEvent(
@@ -514,6 +542,16 @@ async def test_two_dirty_attempts_emit_one_validation_error_and_no_final(
         standalone_chat,
         "_close_analysis_kernel",
         lambda _app, _session_id: True,
+    )
+    monkeypatch.setattr(
+        standalone_chat,
+        "_start_analysis_kernel",
+        lambda _app, _notebook_path: (
+            sessions.setdefault(
+                "dirty-kernel-2", _runtime_session(dirty=True)
+            ),
+            "dirty-kernel-2",
+        )[-1],
     )
     monkeypatch.setattr(standalone_chat, "_archive_analysis_notebook", archive)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- preflight complete notebook edit batches against a fresh dependency graph and synchronize deletions with the kernel before execution
- make `run_cells` return structured failures and MCP errors for exceptions, graph errors, cancellations, unknown states, and timeouts
- clear a requested cell's cached output before rerun so a successful Marimo execution cannot inherit an older exception
- retry one dirty standalone analysis from the original seed with a new kernel and artifact collector
- buffer narrative text until project integrity, notebook validation, and archive creation succeed
- archive validated notebooks safely even when the slim runtime image omits the frontend bundle
- clarify private cell-local names, exact plan/SQL reuse, MCP-preview restrictions, and publication code-hash ordering in the agent contract
- project failed cell executions and clean-retry progress accurately through the gateway

## Validation

- notebook MCP, standalone tool, and execution suites: 38 passed
- gateway standalone store and worker suites: 31 passed
- Ruff checks passed for all touched files
- `git diff --check` passed
- live retry `73e5aa23-b9c2-445c-b6ad-ce3c489ec9ff` completed through the local UI runtime with a governed result, chart artifact, terminal notebook validation, archive `663dc901-5d05-5932-bb8d-697d35224e87`, persisted assistant answer, and stopped kernel
- the live run recovered from an actual cell exception without retaining the stale error and logged no `MultipleDefinitionError`

## Scope

The unrelated aiohttp unclosed client-session leak remains outside this PR.
