### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,11 @@ SignalPilot/
 If SignalPilot is useful, please ⭐ — it helps a ton.
 [![GitHub stars](https://img.shields.io/github/stars/SignalPilot-Labs/signalpilot?style=social)](https://github.com/SignalPilot-Labs/signalpilot/stargazers)
 
-<a href="https://www.star-history.com/?type=date&repos=SignalPilot-Labs%2Fsignalpilot">
+<a href="https://star-history.dera.page/#SignalPilot-Labs/signalpilot&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=SignalPilot-Labs/signalpilot&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=SignalPilot-Labs/signalpilot&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=SignalPilot-Labs/signalpilot&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SignalPilot-Labs/signalpilot&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SignalPilot-Labs/signalpilot&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SignalPilot-Labs/signalpilot&type=date&legend=top-left" />
  </picture>
 </a>
 ---


### PR DESCRIPTION
The current Star History chart is broken, so restore the chart links to make the repository's history visible again.