### PR TITLE
Vercel eval execution backend, live sandbox tail, pod reaper, multi-db schema UI

### DIFF
--- a/signalpilot/gateway/gateway/config/evals.py
+++ b/signalpilot/gateway/gateway/config/evals.py
@@ -48,6 +48,9 @@ class EvalRunSettings(_GatewaySettingsBase):
 
     runner_image: str = Field("", alias="SP_EVAL_RUNNER_IMAGE")
     setup_image: str = Field("", alias="SP_EVAL_SETUP_IMAGE")
+    # "" = pick by deployment mode (docker locally, kubernetes in cloud);
+    # "vercel" = ephemeral Vercel sandbox VMs (needs VERCEL_* credentials).
+    execution_backend: str = Field("", alias="SP_EVAL_EXECUTION_BACKEND")
     docker_socket: str = Field("/var/run/docker.sock", alias="SP_EVAL_DOCKER_SOCKET")
     docker_network: str = Field("signalpilot_eval_runtime", alias="SP_EVAL_DOCKER_NETWORK")
     mcp_url: str = Field("http://gateway:3300/mcp", alias="SP_EVAL_MCP_URL")
@@ -171,6 +174,15 @@ class EvalRunSettings(_GatewaySettingsBase):
                 "Floating tags like ':latest' are not allowed. "
                 "Look up the digest with: crane digest <image> OR "
                 "docker buildx imagetools inspect <image>"
+            )
+        return v
+
+    @field_validator("execution_backend", mode="after")
+    @classmethod
+    def _known_backend(cls, v: str) -> str:
+        if v not in ("", "vercel"):
+            raise ValueError(
+                f"SP_EVAL_EXECUTION_BACKEND must be empty or 'vercel', got {v!r}"
             )
         return v
 

--- a/signalpilot/gateway/gateway/evals/backends.py
+++ b/signalpilot/gateway/gateway/evals/backends.py
@@ -415,17 +415,203 @@ class KubernetesBackend:
                     logger.warning("Failed to delete eval %s %s/%s: %s", what, ns, pod_name, exc)
 
 
+# Vercel.
+
+# Prepares a fresh Vercel sandbox for the runner script: the script assumes
+# /work exists and `claude` is on PATH — both baked into the runner image on
+# the container backends, neither present in a stock sandbox.
+_VERCEL_BOOTSTRAP = (
+    "sudo mkdir -p /work && sudo chown \"$(id -u):$(id -g)\" /work && "
+    "command -v claude >/dev/null 2>&1 || sudo npm install -g @anthropic-ai/claude-code"
+)
+_VERCEL_BOOTSTRAP_TIMEOUT = 240
+# Provider-side ceiling on execution_time_limit (45 min); creation headroom
+# beyond the eval timeout covers bootstrap plus scheduling.
+_VERCEL_MAX_LIFETIME = 2700
+_VERCEL_LIFETIME_HEADROOM = 300
+# The run's combined output is tee'd here inside the sandbox so the panel can
+# poll a live tail (exec only returns output when the command finishes).
+_VERCEL_LOG_PATH = "/tmp/sp-eval-output.log"
+
+
+class VercelBackend:
+    """One ephemeral Vercel sandbox VM per eval container.
+
+    Unlike the container backends, there is no runner image: the sandbox is a
+    stock VM bootstrapped with the Claude CLI at start. The eval MCP config
+    must therefore point at a publicly reachable gateway URL (SP_EVAL_MCP_URL)
+    — sandboxes run in Vercel's network, not next to the gateway.
+
+    Credentials ride the exec environment only; they are never baked into the
+    sandbox spec, and the sandbox is destroyed in a finally block with the
+    provider's execution time limit as backstop.
+    """
+
+    def __init__(self, settings: EvalRunSettings, *, org_id: str) -> None:
+        from ..config.sandbox_runtime import get_sandbox_runtime_settings
+
+        runtime_settings = get_sandbox_runtime_settings()
+        if not runtime_settings.enabled:
+            raise RuntimeError(
+                "Vercel eval backend unavailable: VERCEL_TOKEN / VERCEL_TEAM_ID / "
+                "VERCEL_PROJECT_ID are not all configured."
+            )
+        self._settings = settings
+        self._org_id = org_id
+        self._runtime_settings = runtime_settings
+
+    async def aclose(self) -> None:
+        return None
+
+    def _make_runtime(self):
+        from ..sandbox_runtime.vercel import VercelSandboxRuntime
+
+        return VercelSandboxRuntime(project_id=self._runtime_settings.vercel_project_id)
+
+    @staticmethod
+    def _shell_command(spec: ContainerRun) -> str:
+        # _task_spec/_script_spec always ship ["sh", "-lc", script]; anything
+        # else is joined defensively rather than guessed at.
+        if len(spec.command) == 3 and spec.command[0] == "sh" and spec.command[1] in ("-lc", "-c"):
+            return spec.command[2]
+        import shlex
+
+        return shlex.join(spec.command)
+
+    async def run(self, spec: ContainerRun) -> tuple[int, str]:
+        if spec.binds or spec.extra_network:
+            raise RuntimeError(
+                "This eval set needs host bind mounts or an extra docker network, "
+                "which the Vercel backend cannot provide. Use a git eval repo "
+                "with a self-contained setup script."
+            )
+        from ..sandbox_runtime.base import SandboxSpec
+
+        runtime = self._make_runtime()
+        lifetime = min(spec.timeout_seconds + _VERCEL_LIFETIME_HEADROOM, _VERCEL_MAX_LIFETIME)
+        # Secrets go to exec env, not the creation spec: creation metadata is
+        # readable back from the provider API, per-exec env is not persisted.
+        sandbox_id = await runtime.create(
+            SandboxSpec(time_limit_seconds=lifetime, tags={"sp-eval": "1", "org": self._org_id[:64]})
+        )
+        _notify_start(spec, {"backend": "vercel", "name": sandbox_id, "namespace": ""})
+        try:
+            boot = await runtime.exec(
+                sandbox_id, _VERCEL_BOOTSTRAP, timeout_seconds=_VERCEL_BOOTSTRAP_TIMEOUT
+            )
+            if boot.returncode != 0:
+                return 1, (
+                    "Vercel sandbox bootstrap failed "
+                    f"(exit {boot.returncode}):\n{boot.stdout}\n{boot.stderr}"
+                )
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            # tee the merged output to a file: exec only returns output at
+            # completion, so the file is what makes a live panel tail (and a
+            # post-kill log recovery) possible. pipefail preserves the task's
+            # exit code through the tee.
+            wrapped = (
+                "set -o pipefail; { "
+                + self._shell_command(spec)
+                + f" ; }} 2>&1 | tee {_VERCEL_LOG_PATH}"
+            )
+            result = await runtime.exec(
+                sandbox_id,
+                wrapped,
+                env={**spec.env, **spec.secret_env},
+                timeout_seconds=spec.timeout_seconds,
+            )
+            logs = result.stdout + (("\n" + result.stderr) if result.stderr else "")
+            if not logs.strip():
+                # A kill_after termination can drop the captured stream; the
+                # tee'd file still holds everything up to the kill.
+                data = await runtime.read_file(sandbox_id, _VERCEL_LOG_PATH)
+                if data:
+                    logs = data.decode("utf-8", errors="replace")
+            # kill_after reports a plain non-zero exit; recover the timeout
+            # signal from elapsed time so grading treats it like the container
+            # backends' TIMED_OUT.
+            if result.returncode != 0 and loop.time() - started >= spec.timeout_seconds - 1:
+                return TIMED_OUT, logs
+            return result.returncode, logs
+        finally:
+            await runtime.destroy(sandbox_id)
+
+
+# Reaper.
+
+# Terminal pods linger this long so the sandbox panel can still show their
+# outcome, then they are removed. The run path deletes its own pod in a
+# finally block; this only catches pods stranded by a gateway crash/restart
+# mid-run — bare pods have no TTL, so without it they live forever.
+_EVAL_POD_REAP_AGE_SECONDS = 3600
+
+
+async def reap_terminal_eval_pods(orch, *, max_age_seconds: int = _EVAL_POD_REAP_AGE_SECONDS) -> int:
+    """Delete eval pods (and their env Secrets) in a terminal phase past the age cap.
+
+    `orch` is a KubernetesOrchestrator with an initialized client. Returns the
+    number of pods deleted; permission or listing failures return 0 rather
+    than raising — the cleanup loop must survive a partially-scoped RBAC.
+    """
+    from datetime import UTC, datetime
+
+    await orch._ensure_client()
+    core = orch._core_api
+    if core is None:
+        return 0
+    try:
+        pods = (await core.list_pod_for_all_namespaces(label_selector=f"{_EVAL_POD_LABEL}=1")).to_dict()
+    except Exception as exc:
+        logger.warning("Eval-pod reaper: cannot list pods (%s)", exc)
+        return 0
+
+    now = datetime.now(UTC)
+    deleted = 0
+    for pod in pods.get("items") or []:
+        meta = pod.get("metadata") or {}
+        phase = ((pod.get("status") or {}).get("phase") or "").lower()
+        if phase not in ("succeeded", "failed"):
+            continue
+        created = meta.get("creation_timestamp")
+        if created is not None and (now - created).total_seconds() < max_age_seconds:
+            continue
+        name, ns = meta.get("name") or "", meta.get("namespace") or ""
+        if not name or not ns:
+            continue
+        try:
+            await core.delete_namespaced_pod(name=name, namespace=ns, grace_period_seconds=0)
+            deleted += 1
+            logger.info("Eval-pod reaper: deleted terminal pod %s/%s (phase=%s)", ns, name, phase)
+        except Exception as exc:
+            if "404" not in str(exc):
+                logger.warning("Eval-pod reaper: failed to delete %s/%s: %s", ns, name, exc)
+            continue
+        # The env Secret is ownerRef'd to the pod, but GC is best-effort and a
+        # credential must not outlive the reaped pod.
+        try:
+            await core.delete_namespaced_secret(name=f"sp-eval-env-{name}", namespace=ns)
+        except Exception as exc:
+            if "404" not in str(exc) and "Not Found" not in str(exc):
+                logger.warning("Eval-pod reaper: failed to delete secret for %s/%s: %s", ns, name, exc)
+    return deleted
+
+
 # Selection.
 
 
 def get_execution_backend(settings: EvalRunSettings, *, org_id: str) -> ExecutionBackend:
     """Pick the backend for the current deployment mode.
 
-    Cloud never reaches DockerBackend: a cluster this gateway cannot talk to is
-    a failed run, not a reason to hand untrusted eval workloads the host daemon.
+    SP_EVAL_EXECUTION_BACKEND=vercel opts eval workloads onto ephemeral Vercel
+    sandbox VMs in any mode. Otherwise cloud never reaches DockerBackend: a
+    cluster this gateway cannot talk to is a failed run, not a reason to hand
+    untrusted eval workloads the host daemon.
     """
     from ..runtime.mode import is_cloud_mode
 
