### PR TITLE
Fix org-scoped AI keys in Data Chat

### DIFF
--- a/signalpilot/gateway/gateway/standalone_chat/execution.py
+++ b/signalpilot/gateway/gateway/standalone_chat/execution.py
@@ -29,8 +29,8 @@ from gateway.notebooks.session_service import (
 from gateway.standalone_chat.config import enterprise_chat_feature_flags
 from gateway.standalone_chat.object_storage import chat_object_storage
 from gateway.store import notebook_sessions as notebook_session_store
+from gateway.store import org_secrets as org_secrets_store
 from gateway.store.standalone_chat import set_execution_session
-from gateway.store.user_secrets import get_user_anthropic_key
 
 
 def _join_base_path(base: str, path: str) -> str:
@@ -93,11 +93,7 @@ async def prepare_execution(
         connection_name=connection_name,
         commit_sha=commit_sha,
     )
-    anthropic_api_key = await get_user_anthropic_key(
-        db,
-        run.org_id,
-        run.user_id,
-    )
+    anthropic_api_key = await org_secrets_store.resolve_anthropic_key(db, run.org_id)
     runtime_auth: dict[str, str] | None = None
     if anthropic_api_key:
         runtime_auth = {"type": "api_key", "token": anthropic_api_key}

--- a/signalpilot/gateway/gateway/standalone_chat/projects.py
+++ b/signalpilot/gateway/gateway/standalone_chat/projects.py
@@ -23,7 +23,7 @@ from gateway.db.models import (
     GatewayWorkspaceProject,
 )
 from gateway.git.repos import _run_git, branch_head_sha, repo_path
-from gateway.store.user_secrets import get_user_anthropic_key
+from gateway.store import org_secrets as org_secrets_store
 
 
 @dataclass(frozen=True)
@@ -190,7 +190,7 @@ async def evaluate_project_readiness(
         os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
         or os.getenv("OAUTH_TOKEN")
         or os.getenv("ANTHROPIC_API_KEY")
-        or await get_user_anthropic_key(db, org_id, user_id)
+        or await org_secrets_store.resolve_anthropic_key(db, org_id)
     )
     if not has_runtime_credentials:
         return ProjectReadiness(

--- a/signalpilot/gateway/tests/test_standalone_chat.py
+++ b/signalpilot/gateway/tests/test_standalone_chat.py
@@ -37,6 +37,7 @@ from gateway.models.standalone_chat import (
     StandaloneConversationPatch,
     StandaloneRunCreate,
 )
+from gateway.standalone_chat import execution as chat_execution
 from gateway.standalone_chat import projects as chat_projects
 from gateway.standalone_chat.artifacts import (
     normalize_table_snapshot,
@@ -861,6 +862,112 @@ async def test_existing_conversation_readiness_uses_its_frozen_branch(
     )
     assert readiness.ready
     assert readiness.branch == "production-frozen"
+
+
+@pytest.mark.asyncio
+async def test_project_readiness_accepts_org_anthropic_key(db_session, monkeypatch):
+    project = await _project(db_session)
+    db_session.add_all(
+        [
+            GatewayConnection(
+                org_id="org-a",
+                user_id="user-a",
+                name="production",
+                db_type="postgres",
+                status="connected",
+                created_at=1.0,
+                description="",
+                tags=[],
+                schema_filter_include=[],
+                schema_filter_exclude=[],
+            ),
+            GatewayCredential(
+                org_id="org-a",
+                user_id="user-a",
+                connection_name="production",
+                connection_string_enc=b"encrypted",
+            ),
+        ]
+    )
+    await db_session.commit()
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(
+        chat_projects,
+        "_project_tree",
+        lambda *_args: (["dbt_project.yml", "models/orders.sql"], "frozen-head"),
+    )
+    resolve_org_key = AsyncMock(return_value="sk-ant-org")
+    monkeypatch.setattr(
+        chat_projects.org_secrets_store,
+        "resolve_anthropic_key",
+        resolve_org_key,
+    )
+
+    readiness = await evaluate_project_readiness(
+        db_session,
+        org_id="org-a",
+        user_id="user-without-a-key",
+        project=project,
+    )
+
+    assert readiness.ready
+    resolve_org_key.assert_awaited_once_with(db_session, "org-a")
+
+
+@pytest.mark.asyncio
+async def test_execution_uses_org_anthropic_key_as_request_scoped_auth(
+    db_session,
+    monkeypatch,
+):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-server")
+    monkeypatch.setattr(
+        chat_execution,
+        "ensure_execution_runtime",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                session_id="session-a",
+                internal_base_url="http://notebook.internal",
+            )
+        ),
+    )
+    resolve_org_key = AsyncMock(return_value="sk-ant-org")
+    monkeypatch.setattr(
+        chat_execution.org_secrets_store,
+        "resolve_anthropic_key",
+        resolve_org_key,
+    )
+    monkeypatch.setattr(chat_execution, "mint_session_jwt", lambda **_kwargs: "session-jwt")
+    monkeypatch.setattr(
+        chat_execution,
+        "get_k8s_settings",
+        lambda: SimpleNamespace(sp_session_jwt_ttl_seconds=300),
+    )
+    run = SimpleNamespace(
+        id="run-a",
+        org_id="org-a",
+        user_id="user-without-a-key",
+        project_id="project-a",
+    )
+
+    prepared = await chat_execution.prepare_execution(
+        db_session,
+        run=run,
+        worker_id="worker-a",
+        branch="main",
+        connection_name="production",
+        commit_sha="a" * 40,
+        prompt="Analyze revenue",
+        messages=[],
+        warm_context={},
+    )
+
+    assert prepared.payload["runtime_auth"] == {
+        "type": "api_key",
+        "token": "sk-ant-org",
+    }
+    resolve_org_key.assert_awaited_once_with(db_session, "org-a")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resolve the Anthropic key from org secrets when preparing standalone Data Chat execution
- recognize org-scoped keys during project readiness checks
- add regression coverage for keyless org members and request-scoped auth precedence

## Validation
- uv run pytest tests/test_standalone_chat.py -q
- uv run ruff check gateway/standalone_chat/execution.py gateway/standalone_chat/projects.py tests/test_standalone_chat.py
- git diff --check