### PR TITLE
Hide superseded Data Chat failure attempts

### DIFF
--- a/signalpilot/web/components/chat/standalone-data-chat.tsx
+++ b/signalpilot/web/components/chat/standalone-data-chat.tsx
@@ -69,6 +69,7 @@ import {
   applyStandaloneChatEvent,
   assembleStandaloneRunText,
   containsStandaloneSubmission,
+  hideSupersededStandaloneFailures,
   isStandaloneRunReconciled,
   standaloneMessageKey,
   upsertStandaloneConversation,
@@ -1210,7 +1211,9 @@ export function StandaloneDataChat({
   }, [conversationId, currentRunId, streamStatus, mutateDetail, mutateHistory]);
 
   const uiMessages = useMemo<UiMessage[]>(() => {
-    const messages: UiMessage[] = [...(detail?.messages ?? [])];
+    const messages: UiMessage[] = hideSupersededStandaloneFailures(
+      detail?.messages ?? [],
+    );
     if (currentRun) {
       const runMessages = messages.filter(
         (message) => message.metadata.run_id === currentRun.id,

--- a/signalpilot/web/lib/standalone-chat-state.test.ts
+++ b/signalpilot/web/lib/standalone-chat-state.test.ts
@@ -5,6 +5,7 @@ import {
   applyStandaloneChatEvent,
   assembleStandaloneRunText,
   containsStandaloneSubmission,
+  hideSupersededStandaloneFailures,
   isStandaloneRunReconciled,
   standaloneMessageKey,
   upsertStandaloneConversation,
@@ -124,6 +125,78 @@ describe("standalone chat state", () => {
         submission,
       ),
     ).toBe(true);
+  });
+
+  it("hides failed attempts after a retry for the same user turn completes", () => {
+    const detail = detailFixture();
+    detail.messages = [
+      {
+        id: "user-1",
+        role: "user",
+        content: "Analyze margins",
+        sequence: 1,
+        created_at: 100,
+        metadata: {},
+      },
+      {
+        id: "failed-1",
+        role: "assistant",
+        content: "Analysis failed",
+        sequence: 2,
+        created_at: 101,
+        metadata: { run_id: "run-1", status: "failed" },
+      },
+      {
+        id: "failed-2",
+        role: "assistant",
+        content: "Analysis failed again",
+        sequence: 3,
+        created_at: 102,
+        metadata: { run_id: "run-2", status: "failed" },
+      },
+      {
+        id: "completed-1",
+        role: "assistant",
+        content: "Margins completed",
+        sequence: 4,
+        created_at: 103,
+        metadata: { run_id: "run-3", status: "completed" },
+      },
+    ];
+
+    expect(
+      hideSupersededStandaloneFailures(detail.messages).map(
+        (message) => message.id,
+      ),
+    ).toEqual(["user-1", "completed-1"]);
+  });
+
+  it("keeps the latest failed attempt visible when no retry succeeds", () => {
+    const detail = detailFixture();
+    detail.messages = [
+      {
+        id: "user-1",
+        role: "user",
+        content: "Analyze margins",
+        sequence: 1,
+        created_at: 100,
+        metadata: {},
+      },
+      {
+        id: "failed-1",
+        role: "assistant",
+        content: "Analysis failed",
+        sequence: 2,
+        created_at: 101,
+        metadata: { run_id: "run-1", status: "failed" },
+      },
+    ];
+
+    expect(
+      hideSupersededStandaloneFailures(detail.messages).map(
+        (message) => message.id,
+      ),
+    ).toEqual(["user-1", "failed-1"]);
   });
 
   it("keeps streamed events in conversation state and applies terminal status immediately", () => {

--- a/signalpilot/web/lib/standalone-chat-state.ts
+++ b/signalpilot/web/lib/standalone-chat-state.ts
@@ -49,6 +49,30 @@ export function containsStandaloneSubmission(
   );
 }
 
+export function hideSupersededStandaloneFailures(
+  messages: StandaloneChatMessage[],
+): StandaloneChatMessage[] {
+  const visible: StandaloneChatMessage[] = [];
+  let laterCompletedAttempt = false;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message) continue;
+    if (message.role === "user") {
+      laterCompletedAttempt = false;
+      visible.push(message);
+      continue;
+    }
+
+    const status = message.metadata.status;
+    if (status === "completed") laterCompletedAttempt = true;
+    if (status === "failed" && laterCompletedAttempt) continue;
+    visible.push(message);
+  }
+
+  return visible.reverse();
+}
+
 const runStatuses = new Set<StandaloneChatRunStatus>([
   "queued",
   "running",


### PR DESCRIPTION
## Summary

- hide failed assistant messages once a later retry for the same user turn completes
- keep the latest failed attempt visible when no retry succeeds
- prevent successfully recovered notebook analyses from continuing to look failed in the conversation UI

## Evidence

Conversation `5d5b4508-f55e-4948-8433-759161b4794f` persisted two failed assistant messages for runs `599cd508-02ee-4917-a682-002d30071a1a` and `1d3dd407-c1ae-4d43-b5fd-787ae69efb3b`, followed by the completed retry `73e5aa23-b9c2-445c-b6ad-ce3c489ec9ff`. The runtime was complete, but the UI rendered all three attempt outcomes.

## Validation

- standalone chat web state suite: 40 passed
- TypeScript: `pnpm exec tsc --noEmit` passed
- `git diff --check` passed

ESLint could not run because this checkout has ESLint 9 but no `eslint.config.*`; that existing tooling mismatch is unchanged by this PR.