+    if settings.execution_backend == "vercel":
+        return VercelBackend(settings, org_id=org_id)
     if is_cloud_mode():
         return KubernetesBackend(settings, org_id=org_id)
     return DockerBackend(settings)

--- a/signalpilot/gateway/gateway/evals/sandboxes.py
+++ b/signalpilot/gateway/gateway/evals/sandboxes.py
@@ -44,14 +44,21 @@ LOG_STREAM_MAX_SECONDS = 1800
 _POD_LABEL_SELECTOR = f"{_EVAL_POD_LABEL}=1"
 _DOCKER_LABEL = "signalpilot.eval"
 
-_SANDBOX_NAME_RE = re.compile(r"^(?:sp-eval-[0-9a-f]{6,32}|[0-9a-f]{12,64})$")
+# The Vercel alternative requires >=3 lowercase words plus a random suffix
+# containing an uppercase letter or digit, so plain hyphenated phrases (and
+# sp-eval-* variants the first alternative rejects) never match it.
+_SANDBOX_NAME_RE = re.compile(
+    r"^(?:sp-eval-[0-9a-f]{6,32}|[0-9a-f]{12,64}"
+    r"|[a-z]+(?:-[a-z]+){2,5}-(?=[A-Za-z0-9]*[A-Z0-9])[A-Za-z0-9]{4,16})$"
+)
 
 
 def is_valid_sandbox_name(name: str) -> bool:
     """Names this module will accept from a URL path.
 
-    Covers both what the backends mint: `sp-eval-<hex>` pod names and Docker's
-    hex container ids. Anything else is refused before it reaches an API call.
+    Covers what the backends mint: `sp-eval-<hex>` pod names, Docker's hex
+    container ids, and Vercel's generated word-word-word-Suffix sandbox names.
+    Anything else is refused before it reaches an API call.
     """
     return bool(_SANDBOX_NAME_RE.fullmatch(name or ""))
 
@@ -620,6 +627,174 @@ def _shape_container(c: dict, owners: dict[str, dict]) -> dict:
     }
 
 
+# Vercel.
+
+
+# How often the Vercel log tail re-reads the sandbox log file. The provider
+# has no follow API; the backend tees output to a file and this polls it.
+_VERCEL_LOG_POLL_SECONDS = 2.0
+
+
+class VercelSandboxView:
+    """Vercel backend: ephemeral provider VMs, introspected from run state.
+
+    The provider exposes no pod/event surface to enumerate, so this view lists
+    live sandboxes from the identities the runner records at on_start. Logs
+    tail the file the backend tees inside the sandbox (read_file reattaches by
+    name, so any worker can serve the stream). A sandbox is live while its
+    task row is pending/running; the backend destroys the VM in a finally
+    either way, which ends the tail with sandbox-exited.
+    """
+
+    backend = "vercel"
+    supports_live_logs = True
+
+    def __init__(self, settings: EvalRunSettings, *, org_id: str) -> None:
+        if not org_id:
+            raise ValueError("org_id is required to read eval sandboxes")
+        self._org_id = org_id
+
+    async def aclose(self) -> None:
+        return None
+
+    def _make_runtime(self):
+        from ..config.sandbox_runtime import get_sandbox_runtime_settings
+        from ..sandbox_runtime.vercel import VercelSandboxRuntime
+
+        runtime_settings = get_sandbox_runtime_settings()
+        if not runtime_settings.enabled:
+            return None
+        return VercelSandboxRuntime(project_id=runtime_settings.vercel_project_id)
+
+    async def _owns(self, name: str) -> bool:
+        """A sandbox is this org's only if run state attributes it to one of
+        the org's tasks — read_file must never serve a foreign sandbox."""
+        owners = await runner.sandbox_index(self._org_id)
+        return name in owners
+
+    async def inventory(self) -> dict:
+        from ..db.engine import get_session_factory
+        from ..store import evals as evals_store
+
+        try:
+            factory = get_session_factory()
+            async with factory() as session:
+                live = await evals_store.live_vercel_sandboxes(session, org_id=self._org_id)
+        except Exception as exc:
+            logger.warning("Vercel sandbox inventory failed: %s", exc)
+            return {
+                "backend": self.backend,
+                "live": False,
+                "supports_live_logs": False,
+                "namespace": "",
+                "message": f"Could not read run state: {type(exc).__name__}",
+                "sandboxes": [],
+            }
+        sandboxes = [
+            {
+                "name": e["name"],
+                "backend": self.backend,
+                "phase": "running",
+                "reason": "Running",
+                "message": "",
+                "ready": True,
+                "oom_killed": False,
+                "restart_count": 0,
+                "node": "vercel-sandbox",
+                "created_at": _iso(e.get("started_at")),
+                "started_at": _iso(e.get("started_at")),
+                "age_seconds": _age_seconds(e.get("started_at")),
+                "run_id": e["run_id"],
+                "task_id": e["task_id"],
+                "task_title": e.get("task_title", ""),
+                "task_phase": e.get("task_phase", "agent"),
+            }
+            for e in live
+        ]
+        return {
+            "backend": self.backend,
+            "live": True,
+            "supports_live_logs": True,
+            "namespace": "",
+            "message": ""
+            if sandboxes
+            else "No Vercel sandbox is running right now. Sandboxes appear here while a "
+            "task executes; the full log arrives in the task transcript when it finishes.",
+            "sandboxes": sandboxes,
+        }
+
+    async def events(self, name: str) -> dict:
+        return {
+            "backend": self.backend,
+            "supported": False,
+            "message": "Vercel sandboxes do not expose scheduler events — check the task transcript after the run.",
+            "events": [],
+        }
+
+    async def stream_logs(self, name: str, *, tail_lines: int) -> AsyncIterator[tuple[str, str]]:
+        from ..sandbox_runtime.base import SandboxNotFound
+
+        if not await self._owns(name):
+            yield "error", f"could not attach to {name}: NotFound"
+            yield "end", "attach-failed"
+            return
+        runtime = self._make_runtime()
+        if runtime is None:
+            yield "error", "Vercel credentials are not configured on this gateway"
+            yield "end", "attach-failed"
+            return
+
+        from .backends import _VERCEL_LOG_PATH
+
+        offset = 0
+        first = True
+        sent = 0
+        waiting_reported = False
+        redactor = _RedactionBuffer()
+        deadline = asyncio.get_event_loop().time() + LOG_STREAM_MAX_SECONDS
+        while True:
+            try:
+                data = await runtime.read_file(name, _VERCEL_LOG_PATH)
+            except SandboxNotFound:
+                # The backend destroys the sandbox when the task finishes.
+                if safe := redactor.flush():
+                    yield "log", safe
+                yield "end", "sandbox-exited"
+                return
+            except Exception as exc:
+                yield "error", f"could not read {name}: {type(exc).__name__}"
+                yield "end", "attach-failed"
+                return
+            if data is None:
+                # Sandbox is alive but the task has not started writing yet
+                # (bootstrap is still installing the CLI).
+                if not waiting_reported:
+                    waiting_reported = True
+                    yield "info", "sandbox is bootstrapping — logs start with the task"
+            elif len(data) > offset:
+                chunk = data[offset:]
+                if first:
+                    # Honor the requested tail on first attach.
+                    lines = chunk.splitlines(keepends=True)
+                    chunk = b"".join(lines[-tail_lines:])
+                first = False
+                offset = len(data)
+                sent += len(chunk)
+                if safe := redactor.feed(chunk.decode("utf-8", errors="replace")):
+                    yield "log", safe
+                if sent >= LOG_STREAM_MAX_BYTES:
+                    if safe := redactor.flush():
+                        yield "log", safe
+                    yield "end", "byte-cap"
+                    return
+            if asyncio.get_event_loop().time() >= deadline:
+                if safe := redactor.flush():
+                    yield "log", safe
+                yield "end", "deadline"
+                return
+            await asyncio.sleep(_VERCEL_LOG_POLL_SECONDS)
+
+
 # Selection.
 
 
@@ -632,6 +807,8 @@ def get_sandbox_view(org_id: str) -> SandboxView:
     from ..runtime.mode import is_cloud_mode
 
     settings = get_eval_run_settings()
