### PR TITLE
Fix GitHub repo import into fresh projects (scaffold deadlock + no-op fetch)

### DIFF
--- a/signalpilot/gateway/gateway/git/repos.py
+++ b/signalpilot/gateway/gateway/git/repos.py
@@ -143,7 +143,17 @@ def clone_from_remote(project_id: str, clone_url: str) -> Path:
     """
     path = repo_path(project_id)
     if path.exists():
-        _run_git("fetch", "--all", cwd=path)
+        # Point the github remote at the provided URL before fetching: at
+        # repo-link time no remote exists yet, so a bare `fetch --all` is a
+        # silent no-op and the import "succeeds" without importing anything.
+        rc, _, _ = _run_git("remote", "get-url", _GITHUB_REMOTE, cwd=path)
+        if rc == 0:
+            _run_git("remote", "set-url", _GITHUB_REMOTE, clone_url, cwd=path)
+        else:
+            _run_git("remote", "add", _GITHUB_REMOTE, clone_url, cwd=path)
+        rc, _, err = _run_git("fetch", _GITHUB_REMOTE, cwd=path, timeout=120)
+        if rc != 0:
+            raise RuntimeError(f"git fetch {_GITHUB_REMOTE} failed: {err}")
         materialize_local_branches(project_id)
         return path
 
@@ -219,6 +229,19 @@ def _detect_remote_default_branch(path: Path) -> str | None:
     return None
 
 
+def _is_pristine_scaffold(path: Path, branch: str) -> bool:
+    """True when `branch` is the untouched "Initial empty project" commit.
+
+    Deliberately strict — exactly one commit AND a completely empty tree — so
+    a branch with any user content (or any history) is never overwritten.
+    """
+    rc, out, _ = _run_git("rev-list", "--count", f"refs/heads/{branch}", cwd=path)
+    if rc != 0 or out.strip() != "1":
+        return False
+    rc, out, _ = _run_git("ls-tree", "-r", f"refs/heads/{branch}", cwd=path)
+    return rc == 0 and not out.strip()
+
+
 def materialize_local_branches(project_id: str, default_branch: str | None = None) -> None:
     """Ensure local refs/heads/* + HEAD reflect the fetched github branches.
 
@@ -247,9 +270,14 @@ def materialize_local_branches(project_id: str, default_branch: str | None = Non
         branch = ref.removeprefix(f"refs/remotes/{_GITHUB_REMOTE}/")
         if not branch or branch == "HEAD":
             continue
-        # Skip branches that already have a local head — don't clobber local work.
+        # Skip branches that already have a local head — don't clobber local
+        # work. The one exception is the untouched project scaffold: a single
+        # empty commit created at project creation. It shares no ancestor with
+        # the fetched history, so the sync path can never reconcile the two
+        # (it refuses diverged branches), and without adopting the remote here
+        # a repo linked to a fresh project imports nothing, forever.
         exists, _, _ = _run_git("rev-parse", "--verify", "--quiet", f"refs/heads/{branch}", cwd=path)
-        if exists != 0:
+        if exists != 0 or _is_pristine_scaffold(path, branch):
             _run_git("update-ref", f"refs/heads/{branch}", ref, cwd=path)
         created.append(branch)
 

--- a/signalpilot/gateway/tests/test_git_repos.py
+++ b/signalpilot/gateway/tests/test_git_repos.py
@@ -35,3 +35,75 @@ def test_init_bare_repo_repairs_existing_empty_repo(monkeypatch, tmp_path) -> No
     main_sha = repos.branch_head_sha(project_id, "main")
     assert main_sha
     assert repos.ensure_branch_from(project_id, "analysis/slack/test", "main") == main_sha
+
+
+def _make_github_style_remote(tmp_path, files: dict[str, str]) -> str:
+    """A local 'GitHub' repo with real content on main."""
+    src = tmp_path / "github-src"
+    src.mkdir()
+    subprocess.run(["git", "init", "--initial-branch", "main", str(src)], check=True, capture_output=True)
+    for rel, text in files.items():
+        p = src / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+    env_args = ["-c", "user.email=t@t", "-c", "user.name=t"]
+    subprocess.run(["git", *env_args, "-C", str(src), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(["git", *env_args, "-C", str(src), "commit", "-m", "real content"], check=True, capture_output=True)
+    return str(src)
+
+
+def test_linking_repo_to_fresh_project_adopts_remote_content(monkeypatch, tmp_path) -> None:
+    """The pristine 'Initial empty project' scaffold must not block the import.
+
+    Regression: the scaffold commit shares no ancestor with the fetched
+    history, materialize refused to touch the existing local head, and the
+    sync path refuses diverged branches — so a repo linked to a fresh project
+    imported nothing, forever (demo-dumpsters, 2026-08-19).
+    """
+    from gateway.git import repos
+
+    project_id = "00000000-0000-0000-0000-000000000003"
+    monkeypatch.setattr(repos, "REPOS_ROOT", tmp_path)
+
+    repos.init_bare_repo(project_id)  # scaffold: one empty commit on main
+    remote = _make_github_style_remote(tmp_path, {"models/orders.sql": "select 1"})
+
+    repos.clone_from_remote(project_id, remote)
+
+    path = tmp_path / f"{project_id}.git"
+    out = subprocess.run(
+        ["git", "-C", str(path), "ls-tree", "-r", "main", "--name-only"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert "models/orders.sql" in out
+    out = subprocess.run(
+        ["git", "-C", str(path), "log", "--oneline", "main"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert "real content" in out
+
+
+def test_local_branch_with_user_content_is_never_overwritten(monkeypatch, tmp_path) -> None:
+    from gateway.git import repos
+
+    project_id = "00000000-0000-0000-0000-000000000004"
+    monkeypatch.setattr(repos, "REPOS_ROOT", tmp_path)
+
+    repos.init_bare_repo(project_id)
+    # Simulate user work: push a real file onto main via a working clone.
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", str(tmp_path / f"{project_id}.git"), str(work)], check=True, capture_output=True)
+    (work / "notebook.py").write_text("x = 1", encoding="utf-8")
+    env_args = ["-c", "user.email=t@t", "-c", "user.name=t"]
+    subprocess.run(["git", *env_args, "-C", str(work), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(["git", *env_args, "-C", str(work), "commit", "-m", "user work"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(work), "push", "origin", "main"], check=True, capture_output=True)
+
+    remote = _make_github_style_remote(tmp_path, {"models/orders.sql": "select 1"})
+    repos.clone_from_remote(project_id, remote)
+
+    out = subprocess.run(
+        ["git", "-C", str(tmp_path / f"{project_id}.git"), "log", "--oneline", "main"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert "user work" in out  # local content preserved, not clobbered


### PR DESCRIPTION
Linking a GitHub repo to a freshly created workspace project imported nothing, forever — reproduced on prod with demo-dumpsters (delete + re-link produced another 0-file project).

**Root causes (stacked):**
1. `clone_from_remote()` on a pre-existing bare repo (the normal UI flow — every project gets a bare repo at creation) ran `git fetch --all` before any `github` remote existed → silent no-op, logged as success. Now the remote is configured to the provided URL, fetched explicitly, and a failed fetch raises.
2. Even once a later sync fetched `github/main`, the content could never reach `refs/heads/main`: `materialize_local_branches` refuses existing local heads (the "Initial empty project" scaffold), and the sync path refuses unrelated histories as diverged. Two individually-correct safety rails, jointly a permanent deadlock. Now the fetched history is adopted iff the local branch is a provably pristine scaffold — exactly one commit and a completely empty tree; any user content remains untouchable.

Regression tests cover both the adoption and the never-clobber guarantee.

Prod was hot-fixed manually (update-ref + HEAD + project stats + stale pod recycled); this PR makes future links work without surgery.

Retro with prevention items (verify outcome not attempt; sync-status compares trees; surface "diverged" in UI): sp-local/writeups/retro-demo-dumpsters-sync-2026-08-19.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)