### PR TITLE
Show useful live activity in Data Chat

### DIFF
--- a/signalpilot/web/components/chat/standalone-data-chat.tsx
+++ b/signalpilot/web/components/chat/standalone-data-chat.tsx
@@ -70,16 +70,19 @@ import {
   applyStandaloneChatEvent,
   assembleStandaloneRunText,
   containsStandaloneSubmission,
+  deriveStandaloneRunActivity,
   isStandaloneRunReconciled,
   standaloneMessageKey,
   upsertStandaloneConversation,
   type OptimisticUserMessage,
+  type StandaloneRunActivity,
 } from "~/lib/standalone-chat-state";
 import { projectSettingsHref } from "~/lib/project-settings-route";
 
 type UiMessage = StandaloneChatMessage & {
   runId?: string;
   runStatus?: StandaloneChatRunStatus;
+  activity?: StandaloneRunActivity;
   synthetic?: boolean;
 };
 
@@ -559,10 +562,25 @@ function AssistantMessage({ message }: { message: UiMessage }) {
         </div>
         <div className="min-w-0 flex-1">
           <div className="chat-markdown">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {message.content}
-            </ReactMarkdown>
+            {message.content && (
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {message.content}
+              </ReactMarkdown>
+            )}
           </div>
+          {running && message.activity && (
+            <p
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className={`${message.content ? "mt-3" : ""} text-sm text-[var(--color-text-muted)]`}
+            >
+              <span className="font-medium text-[var(--color-text)]">
+                {message.activity.label}:
+              </span>{" "}
+              {message.activity.detail}
+            </p>
+          )}
           {attachedArtifacts.length > 0 && (
             <div className="mt-5 space-y-4">
               {attachedArtifacts.map((artifact) => (
@@ -1272,16 +1290,15 @@ export function StandaloneDataChat({
         const error = [...runEvents]
           .reverse()
           .find((event) => event.type === "error");
-        const progress = [...runEvents]
-          .reverse()
-          .find((event) => event.type === "progress");
         const content =
           (clarification && eventText(clarification, "message")) ||
           streamed ||
           (error && eventText(error, "message")) ||
           (currentRun.status === "cancelled"
             ? "This run was stopped."
-            : eventText(progress, "label") || "Preparing your answer…");
+            : currentRun.status === "completed"
+              ? "Finalizing your answer…"
+              : "");
         messages.push({
           id: `run-${currentRun.id}`,
           role: "assistant",
@@ -1291,6 +1308,7 @@ export function StandaloneDataChat({
           metadata: { run_id: currentRun.id, optimistic: true },
           runId: currentRun.id,
           runStatus: currentRun.status,
+          activity: deriveStandaloneRunActivity(runEvents, currentRun.id),
           synthetic: true,
         });
       }
@@ -1316,11 +1334,12 @@ export function StandaloneDataChat({
       messages.push({
         id: `pending-assistant-${pendingSubmission.id}`,
         role: "assistant",
-        content: "Preparing your answer…",
+        content: "",
         sequence: Number.MAX_SAFE_INTEGER,
         created_at: pendingSubmission.createdAt,
         metadata: { optimistic: true },
         runStatus: "queued",
+        activity: deriveStandaloneRunActivity([], ""),
         synthetic: true,
       });
     }

--- a/signalpilot/web/lib/standalone-chat-state.test.ts
+++ b/signalpilot/web/lib/standalone-chat-state.test.ts
@@ -5,6 +5,7 @@ import {
   applyStandaloneChatEvent,
   assembleStandaloneRunText,
   containsStandaloneSubmission,
+  deriveStandaloneRunActivity,
   isStandaloneRunReconciled,
   standaloneMessageKey,
   upsertStandaloneConversation,
@@ -38,6 +39,89 @@ function detailFixture(): StandaloneConversationDetail {
 }
 
 describe("standalone chat state", () => {
+  it("turns runtime events into useful live analysis stages", () => {
+    const event = (
+      sequence: number,
+      type: StandaloneConversationDetail["run_events"][number]["type"],
+      payload: Record<string, unknown>,
+    ): StandaloneConversationDetail["run_events"][number] => ({
+      run_id: "run-1",
+      sequence,
+      type,
+      payload,
+      created_at: `2026-07-31T12:00:${String(sequence).padStart(2, "0")}Z`,
+    });
+
+    const events = [
+      event(1, "progress", {
+        label: "Exploring the project and relevant data",
+      }),
+      event(2, "tool_started", {
+        tool: "mcp__standalone-chat__inspect_dbt",
+      }),
+    ];
+    expect(deriveStandaloneRunActivity(events, "run-1")).toEqual({
+      phase: "analyzing",
+      label: "Analyzing project",
+      detail: "Inspecting dbt metadata",
+    });
+
+    events.push(
+      event(3, "tool_started", {
+        tool: "mcp__signalpilot-notebook__run_cells",
+      }),
+    );
+    expect(deriveStandaloneRunActivity(events, "run-1")).toEqual({
+      phase: "running_cells",
+      label: "Running cells",
+      detail: "Executing notebook analysis",
+    });
+
+    events.push(event(4, "cell_executed", { status: "failed" }));
+    events.push(
+      event(5, "tool_started", {
+        tool: "mcp__signalpilot-notebook__edit_notebook",
+      }),
+    );
+    expect(deriveStandaloneRunActivity(events, "run-1")).toEqual({
+      phase: "fixing_query",
+      label: "Fixing query",
+      detail: "Updating notebook analysis",
+    });
+
+    events.push(
+      event(6, "tool_started", {
+        tool: "mcp__signalpilot__query_database",
+      }),
+    );
+    expect(deriveStandaloneRunActivity(events, "run-1")).toEqual({
+      phase: "fixing_query",
+      label: "Fixing query",
+      detail: "Validating the revised query",
+    });
+  });
+
+  it("ignores activity from another run", () => {
+    expect(
+      deriveStandaloneRunActivity(
+        [
+          {
+            run_id: "run-2",
+            sequence: 1,
+            type: "tool_started",
+            payload: { tool: "mcp__signalpilot-notebook__run_cells" },
+            created_at: "2026-07-31T12:00:01Z",
+          },
+        ],
+        "run-1",
+      ),
+    ).toEqual({
+      phase: "analyzing",
+      label: "Analyzing project",
+      detail: "Finding the relevant models and data",
+    });
+  });
+
   it("separates assistant text blocks divided by tool activity", () => {
     const event = (
       sequence: number,

--- a/signalpilot/web/lib/standalone-chat-state.ts
+++ b/signalpilot/web/lib/standalone-chat-state.ts
@@ -12,6 +12,197 @@ export type OptimisticUserMessage = {
   createdAt: number;
 };
 
+export type StandaloneRunActivity = {
+  phase: "analyzing" | "running_cells" | "fixing_query";
+  label: string;
+  detail: string;
+};
+
+const DEFAULT_RUN_ACTIVITY: StandaloneRunActivity = {
+  phase: "analyzing",
+  label: "Analyzing project",
+  detail: "Finding the relevant models and data",
+};
+
+function eventString(event: StandaloneChatEvent, key: string): string {
+  const value = event.payload[key];
+  return typeof value === "string" ? value : "";
+}
+
+function toolSuffix(tool: string): string {
+  return tool.split("__").at(-1) ?? tool;
+}
+
+/**
+ * Convert low-level runtime events into the small set of stages shown in the
+ * live assistant bubble. The full event payload remains available in View work.
+ */
+export function deriveStandaloneRunActivity(
+  events: StandaloneChatEvent[],
+  runId: string,
+): StandaloneRunActivity {
+  let activity = DEFAULT_RUN_ACTIVITY;
+  let repairing = false;
+
+  for (const event of events
+    .filter((candidate) => candidate.run_id === runId)
+    .sort((left, right) => left.sequence - right.sequence)) {
+    if (
+      (event.type === "cell_executed" &&
+        eventString(event, "status") === "failed") ||
+      (event.type === "tool_completed" && event.payload.error === true)
+    ) {
+      repairing = true;
+      activity = {
+        phase: "fixing_query",
+        label: "Fixing query",
+        detail: "Reviewing an execution error",
+      };
+      continue;
+    }
+
+    if (event.type === "progress") {
+      const progress = eventString(event, "label");
+      if (/reconnect|restart|recover|repair|fix/i.test(progress)) {
+        repairing = true;
+        activity = {
+          phase: "fixing_query",
+          label: "Fixing query",
+          detail: progress,
+        };
+      }
+      continue;
+    }
+
+    if (event.type === "cell_executed") {
+      repairing = false;
+      activity = {
+        phase: "running_cells",
+        label: "Running cells",
+        detail: "Notebook analysis completed",
+      };
+      continue;
+    }
+
+    if (event.type === "notebook_started") {
+      activity = {
+        phase: "running_cells",
+        label: "Running cells",
+        detail: repairing
+          ? "Restarting notebook analysis"
+          : "Starting notebook analysis",
+      };
+      continue;
+    }
+
+    if (event.type !== "tool_started") continue;
+    const tool = toolSuffix(eventString(event, "tool"));
+
+    if (tool === "run_cells") {
+      activity = repairing
+        ? {
+            phase: "fixing_query",
+            label: "Fixing query",
+            detail: "Retrying notebook cells",
+          }
+        : {
+            phase: "running_cells",
+            label: "Running cells",
+            detail: "Executing notebook analysis",
+          };
+      continue;
+    }
+
+    if (tool === "edit_notebook") {
+      activity = repairing
+        ? {
+            phase: "fixing_query",
+            label: "Fixing query",
+            detail: "Updating notebook analysis",
+          }
+        : {
+            phase: "running_cells",
+            label: "Running cells",
+            detail: "Preparing notebook analysis",
+          };
+      continue;
+    }
+
+    if (tool === "get_notebook_errors") {
+      activity = repairing
+        ? {
+            phase: "fixing_query",
+            label: "Fixing query",
+            detail: "Checking the notebook error",
+          }
+        : {
+            phase: "running_cells",
+            label: "Running cells",
+            detail: "Checking notebook output",
+          };
+      continue;
+    }
+
+    if (
+      tool === "start_analysis_notebook" ||
+      tool === "get_lightweight_cell_map"
+    ) {
+      activity = {
+        phase: "running_cells",
+        label: "Running cells",
+        detail:
+          tool === "start_analysis_notebook"
+            ? "Starting notebook analysis"
+            : "Inspecting notebook cells",
+      };
+      continue;
+    }
+
+    if (
+      repairing &&
+      /debug|validate|explain|plan_query|query_database/.test(tool)
+    ) {
+      activity = {
+        phase: "fixing_query",
+        label: "Fixing query",
+        detail: "Validating the revised query",
+      };
+      continue;
+    }
+
+    const analysisDetails: Record<string, string> = {
+      inspect_dbt: "Inspecting dbt metadata",
+      list_tables: "Reviewing available tables",
+      list_semantic_metrics: "Reviewing available metrics",
+      schema_overview: "Reviewing the project schema",
+      schema_ddl: "Inspecting table definitions",
+      schema_link: "Tracing project relationships",
+      schema_statistics: "Reviewing schema statistics",
+      describe_table: "Inspecting relevant fields",
+      explore_table: "Exploring relevant data",
+      explore_column: "Inspecting relevant fields",
+      explore_columns: "Inspecting relevant fields",
+      get_relationships: "Tracing data relationships",
+      find_join_path: "Finding the right data relationships",
+      verify_metric_conformance: "Checking metric definitions",
+      get_date_boundaries: "Checking data freshness",
+      plan_query: "Planning a governed query",
+      estimate_query_cost: "Checking query scope",
+      explain_query: "Checking the query plan",
+      validate_sql: "Validating the query",
+      debug_cte_query: "Checking the query",
+      query_database: "Querying relevant data",
+    };
+    activity = {
+      phase: "analyzing",
+      label: "Analyzing project",
+      detail: analysisDetails[tool] ?? "Working with the relevant data",
+    };
+  }
+
+  return activity;
+}
+
 export function appendOptimisticUserMessage(
   detail: StandaloneConversationDetail,
   optimistic: OptimisticUserMessage,


### PR DESCRIPTION
## Summary
- derive user-facing activity from low-level run events
- show `Analyzing project`, `Running cells`, and `Fixing query` with contextual detail
- avoid generic placeholder text while a run has no assistant content
- cover activity transitions and run isolation with unit tests

## Validation
- `pnpm exec vitest run lib/standalone-chat-state.test.ts` (10 passed)
- `git diff --check`

## Known repository checks
- `pnpm exec prettier --check ...` could not run because Prettier is not installed in the web package
- `pnpm exec tsc --noEmit --pretty false` remains blocked by existing unrelated errors in generated `.next` types, API/e2e files, and notebook dependencies; none reference the changed files