+    if settings.execution_backend == "vercel":
+        return VercelSandboxView(settings, org_id=org_id)
     if is_cloud_mode():
         return KubernetesSandboxView(settings, org_id=org_id)
     return DockerSandboxView(settings, org_id=org_id)

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -345,6 +345,17 @@ async def lifespan(app: FastAPI):
                     logger.info("JWT-secret GC: deleted %d orphan Secret(s)", deleted)
             except Exception as e:
                 logger.warning("JWT-secret GC error: %s", e)
+            # Eval pods stranded by a gateway restart mid-run: the run path
+            # deletes its pod in a finally, but bare pods have no TTL, so a
+            # crash leaves them Completed forever without this sweep.
+            try:
+                from .evals.backends import reap_terminal_eval_pods
+
+                reaped = await reap_terminal_eval_pods(orch)
+                if reaped:
+                    logger.info("Eval-pod reaper: deleted %d terminal pod(s)", reaped)
+            except Exception as e:
+                logger.warning("Eval-pod reaper error: %s", e)
 
     async def _knowledge_retention_loop():
         """Prune knowledge retrieval events past the retention window.

--- a/signalpilot/gateway/gateway/store/evals.py
+++ b/signalpilot/gateway/gateway/store/evals.py
@@ -435,6 +435,64 @@ async def tasks_with_live_sandboxes(
     return index
 
 
+async def live_vercel_sandboxes(
+    session: AsyncSession, *, org_id: str, limit_runs: int = 25
+) -> list[dict[str, Any]]:
+    """Vercel sandboxes attributed to tasks still executing, for the panel.
+
+    The Vercel provider has no pod/label API surface to enumerate, so run
+    state is the only inventory: a sandbox is "live" while its task row is
+    pending/running (the backend destroys the VM in a finally either way).
+    """
+    run_ids = (
+        (
+            await session.execute(
+                select(GatewayEvalRun.id)
+                .where(GatewayEvalRun.org_id == org_id)
+                .order_by(GatewayEvalRun.created_at.desc())
+                .limit(limit_runs)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not run_ids:
+        return []
+    rows = (
+        (
+            await session.execute(
+                select(GatewayEvalRunTask).where(
+                    GatewayEvalRunTask.org_id == org_id,
+                    GatewayEvalRunTask.run_id.in_(run_ids),
+                    GatewayEvalRunTask.status.in_(("pending", "running")),
+                    GatewayEvalRunTask.sandbox.is_not(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    out: list[dict[str, Any]] = []
+    for t in rows:
+        sandbox = t.sandbox or {}
+        if str(sandbox.get("backend", "") or "") != "vercel":
+            continue
+        name = str(sandbox.get("name", "") or "")
+        if not name:
+            continue
+        out.append(
+            {
+                "name": name,
+                "run_id": t.run_id,
+                "task_id": t.task_id,
+                "task_title": t.title,
+                "task_phase": str(sandbox.get("phase", "") or "agent"),
+                "started_at": sandbox.get("started_at"),
+            }
+        )
+    return out
+
+
 # Accuracy history + regressions.
 
 

--- a/signalpilot/gateway/tests/test_eval_pod_reaper.py
+++ b/signalpilot/gateway/tests/test_eval_pod_reaper.py
@@ -1,0 +1,91 @@
+"""Tests for reap_terminal_eval_pods (gateway/evals/backends.py).
+
+The reaper removes eval pods stranded in a terminal phase by a gateway
+restart. It must skip running pods, respect the age cap, delete the env
+Secret with the pod, and swallow listing/permission failures.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.evals.backends import reap_terminal_eval_pods
+
+
+def _pod(name: str, phase: str, age_seconds: int, ns: str = "sp-nb-org1") -> dict:
+    return {
+        "metadata": {
+            "name": name,
+            "namespace": ns,
+            "creation_timestamp": datetime.now(UTC) - timedelta(seconds=age_seconds),
+        },
+        "status": {"phase": phase},
+    }
+
+
+def _orch(pods: list[dict]):
+    orch = MagicMock()
+    orch._ensure_client = AsyncMock()
+    core = MagicMock()
+    listing = MagicMock()
+    listing.to_dict.return_value = {"items": pods}
+    core.list_pod_for_all_namespaces = AsyncMock(return_value=listing)
+    core.delete_namespaced_pod = AsyncMock()
+    core.delete_namespaced_secret = AsyncMock()
+    orch._core_api = core
+    return orch, core
+
+
+class TestReaper:
+    async def test_deletes_old_terminal_pods_and_their_secrets(self):
+        orch, core = _orch(
+            [
+                _pod("sp-eval-old", "Succeeded", age_seconds=7200),
+                _pod("sp-eval-dead", "Failed", age_seconds=86400),
+            ]
+        )
+        assert await reap_terminal_eval_pods(orch) == 2
+        deleted = [c.kwargs["name"] for c in core.delete_namespaced_pod.call_args_list]
+        assert deleted == ["sp-eval-old", "sp-eval-dead"]
+        secrets = [c.kwargs["name"] for c in core.delete_namespaced_secret.call_args_list]
+        assert secrets == ["sp-eval-env-sp-eval-old", "sp-eval-env-sp-eval-dead"]
+
+    async def test_skips_running_and_recent_pods(self):
+        orch, core = _orch(
+            [
+                _pod("sp-eval-live", "Running", age_seconds=7200),
+                _pod("sp-eval-fresh", "Succeeded", age_seconds=60),
+            ]
+        )
+        assert await reap_terminal_eval_pods(orch) == 0
+        core.delete_namespaced_pod.assert_not_called()
+
+    async def test_missing_creation_timestamp_still_reaps_terminal_pod(self):
+        pod = _pod("sp-eval-nots", "Succeeded", age_seconds=0)
+        pod["metadata"]["creation_timestamp"] = None
+        orch, core = _orch([pod])
+        assert await reap_terminal_eval_pods(orch) == 1
+
+    async def test_list_failure_returns_zero(self):
+        orch, core = _orch([])
+        core.list_pod_for_all_namespaces = AsyncMock(side_effect=RuntimeError("403 forbidden"))
+        assert await reap_terminal_eval_pods(orch) == 0
+
+    async def test_delete_failure_continues_to_next_pod(self):
+        orch, core = _orch(
+            [
+                _pod("sp-eval-a", "Succeeded", age_seconds=7200),
+                _pod("sp-eval-b", "Succeeded", age_seconds=7200),
+            ]
+        )
+        core.delete_namespaced_pod = AsyncMock(side_effect=[RuntimeError("boom"), None])
+        assert await reap_terminal_eval_pods(orch) == 1
+
+    async def test_no_client_returns_zero(self):
+        orch = MagicMock()
+        orch._ensure_client = AsyncMock()
+        orch._core_api = None
+        assert await reap_terminal_eval_pods(orch) == 0

--- a/signalpilot/gateway/tests/test_eval_sandbox_panel.py
+++ b/signalpilot/gateway/tests/test_eval_sandbox_panel.py
@@ -205,7 +205,17 @@ def _patch_owners(monkeypatch, owners: dict[str, dict] | None = None) -> None:
 
 
 class TestSandboxNameValidation:
-    @pytest.mark.parametrize("name", ["sp-eval-aaaaaaaaaaaa", "a" * 12, "0123456789abcdef" * 4])
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "sp-eval-aaaaaaaaaaaa",
+            "a" * 12,
+            "0123456789abcdef" * 4,
+            # Vercel-generated sandbox names
+            "gold-planned-chicken-DbtqQZ",
+            "ivory-complicated-pelican-euE6FH",
+        ],
+    )
     def test_accepts_backend_minted_names(self, name: str) -> None:
         assert sandboxes.is_valid_sandbox_name(name)
 

