### PR TITLE
Stop Data Chat runs immediately

### DIFF
--- a/signalpilot/gateway/gateway/standalone_chat/worker.py
+++ b/signalpilot/gateway/gateway/standalone_chat/worker.py
@@ -184,7 +184,12 @@ async def _lease_renewer(run_id: str, worker_id: str, stop: asyncio.Event) -> No
                 return
 
 
-async def _cancellation_monitor(run_id: str, worker_id: str, stop: asyncio.Event) -> None:
+async def _cancellation_monitor(
+    run_id: str,
+    worker_id: str,
+    stop: asyncio.Event,
+    worker_task: asyncio.Task[None],
+) -> None:
     factory = get_session_factory()
     while not stop.is_set():
         try:
@@ -198,7 +203,8 @@ async def _cancellation_monitor(run_id: str, worker_id: str, stop: asyncio.Event
                 stop.set()
                 return
             if run.cancellation_requested_at:
-                await cancel_execution_session(db, run)
+                stop.set()
+                worker_task.cancel()
                 return
 
 
@@ -265,7 +271,11 @@ async def _update_summary(run_id: str) -> None:
 async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
     stop = asyncio.Event()
     renewer = asyncio.create_task(_lease_renewer(run_id, worker_id, stop))
-    cancellation = asyncio.create_task(_cancellation_monitor(run_id, worker_id, stop))
+    worker_task = asyncio.current_task()
+    assert worker_task is not None
+    cancellation = asyncio.create_task(
+        _cancellation_monitor(run_id, worker_id, stop, worker_task)
+    )
     final_text = ""
     streamed_text = ""
     starts_new_text_block = False
@@ -492,6 +502,11 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
             await _update_summary(run_id)
     except asyncio.CancelledError:
         async with get_session_factory()() as db:
+            run = await chat_store.get_worker_run(
+                db,
+                run_id=run_id,
+                worker_id=worker_id,
+            )
             await chat_store.fail_run(
                 db,
                 run_id=run_id,
@@ -499,6 +514,8 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
                 code="cancelled",
                 message="The run was stopped.",
             )
+            if run is not None:
+                await cancel_execution_session(db, run)
     except Exception as exc:
         logger.warning(
             "Standalone chat run %s failed: %s",

--- a/signalpilot/gateway/tests/test_standalone_chat_worker.py
+++ b/signalpilot/gateway/tests/test_standalone_chat_worker.py
@@ -2,12 +2,43 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from gateway.standalone_chat import worker
+
+
+@pytest.mark.asyncio
+async def test_cancellation_monitor_interrupts_the_active_worker_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop = asyncio.Event()
+
+    class FakeSessionContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    async def get_worker_run(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(cancellation_requested_at="2026-08-19T12:00:00Z")
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(worker, "get_session_factory", lambda: FakeSessionContext)
+    monkeypatch.setattr(worker.chat_store, "get_worker_run", get_worker_run)
+    worker_task = asyncio.create_task(wait_forever())
+
+    await worker._cancellation_monitor("run-a", "worker-a", stop, worker_task)
+
+    assert stop.is_set()
+    with pytest.raises(asyncio.CancelledError):
+        await worker_task
 
 
 @pytest.mark.asyncio
@@ -84,7 +115,12 @@ async def test_notebook_stream_does_not_hold_a_database_session(monkeypatch: pyt
     async def fail_run(*_args: Any, **kwargs: Any) -> None:
         failed_runs.append(kwargs["run_id"])
 
-    async def wait_until_stopped(_run_id: str, _worker_id: str, stop: Any) -> None:
+    async def wait_until_stopped(
+        _run_id: str,
+        _worker_id: str,
+        stop: Any,
+        _worker_task: Any = None,
+    ) -> None:
         await stop.wait()
 
     async def noop(*_args: Any, **_kwargs: Any) -> None:
@@ -184,7 +220,12 @@ async def test_terminal_notebook_validation_error_persists_no_answer_or_artifact
     async def persist_artifacts(*_args: Any, **kwargs: Any) -> None:
         persisted_artifacts.append(kwargs["run_id"])
 
-    async def wait_until_stopped(_run_id: str, _worker_id: str, stop: Any) -> None:
+    async def wait_until_stopped(
+        _run_id: str,
+        _worker_id: str,
+        stop: Any,
+        _worker_task: Any = None,
+    ) -> None:
         await stop.wait()
 
     async def noop(*_args: Any, **_kwargs: Any) -> None:

--- a/signalpilot/web/components/chat/standalone-data-chat.tsx
+++ b/signalpilot/web/components/chat/standalone-data-chat.tsx
@@ -72,6 +72,7 @@ import {
   containsStandaloneSubmission,
   deriveStandaloneRunActivity,
   isStandaloneRunReconciled,
+  markStandaloneRunStopped,
   standaloneMessageKey,
   upsertStandaloneConversation,
   type OptimisticUserMessage,
@@ -1499,18 +1500,45 @@ export function StandaloneDataChat({
 
   const onStop = useCallback(
     async (runId: string) => {
+      const stoppedAt = new Date().toISOString();
+      await mutateDetail(
+        (current) =>
+          current
+            ? markStandaloneRunStopped(current, runId, stoppedAt)
+            : current,
+        { revalidate: false },
+      );
+      await mutateHistory(
+        (current) =>
+          current
+            ? {
+                conversations: current.conversations.map((conversation) =>
+                  conversation.id === conversationId
+                    ? {
+                        ...conversation,
+                        run_status: "cancelled" as const,
+                        updated_at: Date.parse(stoppedAt) / 1_000,
+                      }
+                    : conversation,
+                ),
+              }
+            : current,
+        { revalidate: false },
+      );
       try {
         await cancelStandaloneRun(runId);
-        await mutateDetail();
-        await mutateHistory();
+        void mutateDetail();
+        void mutateHistory();
       } catch (error) {
+        void mutateDetail();
+        void mutateHistory();
         toast(
           error instanceof Error ? error.message : "Could not stop the run",
           "error",
         );
       }
     },
-    [mutateDetail, mutateHistory, toast],
+    [conversationId, mutateDetail, mutateHistory, toast],
   );
   const onRetry = useCallback(
     async (runId: string) => {

--- a/signalpilot/web/lib/standalone-chat-state.test.ts
+++ b/signalpilot/web/lib/standalone-chat-state.test.ts
@@ -7,6 +7,7 @@ import {
   containsStandaloneSubmission,
   deriveStandaloneRunActivity,
   isStandaloneRunReconciled,
+  markStandaloneRunStopped,
   standaloneMessageKey,
   upsertStandaloneConversation,
 } from "~/lib/standalone-chat-state";
@@ -184,6 +185,39 @@ describe("standalone chat state", () => {
       sequence: 1,
       created_at: 123,
       metadata: { optimistic: true },
+    });
+  });
+
+  it("shows a stopped run immediately while backend cancellation finishes", () => {
+    const detail = detailFixture();
+    detail.current_run = {
+      id: "run-1",
+      conversation_id: detail.conversation.id,
+      status: "running",
+      retry_of_run_id: null,
+      public_error_code: null,
+      public_error_message: null,
+      cancellation_requested_at: null,
+      created_at: "2026-07-31T12:00:00Z",
+      started_at: "2026-07-31T12:00:01Z",
+      terminal_at: null,
+      last_event_sequence: 3,
+    };
+
+    const updated = markStandaloneRunStopped(
+      detail,
+      "run-1",
+      "2026-07-31T12:00:02Z",
+    );
+
+    expect(updated.current_run).toMatchObject({
+      status: "cancelled",
+      cancellation_requested_at: "2026-07-31T12:00:02Z",
+      terminal_at: "2026-07-31T12:00:02Z",
+    });
+    expect(updated.conversation).toMatchObject({
+      run_status: "cancelled",
+      updated_at: 1785499202,
     });
   });
 

--- a/signalpilot/web/lib/standalone-chat-state.ts
+++ b/signalpilot/web/lib/standalone-chat-state.ts
@@ -225,6 +225,28 @@ export function appendOptimisticUserMessage(
   };
 }
 
+export function markStandaloneRunStopped(
+  detail: StandaloneConversationDetail,
+  runId: string,
+  stoppedAt = new Date().toISOString(),
+): StandaloneConversationDetail {
+  if (detail.current_run?.id !== runId) return detail;
+  return {
+    ...detail,
+    conversation: {
+      ...detail.conversation,
+      run_status: "cancelled",
+      updated_at: Date.parse(stoppedAt) / 1_000,
+    },
+    current_run: {
+      ...detail.current_run,
+      status: "cancelled",
+      cancellation_requested_at: stoppedAt,
+      terminal_at: stoppedAt,
+    },
+  };
+}
+
 export function containsStandaloneSubmission(
   messages: StandaloneChatMessage[],
   submission: OptimisticUserMessage,


### PR DESCRIPTION
## Summary
- update the Data Chat UI optimistically as soon as Stop is clicked
- interrupt the active gateway worker task when cancellation is observed
- preserve downstream notebook execution and kernel cleanup

## Validation
- `uv run --project signalpilot/gateway pytest signalpilot/gateway/tests/test_standalone_chat_worker.py -q`
- `uv run --project signalpilot/gateway ruff check signalpilot/gateway/gateway/standalone_chat/worker.py signalpilot/gateway/tests/test_standalone_chat_worker.py`
- `pnpm --dir signalpilot/web exec vitest run lib/standalone-chat-state.test.ts`
- `pnpm --dir signalpilot/web exec tsc --noEmit --pretty false`
- `git diff --check`