### PR TITLE
Restrict standalone Data Chat tool access

### DIFF
--- a/signalpilot/gateway/gateway/mcp/audit.py
+++ b/signalpilot/gateway/gateway/mcp/audit.py
@@ -44,8 +44,10 @@ MCP_TOOL_SCOPES: dict[str, str] = {
     "audit_model_sources": "query",
     "compare_join_types": "query",
     "verify_model_values": "query",
-    "manage_report": "admin",
-    "manage_dashboard": "admin",
+    # Disabled with the reports MCP registration. Durable reports and dashboards
+    # require explicit user creation or approval.
+    # "manage_report": "admin",
+    # "manage_dashboard": "admin",
     "list_semantic_metrics": "query",
     "verify_metric_conformance": "query",
     "plan_query": "query",

--- a/signalpilot/gateway/gateway/mcp/tools/__init__.py
+++ b/signalpilot/gateway/gateway/mcp/tools/__init__.py
@@ -22,7 +22,9 @@ from gateway.mcp.tools import model_verify as model_verify  # noqa: E402
 from gateway.mcp.tools import notebook as notebook  # noqa: E402
 from gateway.mcp.tools import notion as notion  # noqa: E402
 from gateway.mcp.tools import query as query  # noqa: E402
-from gateway.mcp.tools import reports as reports  # noqa: E402
+# Disabled for ordinary agent use: durable reports and dashboards require
+# explicit user creation or approval rather than an agent-managed MCP action.
+# from gateway.mcp.tools import reports as reports  # noqa: E402
 from gateway.mcp.tools import schema as schema  # noqa: E402
 from gateway.mcp.tools import semantic_layer as semantic_layer  # noqa: E402
 from gateway.mcp.tools import workspace_projects as workspace_projects  # noqa: E402

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat.py
@@ -90,6 +90,16 @@ IMPROVEMENT_EXTRA_TOOLS = [
     "mcp__signalpilot__sandbox_read_file",
 ]
 
+# Gateway MCP tools that must not be offered to the ordinary Data Chat agent.
+# analyze_project_db and map_columns can return after they use the governed
+# plan/result and frozen-project boundaries. get_dbt_profile is intentionally
+# reserved for writable dbt/Xata administration.
+STANDALONE_DISALLOWED_MCP_TOOLS = [
+    "mcp__signalpilot__analyze_project_db",
+    "mcp__signalpilot__get_dbt_profile",
+    "mcp__signalpilot__map_columns",
+]
+
 IMPROVEMENT_SYSTEM_PROMPT_SUFFIX = """
 
 <automated_improvement_run>
@@ -990,7 +1000,12 @@ async def execute(*, request: Request) -> StreamingResponse:
                     ),
                     cwd=str(project_directory),
                     disallow_file_edits=True,
-                    additional_disallowed_tools=["WebFetch", "WebSearch"],
+                    additional_disallowed_tools=[
+                        "WebFetch",
+                        "WebSearch",
+                        *STANDALONE_DISALLOWED_MCP_TOOLS,
+                        *([] if is_improvement_run else IMPROVEMENT_EXTRA_TOOLS),
+                    ],
                     allowed_tools=(
                         (
                             STANDALONE_ALLOWED_TOOLS

--- a/signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py
@@ -39,7 +39,9 @@ from signalpilot._server.ai.standalone_chat_tools import (
     build_standalone_chat_mcp_server,
 )
 from signalpilot._server.api.endpoints.standalone_chat import (
+    IMPROVEMENT_EXTRA_TOOLS,
     STANDALONE_ALLOWED_TOOLS,
+    STANDALONE_DISALLOWED_MCP_TOOLS,
     STANDALONE_SYSTEM_PROMPT,
     _require_execution_scope,
     _runtime_auth_override,
@@ -450,6 +452,12 @@ def test_agent_contract_excludes_mutating_and_external_tools():
         forbidden not in STANDALONE_ALLOWED_TOOLS
         for forbidden in ("Bash", "Write", "Edit", "WebFetch", "WebSearch")
     )
+    assert set(STANDALONE_DISALLOWED_MCP_TOOLS) == {
+        "mcp__signalpilot__analyze_project_db",
+        "mcp__signalpilot__get_dbt_profile",
+        "mcp__signalpilot__map_columns",
+    }
+    assert not set(IMPROVEMENT_EXTRA_TOOLS) & set(STANDALONE_ALLOWED_TOOLS)
 
 
 def test_runtime_publication_sdk_is_exposed_from_top_level_package():


### PR DESCRIPTION
## Summary
- disable agent-managed `manage_report` and `manage_dashboard` MCP registration
- explicitly disallow unsafe project mapping/profile tools in ordinary standalone Data Chat
- keep sandbox tools limited to capability-gated automated improvement runs
- preserve `publish_table`, `publish_chart`, and `publish_report` artifact tools

## Validation
- `signalpilot/notebook-server/.venv/bin/python -m pytest signalpilot/notebook-server/tests/_server/ai/test_standalone_chat_tools.py -q` (18 passed)
- `signalpilot/gateway/.venv/bin/python -m pytest signalpilot/gateway/tests/test_mcp_scope_policy.py signalpilot/gateway/tests/test_sandbox_mcp_tools.py -q` (27 passed)
- `git diff --check`