--- a/signalpilot/gateway/tests/test_eval_vercel_backend.py
+++ b/signalpilot/gateway/tests/test_eval_vercel_backend.py
@@ -1,0 +1,275 @@
+"""Tests for the Vercel eval execution backend (gateway/evals/backends.py).
+
+Covers selection via SP_EVAL_EXECUTION_BACKEND, credential gating, the
+bootstrap/exec/destroy lifecycle against a fake runtime, secret handling
+(exec env only, never the creation spec), timeout mapping, and the
+bind-mount refusal shared with the Kubernetes backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config.evals import EvalRunSettings
+from gateway.config.sandbox_runtime import reset_sandbox_runtime_settings
+from gateway.evals.backends import (
+    TIMED_OUT,
+    ContainerRun,
+    DockerBackend,
+    KubernetesBackend,
+    VercelBackend,
+    get_execution_backend,
+)
+from gateway.sandbox_runtime.base import ExecResult
+
+_DIGEST_IMAGE = "reg.example.com/eval-runner@sha256:" + "b" * 64
+
+
+def _settings(**overrides) -> EvalRunSettings:
+    base = {
+        "SP_EVAL_RUNNER_IMAGE": _DIGEST_IMAGE,
+        "SP_EVAL_MCP_URL": "https://gateway.example.com/mcp",
+        "SP_EVAL_TIMEOUT_SECONDS": "600",
+        "SP_EVAL_EXECUTION_BACKEND": "vercel",
+    }
+    base.update(overrides)
+    return EvalRunSettings(**base)
+
+
+def _spec(**overrides) -> ContainerRun:
+    kwargs = {
+        "image": "sp-eval-runner:latest",
+        "command": ["sh", "-lc", "echo hi"],
+        "env": {"SP_PROMPT": "how many orders?", "SP_MODEL": "sonnet"},
+        "secret_env": {
+            "SP_MCP_JSON_B64": "eyJ4IjoxfQ==",
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-oauth-supersecret",
+        },
+        "labels": {"run": "run-20260101-010101-aaaaaa"},
+        "memory_bytes": 2 * 1024 * 1024 * 1024,
+        "nano_cpus": 2_000_000_000,
+        "timeout_seconds": 600,
+    }
+    kwargs.update(overrides)
+    return ContainerRun(**kwargs)
+
+
+@pytest.fixture
+def vercel_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VERCEL_TOKEN", "vc-token")
+    monkeypatch.setenv("VERCEL_TEAM_ID", "team_x")
+    monkeypatch.setenv("VERCEL_PROJECT_ID", "prj_x")
+    reset_sandbox_runtime_settings()
+    yield
+    reset_sandbox_runtime_settings()
+
+
+class FakeRuntime:
+    """Scripted stand-in for VercelSandboxRuntime."""
+
+    def __init__(self, exec_results: list[ExecResult]):
+        self._exec_results = list(exec_results)
+        self.created: list[object] = []
+        self.execs: list[dict] = []
+        self.destroyed: list[str] = []
+
+    async def create(self, spec) -> str:
+        self.created.append(spec)
+        return "sbx-fake-1"
+
+    async def exec(self, sandbox_id, command, *, cwd=None, env=None, timeout_seconds=None):
+        self.execs.append(
+            {"sandbox_id": sandbox_id, "command": command, "env": env, "timeout": timeout_seconds}
+        )
+        return self._exec_results.pop(0)
+
+    async def read_file(self, sandbox_id, path):
+        return None
+
+    async def destroy(self, sandbox_id) -> None:
+        self.destroyed.append(sandbox_id)
+
+
+def _backend(fake: FakeRuntime, settings: EvalRunSettings | None = None) -> VercelBackend:
+    backend = VercelBackend(settings or _settings(), org_id="org_1")
+    backend._make_runtime = lambda: fake  # type: ignore[method-assign]
+    return backend
+
+
+class TestSelection:
+    def test_vercel_backend_selected_when_configured(self, monkeypatch, vercel_env):
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        backend = get_execution_backend(_settings(), org_id="org_1")
+        assert isinstance(backend, VercelBackend)
+
+    def test_vercel_overrides_local_docker(self, monkeypatch, vercel_env):
+        monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+        backend = get_execution_backend(_settings(), org_id="org_1")
+        assert isinstance(backend, VercelBackend)
+
+    def test_default_backend_unchanged(self, monkeypatch):
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+        backend = get_execution_backend(
+            _settings(SP_EVAL_EXECUTION_BACKEND=""), org_id="org_1"
+        )
+        assert isinstance(backend, KubernetesBackend)
+        monkeypatch.delenv("SP_DEPLOYMENT_MODE", raising=False)
+        backend = get_execution_backend(
+            _settings(SP_EVAL_EXECUTION_BACKEND=""), org_id="org_1"
+        )
+        assert isinstance(backend, DockerBackend)
+
+    def test_unknown_backend_value_is_rejected(self):
+        with pytest.raises(ValueError, match="SP_EVAL_EXECUTION_BACKEND"):
+            _settings(SP_EVAL_EXECUTION_BACKEND="fargate")
+
+    def test_missing_vercel_credentials_fail_loudly(self, monkeypatch):
+        for name in ("VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"):
+            monkeypatch.delenv(name, raising=False)
+        reset_sandbox_runtime_settings()
+        try:
+            with pytest.raises(RuntimeError, match="VERCEL_TOKEN"):
+                VercelBackend(_settings(), org_id="org_1")
+        finally:
+            reset_sandbox_runtime_settings()
+
+
+class TestLifecycle:
+    async def test_bootstrap_then_command_then_destroy(self, vercel_env):
+        fake = FakeRuntime(
+            [ExecResult(0, "bootstrapped", ""), ExecResult(0, "task output", "warn")]
+        )
+        exit_code, logs = await _backend(fake).run(_spec())
+        assert exit_code == 0
+        assert "task output" in logs and "warn" in logs
+        assert len(fake.execs) == 2
+        assert "claude" in fake.execs[0]["command"]  # bootstrap installs the CLI
+        # The task command is tee'd to the live-tail log file with its exit
+        # code preserved through the pipe.
+        task_cmd = fake.execs[1]["command"]
+        assert "echo hi" in task_cmd
+        assert "tee /tmp/sp-eval-output.log" in task_cmd
+        assert "pipefail" in task_cmd
+        assert fake.destroyed == ["sbx-fake-1"]
+
+    async def test_secrets_ride_exec_env_not_creation_spec(self, vercel_env):
+        fake = FakeRuntime([ExecResult(0, "", ""), ExecResult(0, "", "")])
+        await _backend(fake).run(_spec())
+        created = fake.created[0]
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in (created.env or {})
+        assert fake.execs[1]["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-oauth-supersecret"
+        assert fake.execs[1]["env"]["SP_MODEL"] == "sonnet"
+
+    async def test_bootstrap_failure_reports_without_running_task(self, vercel_env):
+        fake = FakeRuntime([ExecResult(1, "", "npm exploded")])
+        exit_code, logs = await _backend(fake).run(_spec())
+        assert exit_code == 1
+        assert "bootstrap failed" in logs and "npm exploded" in logs
+        assert len(fake.execs) == 1
+        assert fake.destroyed == ["sbx-fake-1"]
+
+    async def test_sandbox_destroyed_when_exec_raises(self, vercel_env):
+        class ExplodingRuntime(FakeRuntime):
+            async def exec(self, *a, **kw):
+                raise RuntimeError("provider hiccup")
+
+        fake = ExplodingRuntime([])
+        with pytest.raises(RuntimeError, match="provider hiccup"):
+            await _backend(fake).run(_spec())
+        assert fake.destroyed == ["sbx-fake-1"]
+
+    async def test_timeout_maps_to_timed_out(self, vercel_env, monkeypatch):
+        fake = FakeRuntime([ExecResult(0, "", ""), ExecResult(137, "killed", "")])
+        backend = _backend(fake, _settings())
+        # Simulate the elapsed clock crossing the task timeout.
+        import gateway.evals.backends as backends_mod
+
+        times = iter([0.0, 700.0])
+
+        class FakeLoop:
+            def time(self):
+                return next(times)
+
+        monkeypatch.setattr(
+            backends_mod.asyncio, "get_event_loop", lambda: FakeLoop()
+        )
+        exit_code, _ = await backend.run(_spec())
+        assert exit_code == TIMED_OUT
+
+    async def test_binds_are_refused(self, vercel_env):
+        fake = FakeRuntime([])
+        with pytest.raises(RuntimeError, match="bind mounts"):
+            await _backend(fake).run(_spec(binds=["/host:/repo:ro"]))
+        assert fake.created == []
+
+
+class TestLiveTail:
+    """The panel's Vercel log tail polls the tee'd file inside the sandbox."""
+
+    def _view(self, monkeypatch, reads):
+        """A VercelSandboxView whose runtime serves `reads` in sequence.
+
+        Each entry is bytes (file contents), None (file not written yet), or
+        an exception instance to raise.
+        """
+        from gateway.evals import sandboxes as sandboxes_mod
+        from gateway.evals.sandboxes import VercelSandboxView
+
+        monkeypatch.setattr(sandboxes_mod, "_VERCEL_LOG_POLL_SECONDS", 0.0)
+        view = VercelSandboxView(_settings(), org_id="org_1")
+
+        class TailRuntime:
+            def __init__(self):
+                self._reads = list(reads)
+
+            async def read_file(self, sandbox_id, path):
+                item = self._reads.pop(0)
+                if isinstance(item, Exception):
+                    raise item
+                return item
+
+        async def owns(name):
+            return True
+
+        monkeypatch.setattr(view, "_make_runtime", lambda: TailRuntime())
+        monkeypatch.setattr(view, "_owns", owns)
+        return view
+
+    async def _collect(self, view, tail_lines=200):
+        return [event async for event in view.stream_logs("gold-planned-chicken-DbtqQZ", tail_lines=tail_lines)]
+
+    async def test_incremental_tail_ends_on_sandbox_exit(self, monkeypatch, vercel_env):
+        from gateway.sandbox_runtime.base import SandboxNotFound
+
+        events = await self._collect(
+            self._view(
+                monkeypatch,
+                [None, b"line one\n", b"line one\nline two\n", SandboxNotFound("gone")],
+            )
+        )
+        kinds = [k for k, _ in events]
+        assert kinds[0] == "info"  # bootstrap notice while the file is absent
+        logs = "".join(text for kind, text in events if kind == "log")
+        assert logs == "line one\nline two\n"  # each chunk emitted exactly once
+        assert events[-1] == ("end", "sandbox-exited")
+
+    async def test_first_read_honors_tail_lines(self, monkeypatch, vercel_env):
+        from gateway.sandbox_runtime.base import SandboxNotFound
+
+        backlog = b"".join(b"line %d\n" % i for i in range(50))
+        events = await self._collect(
+            self._view(monkeypatch, [backlog, SandboxNotFound("gone")]), tail_lines=2
+        )
+        logs = "".join(text for kind, text in events if kind == "log")
+        assert logs == "line 48\nline 49\n"
+
+    async def test_foreign_sandbox_is_refused(self, monkeypatch, vercel_env):
+        view = self._view(monkeypatch, [b"secret log\n"])
+
+        async def not_ours(name):
+            return False
+
+        monkeypatch.setattr(view, "_owns", not_ours)
+        events = await self._collect(view)
+        assert events[-1] == ("end", "attach-failed")
+        assert not any(kind == "log" for kind, _ in events)

--- a/signalpilot/web/app/connections/connection-schema-browser.tsx
+++ b/signalpilot/web/app/connections/connection-schema-browser.tsx
@@ -3,9 +3,12 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import {
+  ArrowLeft,
   ArrowUpRight,
   Check,
+  ChevronRight,
   Clock,
+  Database,
   Eye,
   EyeOff,
   KeyRound,
@@ -18,11 +21,13 @@ import {
 } from "lucide-react";
 import { setSchemaEndorsements } from "~/lib/api";
 import { useConnection } from "~/lib/connection-context";
+import { groupTablesByDatabase, localSchema, tableDatabaseKey } from "~/lib/schema-databases";
 import { useToast } from "~/components/ui/toast";
 
 export interface ConnectionSchemaTable {
   schema?: string;
   name: string;
+  database?: string;
   type?: string;
   description?: string;
   row_count?: number;
@@ -67,6 +72,8 @@ interface ExploredColumn {
 
 interface Props {
   connectionName: string;
+  /** Configured database/catalog of the connection — labels the implicit group on single-database connectors. */
+  defaultDatabaseName?: string;
   tables: Record<string, ConnectionSchemaTable>;
   searchTables?: Record<string, ConnectionSchemaTable>;
   searchResultCount?: number;
@@ -105,10 +112,9 @@ function relativeTime(timestamp: number | null | undefined): string {
 
 export function ConnectionSchemaBrowser({
   connectionName,
+  defaultDatabaseName,
   tables,
   searchTables,
-  searchResultCount,
-  totalTables,
   search,
   searchLoading,
   onSearch,
@@ -126,22 +132,43 @@ export function ConnectionSchemaBrowser({
 }: Props) {
   const { setSelectedConn } = useConnection();
   const { toast } = useToast();
+  const [selectedDb, setSelectedDb] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState("");
   const [savingTable, setSavingTable] = useState(false);
   const [semanticLoading, setSemanticLoading] = useState(false);
-  const displayTables = searchTables ?? tables;
+
+  const fallbackDb = defaultDatabaseName || "default";
+  const databaseGroups = useMemo(() => groupTablesByDatabase(tables, fallbackDb), [fallbackDb, tables]);
+
+  useEffect(() => {
+    setSelectedDb(null);
+    setSelectedKey("");
+  }, [connectionName]);
+
+  const sourceTables = searchTables ?? tables;
+  const displayTables = useMemo(() => {
+    if (!selectedDb) return {};
+    return Object.fromEntries(
+      Object.entries(sourceTables).filter(([, table]) => tableDatabaseKey(table, fallbackDb) === selectedDb),
+    );
+  }, [fallbackDb, selectedDb, sourceTables]);
+  const dbTableTotal = useMemo(
+    () => selectedDb
+      ? Object.values(tables).filter((table) => tableDatabaseKey(table, fallbackDb) === selectedDb).length
+      : 0,
+    [fallbackDb, selectedDb, tables],
+  );
   const entries = useMemo(
-    () => Object.entries(displayTables).sort(([, left], [, right]) => {
-      const leftSchema = left.schema || "default";
-      const rightSchema = right.schema || "default";
-      return leftSchema.localeCompare(rightSchema) || left.name.localeCompare(right.name);
-    }),
+    () => Object.entries(displayTables).sort(([, left], [, right]) =>
+      localSchema(left).localeCompare(localSchema(right)) || left.name.localeCompare(right.name),
+    ),
     [displayTables],
   );
 
   useEffect(() => {
+    if (!selectedDb) return;
     if (!selectedKey || !displayTables[selectedKey]) setSelectedKey(entries[0]?.[0] ?? "");
-  }, [displayTables, entries, selectedKey]);
+  }, [displayTables, entries, selectedDb, selectedKey]);
 
   const selectedTable = selectedKey ? displayTables[selectedKey] : undefined;
   const selectedExploredData = selectedKey ? exploredData[`${connectionName}:${selectedKey}`] : undefined;
@@ -202,11 +229,40 @@ export function ConnectionSchemaBrowser({
     }
   }
 
+  if (!selectedDb) {
+    return (
+      <section className="connection-schema-workbench">
+        <div className="connection-schema-db-picker">
+          <header>
+            <span><strong>{databaseGroups.length}</strong> {databaseGroups.length === 1 ? "database" : "databases"} on this connection</span>
+            <span>pick a database to explore its tables</span>
+          </header>
+          <div className="connection-schema-db-grid">
+            {databaseGroups.map((group) => (
+              <button key={group.name} type="button" onClick={() => setSelectedDb(group.name)}>
+                <Database aria-hidden="true" />
+                <span>
+                  <strong>{group.name}</strong>
+                  <small>{group.schemaCount} {group.schemaCount === 1 ? "schema" : "schemas"} · {group.tableCount} {group.tableCount === 1 ? "table" : "tables"}</small>
+                </span>
+                <ChevronRight aria-hidden="true" />
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="connection-schema-workbench">
       <header className="connection-schema-toolbar">
         <div className="connection-schema-summary">
-          <span><strong>{searchTables ? searchResultCount ?? entries.length : entries.length}</strong>{searchTables ? ` of ${totalTables ?? Object.keys(tables).length}` : ""} tables</span>
+          <button type="button" className="connection-schema-db-back" onClick={() => { setSelectedDb(null); setSelectedKey(""); }} title="Choose another database">
+            <ArrowLeft aria-hidden="true" /><span>databases</span>
+          </button>
+          <span className="connection-schema-db-current"><Database aria-hidden="true" /><strong>{selectedDb}</strong></span>
+          <span><strong>{entries.length}</strong>{searchTables ? ` of ${dbTableTotal}` : ""} tables</span>
           <span><strong>{columnCount}</strong> columns</span>
           <span><strong>{relationshipCount}</strong> relationships</span>
           {refreshStatus?.fingerprint && <code>#{refreshStatus.fingerprint.slice(0, 8)}</code>}
@@ -228,7 +284,7 @@ export function ConnectionSchemaBrowser({
             {entries.map(([key, table]) => (
               <button key={key} type="button" className={selectedKey === key ? "is-active" : ""} onClick={() => setSelectedKey(key)}>
                 <Table2 />
-                <span><strong>{table.name}</strong><small>{table.schema || "default"}</small></span>
+                <span><strong>{table.name}</strong><small>{localSchema(table)}</small></span>
                 <em>{table.columns?.length ?? 0}</em>
                 {endorsements.endorsed.includes(key) && <Star className="is-endorsed" aria-label="Endorsed" />}
                 {endorsements.hidden.includes(key) && <EyeOff className="is-hidden" aria-label="Hidden from agents" />}
@@ -242,7 +298,7 @@ export function ConnectionSchemaBrowser({
           {selectedTable ? (
             <>
               <header>
-                <div><span>{selectedTable.schema || "default"}</span><h3>{selectedTable.name}</h3><p>{selectedTable.description || `${selectedTable.type === "view" ? "View" : "Table"} with ${selectedTable.columns?.length ?? 0} columns`}</p></div>
+                <div><span>{selectedDb} / {localSchema(selectedTable)}</span><h3>{selectedTable.name}</h3><p>{selectedTable.description || `${selectedTable.type === "view" ? "View" : "Table"} with ${selectedTable.columns?.length ?? 0} columns`}</p></div>
                 <dl><div><dt>Rows</dt><dd>{formatRows(selectedTable.row_count)}</dd></div><div><dt>Columns</dt><dd>{selectedTable.columns?.length ?? 0}</dd></div><div><dt>Relations</dt><dd>{selectedTable.foreign_keys?.length ?? 0}</dd></div></dl>
                 <div className="connection-schema-table-actions">
                   <button type="button" className={selectedEndorsed ? "is-endorsed" : ""} onClick={() => void toggleSelectedEndorsement()} disabled={savingTable} title={selectedEndorsed ? "Remove endorsement" : "Endorse for agents"}>{savingTable ? <Loader2 className="is-spinning" /> : selectedEndorsed ? <Check /> : <Star />}<span>{selectedEndorsed ? "Endorsed" : "Endorse"}</span></button>

--- a/signalpilot/web/app/connections/connections.css
+++ b/signalpilot/web/app/connections/connections.css
@@ -122,7 +122,10 @@
 .connection-schema-explore > div { display: flex; gap: 0.65rem; margin-top: 0.4rem; overflow-x: auto; }
 .connection-schema-explore > div span { flex: 0 0 auto; color: var(--color-text-dim); font-size: 7px; }
 .connection-schema-explore > div strong { color: var(--color-text-muted); font-family: var(--font-mono); font-weight: 500; }
-.connection-schema-empty { display: flex; min-height: 90px; align-items: center; justify-content: center; color: var(--color-text-dim); font-size: 9px; }
+.connection-schema-empty { display: flex; min-height: 90px; align-items: center; justify-content: center; gap: 0.45rem; color: var(--color-text-dim); font-size: 9px; }
+.connection-schema-empty svg { width: 13px; height: 13px; flex: 0 0 auto; }
+.connection-schema-empty .is-spinning { animation: connection-schema-spin 800ms linear infinite; }
+@keyframes connection-schema-spin { to { transform: rotate(360deg); } }
 
 @media (max-width: 1120px) {
   .connections-overview { grid-template-columns: repeat(4, 1fr); }
@@ -156,3 +159,20 @@
   .connection-schema-detail header dl { grid-template-columns: repeat(3, 1fr); }
   .connection-schema-detail header dl div:first-child { border-left: 0; }
 }
+
+/* ── Database picker step (schema browser) ── */
+.connection-schema-db-picker { padding: 0.65rem 0.75rem 0.85rem; }
+.connection-schema-db-picker > header { display: flex; align-items: baseline; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.55rem; color: var(--color-text-dim); font-size: 8px; white-space: nowrap; }
+.connection-schema-db-picker > header strong { color: var(--color-text-muted); font-family: var(--font-mono); font-weight: 500; }
+.connection-schema-db-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 0.45rem; }
+.connection-schema-db-grid > button { display: grid; grid-template-columns: 13px minmax(0, 1fr) 11px; align-items: center; gap: 0.45rem; padding: 0.5rem 0.55rem; border: 1px solid var(--color-border); border-radius: 6px; background: var(--color-bg-input); color: var(--color-text-dim); text-align: left; transition: border-color 120ms ease, background 120ms ease; }
+.connection-schema-db-grid > button:hover { border-color: var(--color-border-active); background: var(--color-bg-hover); color: var(--color-text-muted); }
+.connection-schema-db-grid > button > svg { width: 12px; height: 12px; }
+.connection-schema-db-grid > button span { min-width: 0; }
+.connection-schema-db-grid > button strong { display: block; overflow: hidden; color: var(--color-text); font-family: var(--font-mono); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.connection-schema-db-grid > button small { display: block; margin-top: 0.12rem; overflow: hidden; color: var(--color-text-dim); font-size: 7px; text-overflow: ellipsis; white-space: nowrap; }
+.connection-schema-db-back { display: inline-flex; height: 22px; flex: 0 0 auto; align-items: center; gap: 0.25rem; padding: 0 0.4rem; border: 1px solid var(--color-border); border-radius: 4px; color: var(--color-text-dim); font-size: 8px; white-space: nowrap; }
+.connection-schema-db-back:hover { color: var(--color-text); background: var(--color-bg-hover); }
+.connection-schema-db-back svg { width: 9px; height: 9px; }
+.connection-schema-db-current { display: inline-flex; align-items: center; gap: 0.25rem; }
+.connection-schema-db-current strong { overflow: hidden; max-width: 160px; text-overflow: ellipsis; white-space: nowrap; }

--- a/signalpilot/web/app/connections/page.tsx
+++ b/signalpilot/web/app/connections/page.tsx
@@ -3953,10 +3953,11 @@ export default function ConnectionsPage() {
 
                 {isExpanded && (
                   schemaLoading === conn.name && !tables ? (
-                    <div className="connection-schema-empty"><Loader2 className="is-spinning" /> Loading schema</div>
+                    <div className="connection-schema-empty"><Loader2 className="is-spinning" aria-hidden="true" /><span>Loading schema</span></div>
                   ) : tables && Object.keys(tables).length > 0 ? (
                     <ConnectionSchemaBrowser
                       connectionName={conn.name}
+                      defaultDatabaseName={conn.database || conn.catalog || conn.project || undefined}
                       tables={tables as Record<string, ConnectionSchemaTable>}
                       searchTables={schemaSearchResults[conn.name]?.tables as Record<string, ConnectionSchemaTable> | undefined}
                       searchResultCount={schemaSearchResults[conn.name]?.result_count}

--- a/signalpilot/web/app/schema/page.tsx
+++ b/signalpilot/web/app/schema/page.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  AlertTriangle,
+  ArrowLeft,
   Braces,
   Check,
   ChevronRight,
@@ -31,6 +33,12 @@ import {
   setPIIConfig,
 } from "~/lib/api";
 import { useConnection } from "~/lib/connection-context";
+import {
+  connectionDefaultDatabase,
+  groupTablesByDatabase,
+  localSchema,
+  tableDatabaseKey,
+} from "~/lib/schema-databases";
 import { EmptyDatabase, EmptyState } from "~/components/ui/empty-states";
 import { useToast } from "~/components/ui/toast";
 import "./schema.css";
@@ -65,6 +73,7 @@ interface ForeignKey {
 interface TableSchema {
   schema: string;
   name: string;
+  database?: string;
   columns: Column[];
   foreign_keys?: ForeignKey[];
   row_count?: number;
@@ -148,6 +157,8 @@ export default function SchemaExplorerPage() {
   const [schema, setSchema] = useState<SchemaData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedDatabase, setSelectedDatabase] = useState<string | null>(null);
+  const [databaseSearch, setDatabaseSearch] = useState("");
   const [selectedTableKey, setSelectedTableKey] = useState("");
   const [search, setSearch] = useState("");
   const [columnSearch, setColumnSearch] = useState("");
@@ -176,6 +187,8 @@ export default function SchemaExplorerPage() {
       ]);
       setSchema(schemaData);
       setPiiConfigState(config);
+      // Suggestions are session-scoped review flags — a refresh clears them.
+      setPiiDetections({});
       const keys = Object.keys(schemaData.tables).sort((left, right) => left.localeCompare(right));
       setSelectedTableKey((current) => current && schemaData.tables[current] ? current : keys[0] ?? "");
       const status = await getSchemaRefreshStatus(selectedConn).catch(() => null);
@@ -206,6 +219,8 @@ export default function SchemaExplorerPage() {
 
   useEffect(() => {
     setSchema(null);
+    setSelectedDatabase(null);
+    setDatabaseSearch("");
     setSelectedTableKey("");
     setSchemaFilter("all");
     setSearch("");
@@ -229,25 +244,60 @@ export default function SchemaExplorerPage() {
     [schema],
   );
 
+  const fallbackDb = useMemo(
+    () => connectionDefaultDatabase(connections.find((connection) => connection.name === selectedConn)),
+    [connections, selectedConn],
+  );
+
+  const databaseGroups = useMemo(
+    () => groupTablesByDatabase(schema?.tables ?? {}, fallbackDb),
+    [fallbackDb, schema],
+  );
+
+  const filteredDatabaseGroups = useMemo(() => {
+    const needle = databaseSearch.trim().toLowerCase();
+    return needle ? databaseGroups.filter((group) => group.name.toLowerCase().includes(needle)) : databaseGroups;
+  }, [databaseGroups, databaseSearch]);
+
+  const dbTables = useMemo(
+    () => selectedDatabase
+      ? tables.filter(([, table]) => tableDatabaseKey(table, fallbackDb) === selectedDatabase)
+      : [],
+    [fallbackDb, selectedDatabase, tables],
+  );
+
   const schemaGroups = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const [, table] of tables) {
-      const group = table.schema || "default";
+    for (const [, table] of dbTables) {
+      const group = localSchema(table);
       counts.set(group, (counts.get(group) ?? 0) + 1);
     }
     return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right));
-  }, [tables]);
+  }, [dbTables]);
 
   const filteredTables = useMemo(() => {
     const needle = search.trim().toLowerCase();
-    return tables.filter(([key, table]) => {
-      if (schemaFilter !== "all" && (table.schema || "default") !== schemaFilter) return false;
+    return dbTables.filter(([key, table]) => {
+      if (schemaFilter !== "all" && localSchema(table) !== schemaFilter) return false;
       if (!needle) return true;
       return key.toLowerCase().includes(needle)
         || table.name.toLowerCase().includes(needle)
         || table.columns.some((column) => column.name.toLowerCase().includes(needle));
     });
-  }, [schemaFilter, search, tables]);
+  }, [dbTables, schemaFilter, search]);
+
+  const openDatabase = useCallback((name: string) => {
+    setSelectedDatabase(name);
+    setSchemaFilter("all");
+    setSearch("");
+    setColumnSearch("");
+    if (schema) {
+      const first = Object.entries(schema.tables)
+        .filter(([, table]) => tableDatabaseKey(table, fallbackDb) === name)
+        .sort(([left], [right]) => left.localeCompare(right))[0];
+      setSelectedTableKey(first?.[0] ?? "");
+    }
+  }, [fallbackDb, schema]);
 
   const selectedTable = selectedTableKey ? schema?.tables[selectedTableKey] ?? null : null;
   const selectedColumns = useMemo(() => {
@@ -362,9 +412,10 @@ export default function SchemaExplorerPage() {
       {schema && (
         <section className="schema-statusbar" aria-label="Schema summary">
           <span><i className="schema-live-dot" /> {selectedConn}</span>
+          <span><strong>{databaseGroups.length.toLocaleString()}</strong> databases</span>
           <span><strong>{schema.table_count.toLocaleString()}</strong> tables</span>
           <span><strong>{totalColumns.toLocaleString()}</strong> columns</span>
-          <span><strong>{schemaGroups.length.toLocaleString()}</strong> schemas</span>
+          <span><strong>{databaseGroups.reduce((sum, group) => sum + group.schemaCount, 0).toLocaleString()}</strong> schemas</span>
           <span><strong>{protectedColumns.toLocaleString()}</strong> protected</span>
           <span className="schema-statusbar-tail">{schema.db_type}{lastRefresh ? ` / refreshed ${new Date(lastRefresh * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}` : ""}{refreshInterval ? ` / every ${refreshInterval >= 3600 ? `${Math.round(refreshInterval / 3600)}h` : `${Math.round(refreshInterval / 60)}m`}` : ""}</span>
         </section>
@@ -380,7 +431,51 @@ export default function SchemaExplorerPage() {
         <EmptyState icon={EmptyDatabase} title="Select a connection" description="Choose a database connection to inspect its schema." />
       )}
 
-      {schema && (
+      {schema && !selectedDatabase && (
+        <section className="schema-db-picker" aria-label="Choose a database">
+          <header className="schema-db-picker-head">
+            <div>
+              <h2>Choose a database</h2>
+              <p>{databaseGroups.length === 1 ? "This connection exposes one database" : `This connection exposes ${databaseGroups.length} databases`} — pick one to explore its schemas and tables.</p>
+            </div>
+            {databaseGroups.length > 6 && (
+              <label className="schema-db-search">
+                <Search aria-hidden="true" />
+                <input value={databaseSearch} onChange={(event) => setDatabaseSearch(event.target.value)} placeholder="Filter databases" aria-label="Filter databases" />
+              </label>
+            )}
+          </header>
+          <div className="schema-db-grid">
+            {filteredDatabaseGroups.map((group) => (
+              <button key={group.name} type="button" className="schema-db-card" onClick={() => openDatabase(group.name)}>
+                <span className="schema-db-card-title"><Database aria-hidden="true" /><strong>{group.name}</strong><ChevronRight aria-hidden="true" /></span>
+                <dl>
+                  <div><dt>Tables</dt><dd>{group.tableCount.toLocaleString()}</dd></div>
+                  <div><dt>Schemas</dt><dd>{group.schemaCount.toLocaleString()}</dd></div>
+                  <div><dt>Rows</dt><dd>{formatCount(group.rowCount)}</dd></div>
+                </dl>
+              </button>
+            ))}
+            {filteredDatabaseGroups.length === 0 && <div className="schema-no-results">No matching databases</div>}
+          </div>
+        </section>
+      )}
+
+      {schema && selectedDatabase && (
+        <>
+        <div className="schema-db-breadcrumb">
+          <button type="button" className="schema-db-back" onClick={() => { setSelectedDatabase(null); setSelectedTableKey(""); }}>
+            <ArrowLeft aria-hidden="true" /> Databases
+          </button>
+          <ChevronRight aria-hidden="true" className="schema-db-crumb-sep" />
+          <div className="schema-db-strip" role="tablist" aria-label="Switch database">
+            {databaseGroups.map((group) => (
+              <button key={group.name} type="button" role="tab" aria-selected={group.name === selectedDatabase} className={group.name === selectedDatabase ? "is-active" : ""} onClick={() => openDatabase(group.name)}>
+                <Database aria-hidden="true" />{group.name} <span>{group.tableCount}</span>
+              </button>
+            ))}
+          </div>
+        </div>
         <section className="schema-workbench">
           <aside className="schema-object-browser">
             <div className="schema-pane-heading"><div><span>Objects</span><strong>{filteredTables.length.toLocaleString()}</strong></div></div>
@@ -389,7 +484,7 @@ export default function SchemaExplorerPage() {
               <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Find tables or columns" aria-label="Find tables or columns" />
             </label>
             <div className="schema-filter-strip" role="tablist" aria-label="Filter by schema">
-              <button type="button" className={schemaFilter === "all" ? "is-active" : ""} onClick={() => setSchemaFilter("all")}>All <span>{tables.length}</span></button>
+              <button type="button" className={schemaFilter === "all" ? "is-active" : ""} onClick={() => setSchemaFilter("all")}>All <span>{dbTables.length}</span></button>
               {schemaGroups.map(([group, count]) => (
                 <button key={group} type="button" className={schemaFilter === group ? "is-active" : ""} onClick={() => setSchemaFilter(group)}>{group} <span>{count}</span></button>
               ))}
@@ -398,13 +493,17 @@ export default function SchemaExplorerPage() {
               {filteredTables.length === 0 && <div className="schema-no-results">No matching tables</div>}
               {filteredTables.map(([key, table]) => {
                 const active = selectedTableKey === key;
-                const hiddenCount = table.columns.filter((column) => findRule(piiConfig.rules, column.name)?.[1] === "hide").length;
+                const protectedCount = table.columns.filter((column) => findRule(piiConfig.rules, column.name)).length;
+                const pendingCount = table.columns.filter((column) => !findRule(piiConfig.rules, column.name) && suggestionFor(table, column.name)).length;
                 return (
                   <button key={key} type="button" className={`schema-table-item${active ? " is-active" : ""}`} onClick={() => { setSelectedTableKey(key); setColumnSearch(""); setViewMode("columns"); }}>
                     <Table2 aria-hidden="true" />
-                    <span><strong>{table.name}</strong><small>{table.schema || "default"}</small></span>
+                    <span><strong>{table.name}</strong><small>{localSchema(table)}</small></span>
                     <em>{table.columns.length}</em>
-                    {hiddenCount > 0 && <EyeOff aria-label={`${hiddenCount} protected columns`} />}
+                    <i className="schema-table-flags">
+                      {pendingCount > 0 && <AlertTriangle className="is-pending" aria-label={`${pendingCount} suggested PII columns need a decision`} />}
+                      {protectedCount > 0 && <ShieldCheck className="is-protected" aria-label={`${protectedCount} protected columns`} />}
+                    </i>
                     <ChevronRight aria-hidden="true" />
                   </button>
                 );
@@ -417,7 +516,7 @@ export default function SchemaExplorerPage() {
               <>
                 <header className="schema-table-header">
                   <div className="schema-table-identity">
-                    <span>{selectedTable.schema || "default"}</span>
+                    <span>{selectedDatabase ? `${selectedDatabase} / ${localSchema(selectedTable)}` : localSchema(selectedTable)}</span>
                     <h2>{selectedTable.name}</h2>
                     {selectedTable.description && <p>{selectedTable.description}</p>}
                   </div>
@@ -511,7 +610,7 @@ export default function SchemaExplorerPage() {
                 Object.entries(piiConfig.rules).sort(([left], [right]) => left.localeCompare(right)).map(([column, rule]) => (
                   <button key={column} type="button" onClick={() => {
                     const tableWithColumn = tables.find(([, table]) => table.columns.some((candidate) => candidate.name.toLowerCase() === column.toLowerCase()));
-                    if (tableWithColumn) { setSelectedTableKey(tableWithColumn[0]); setViewMode("columns"); setColumnSearch(column); }
+                    if (tableWithColumn) { setSelectedDatabase(tableDatabaseKey(tableWithColumn[1], fallbackDb)); setSelectedTableKey(tableWithColumn[0]); setViewMode("columns"); setColumnSearch(column); }
                   }}>
                     <span><strong>{column}</strong><small>query result field</small></span><em className={`is-${rule}`}>{rule}</em>
                   </button>
@@ -532,6 +631,7 @@ export default function SchemaExplorerPage() {
             )}
           </aside>
         </section>
+        </>
       )}
     </main>
   );

--- a/signalpilot/web/app/schema/schema.css
+++ b/signalpilot/web/app/schema/schema.css
@@ -37,7 +37,7 @@
 .schema-filter-strip button.is-active { border-color: var(--color-border); color: var(--color-text); background: var(--color-bg-elevated); }
 .schema-filter-strip span { color: var(--color-text-dim); font-family: var(--font-mono); font-size: 8px; }
 .schema-table-list { min-height: 0; flex: 1; overflow-y: auto; padding: 0.35rem; }
-.schema-table-item { display: grid; grid-template-columns: 14px minmax(0, 1fr) auto 12px 10px; width: 100%; min-height: 38px; align-items: center; gap: 0.45rem; padding: 0.3rem 0.4rem; border: 1px solid transparent; border-radius: 4px; color: var(--color-text-dim); text-align: left; }
+.schema-table-item { display: grid; grid-template-columns: 14px minmax(0, 1fr) auto auto 10px; width: 100%; min-height: 38px; align-items: center; gap: 0.45rem; padding: 0.3rem 0.4rem; border: 1px solid transparent; border-radius: 4px; color: var(--color-text-dim); text-align: left; }
 .schema-table-item:hover { color: var(--color-text-muted); background: var(--color-bg-hover); }
 .schema-table-item.is-active { border-color: var(--color-border); color: var(--color-text); background: var(--color-bg-elevated); }
 .schema-table-item > svg { width: 12px; height: 12px; }
@@ -46,6 +46,10 @@
 .schema-table-item strong { color: inherit; font-family: var(--font-mono); font-size: 10px; font-weight: 500; }
 .schema-table-item small { margin-top: 0.12rem; color: var(--color-text-dim); font-size: 8px; }
 .schema-table-item em { color: var(--color-text-dim); font-family: var(--font-mono); font-size: 8px; font-style: normal; }
+.schema-table-flags { display: inline-flex; min-width: 12px; align-items: center; justify-content: flex-end; gap: 0.2rem; font-style: normal; }
+.schema-table-flags svg { width: 11px; height: 11px; flex: 0 0 auto; }
+.schema-table-flags .is-pending { color: var(--color-warning); }
+.schema-table-flags .is-protected { color: var(--color-success); }
 .schema-table-header { padding: 1rem 1.1rem 0.85rem; border-bottom: 1px solid var(--color-border); }
 .schema-table-identity > span { color: var(--color-text-dim); font-family: var(--font-mono); font-size: 9px; }
 .schema-table-identity h2 { margin-top: 0.15rem; overflow-wrap: anywhere; color: var(--color-text); font-family: var(--font-mono); font-size: 17px; font-weight: 500; letter-spacing: 0; }
@@ -176,4 +180,44 @@
   .schema-table-metrics { grid-template-columns: repeat(2, 1fr); }
   .schema-rule-list, .schema-table-properties { border-left: 0; }
   .schema-column-search { width: 44%; }
+}
+
+/* ── Database picker step ── */
+.schema-db-picker { display: flex; min-height: 340px; flex-direction: column; border: 1px solid var(--color-border); border-radius: 0 0 6px 6px; background: var(--color-bg-card); }
+.schema-db-picker-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.9rem 1.1rem; border-bottom: 1px solid var(--color-border); }
+.schema-db-picker-head h2 { margin: 0; color: var(--color-text); font-size: 13px; font-weight: 600; }
+.schema-db-picker-head p { margin-top: 0.3rem; color: var(--color-text-muted); font-size: 10px; }
+.schema-db-search { display: flex; width: 220px; align-items: center; gap: 0.45rem; height: 32px; padding: 0 0.55rem; border: 1px solid var(--color-border); border-radius: 5px; background: var(--color-bg-input); }
+.schema-db-search:focus-within { border-color: var(--color-border-active); }
+.schema-db-search svg { flex: 0 0 auto; width: 12px; height: 12px; color: var(--color-text-dim); }
+.schema-db-search input { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; color: var(--color-text); font-size: 10px; }
+.schema-db-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 0.6rem; padding: 1rem 1.1rem; overflow-y: auto; }
+.schema-db-card { display: flex; flex-direction: column; gap: 0.65rem; padding: 0.8rem 0.85rem; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-bg-input); text-align: left; transition: border-color 120ms ease, background 120ms ease; }
+.schema-db-card:hover { border-color: var(--color-border-active); background: var(--color-bg-hover); }
+.schema-db-card-title { display: flex; align-items: center; gap: 0.5rem; color: var(--color-text-muted); }
+.schema-db-card-title svg { width: 13px; height: 13px; flex: 0 0 auto; }
+.schema-db-card-title svg:last-child { width: 12px; height: 12px; margin-left: auto; color: var(--color-text-dim); }
+.schema-db-card-title strong { overflow: hidden; color: var(--color-text); font-family: var(--font-mono); font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.schema-db-card dl { display: flex; margin: 0; gap: 1rem; }
+.schema-db-card dt { color: var(--color-text-dim); font-size: 8px; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; }
+.schema-db-card dd { margin: 0.15rem 0 0; color: var(--color-text-muted); font-family: var(--font-mono); font-size: 10px; }
+
+/* ── Database breadcrumb + switcher above the workbench ── */
+.schema-db-breadcrumb { display: flex; min-height: 36px; align-items: center; gap: 0.45rem; padding: 0 0.6rem; border: 1px solid var(--color-border); border-bottom: 0; background: var(--color-bg-input); }
+.schema-db-back { display: inline-flex; height: 25px; flex: 0 0 auto; align-items: center; gap: 0.3rem; padding: 0 0.5rem; border: 1px solid var(--color-border); border-radius: 4px; color: var(--color-text-dim); font-size: 9px; white-space: nowrap; }
+.schema-db-back:hover { color: var(--color-text); background: var(--color-bg-hover); }
+.schema-db-back svg { width: 11px; height: 11px; }
+.schema-db-crumb-sep { width: 11px; height: 11px; flex: 0 0 auto; color: var(--color-text-dim); }
+.schema-db-strip { display: flex; min-width: 0; gap: 0.25rem; overflow-x: auto; scrollbar-width: none; }
+.schema-db-strip::-webkit-scrollbar { display: none; }
+.schema-db-strip button { display: inline-flex; height: 25px; align-items: center; gap: 0.3rem; padding: 0 0.5rem; border: 1px solid transparent; border-radius: 4px; color: var(--color-text-dim); font-family: var(--font-mono); font-size: 9px; white-space: nowrap; }
+.schema-db-strip button:hover { color: var(--color-text-muted); background: var(--color-bg-hover); }
+.schema-db-strip button.is-active { border-color: var(--color-border); color: var(--color-text); background: var(--color-bg-elevated); }
+.schema-db-strip button svg { width: 10px; height: 10px; }
+.schema-db-strip button span { color: var(--color-text-dim); font-size: 8px; }
+
+@media (max-width: 820px) {
+  .schema-db-picker-head { align-items: stretch; flex-direction: column; }
+  .schema-db-search { width: 100%; }
+  .schema-db-grid { grid-template-columns: 1fr; }
 }

--- a/signalpilot/web/lib/schema-databases.ts
+++ b/signalpilot/web/lib/schema-databases.ts
@@ -1,0 +1,83 @@
+/**
+ * Grouping helpers for multi-database connections.
+ *
+ * One connection can expose several databases: MSSQL multi-db mode keys tables
+ * as database.schema.table and stamps a `database` field on each table; Trino
+ * and Databricks use catalog.schema.table with the catalog folded into the
+ * `schema` string. Single-database connectors carry a plain schema name and no
+ * database field — those group under the connection's configured database.
+ */
+
+export interface DatabaseGroupableTable {
+  schema?: string;
+  name: string;
+  database?: string;
+  row_count?: number;
+  columns?: unknown[];
+}
+
+export interface DatabaseGroup {
+  name: string;
+  tableCount: number;
+  schemaCount: number;
+  columnCount: number;
+  rowCount: number;
+}
+
+/** Database a table belongs to, or null when the connector is single-database. */
+export function tableDatabase(table: DatabaseGroupableTable): string | null {
+  if (table.database) return table.database;
+  const schema = table.schema ?? "";
+  const dot = schema.indexOf(".");
+  return dot > 0 ? schema.slice(0, dot) : null;
+}
+
+/** Schema name with the database/catalog prefix stripped, for display inside one database. */
+export function localSchema(table: DatabaseGroupableTable): string {
+  const schema = table.schema || "default";
+  const db = tableDatabase(table);
+  if (db && schema.startsWith(`${db}.`)) return schema.slice(db.length + 1) || "default";
+  return schema;
+}
+
+/** Group key for a table: its own database, or the connection-level fallback label. */
+export function tableDatabaseKey(table: DatabaseGroupableTable, fallback: string): string {
+  return tableDatabase(table) ?? fallback;
+}
+
+export function groupTablesByDatabase(
+  tables: Record<string, DatabaseGroupableTable>,
+  fallback: string,
+): DatabaseGroup[] {
+  const groups = new Map<string, { tables: number; schemas: Set<string>; columns: number; rows: number }>();
+  for (const table of Object.values(tables)) {
+    const name = tableDatabaseKey(table, fallback);
+    let group = groups.get(name);
+    if (!group) {
+      group = { tables: 0, schemas: new Set(), columns: 0, rows: 0 };
+      groups.set(name, group);
+    }
+    group.tables += 1;
+    group.schemas.add(localSchema(table));
+    group.columns += table.columns?.length ?? 0;
+    group.rows += table.row_count ?? 0;
+  }
+  return [...groups.entries()]
+    .map(([name, group]) => ({
+      name,
+      tableCount: group.tables,
+      schemaCount: group.schemas.size,
+      columnCount: group.columns,
+      rowCount: group.rows,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** Human label for the implicit database of a single-database connection. */
+export function connectionDefaultDatabase(connection?: {
+  database?: string | null;
+  catalog?: string | null;
+  project?: string | null;
+} | null): string {
+  return connection?.database || connection?.catalog || connection?.project || "default";
+}


### PR DESCRIPTION
## Eval execution on Vercel sandboxes

- **`SP_EVAL_EXECUTION_BACKEND=vercel`** runs each eval task in an ephemeral Vercel sandbox VM instead of a Docker container / EKS pod. There is no runner image on Vercel: each sandbox bootstraps the Claude CLI at start (`sudo npm i -g @anthropic-ai/claude-code`), creates `/work`, and runs the standard runner script. Secrets ride the per-exec environment only — never the sandbox creation spec, which the provider API can read back. `kill_after` timeouts are mapped back to `TIMED_OUT` so grading treats them like the container backends. Validated end-to-end against a live MSSQL estate (agent → SignalPilot MCP → warehouse → graded transcript, ~140s/task).
- **Live log tail**: the task command is wrapped as `set -o pipefail; { <task> ; } 2>&1 | tee <file>` inside the sandbox, and the sandbox panel's `VercelSandboxView` polls that file via `read_file` (reattach-by-name, so any worker serves the stream) with the same redaction buffer, byte cap, and wall-clock deadline as the Kubernetes tail. First attach honors tail-lines; org ownership is verified against run state before any read. Bonus: logs survive a timeout kill (recovered from the file) instead of being lost.
- **Sandbox panel**: Vercel sandboxes are listed from run state (the provider has no pod/label/event API); sandbox-name validation now accepts Vercel's generated `word-word-word-Suffix` names while still rejecting path escapes and forged `sp-eval-*` names.
- Requirement worth knowing: `SP_EVAL_MCP_URL` must be publicly reachable from Vercel's network (production gateway domain; ngrok for local testing).

## Stranded eval-pod reaper

Eval sandboxes are bare pods with no TTL — the run path deletes its pod in a `finally`, but a gateway restart mid-run strands it forever (one pod had been sitting Completed for 18 days). `reap_terminal_eval_pods` sweeps eval-labeled pods in a terminal phase older than 1h across namespaces, deletes their env Secrets too, and degrades gracefully on scoped RBAC. Wired into the existing periodic cleanup loop next to the JWT-secret GC.

## Web: multi-database schema browsing

Companion UI for the mssql multi-db connections (#259): `lib/schema-databases.ts` grouping helpers (mssql `database.schema.table`, Trino/Databricks catalogs, single-db fallback), database groups in the connection schema browser and the schema page.

## Tests

New suites for the Vercel backend (selection, credential gating, bootstrap lifecycle, secrets-in-exec-env-only, timeout mapping, binds refusal), the live tail (incremental emission, tail-lines, foreign-sandbox refusal, sandbox-exit termination), and the pod reaper; panel name-validation tests extended. 152 passing across the touched eval suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)