### PR TITLE
feat(notebook-image): bake MSSQL ODBC driver and dbt-sqlserver adapter

### DIFF
--- a/Dockerfile.notebook
+++ b/Dockerfile.notebook
@@ -4,7 +4,14 @@ FROM python:3.13-slim
 RUN groupadd -g 10001 notebook && \
     useradd -r -u 10001 -g notebook notebook && \
     mkdir -p /workspace /home/notebook/.sp && \
-    apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/* && \
+    apt-get update && apt-get install -y git curl gnupg && \
+    # Microsoft ODBC driver for dbt-sqlserver (SQL Server customers). A prod
+    # sandbox is recreated constantly — anything not baked here does not exist.
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc -o /usr/share/keyrings/microsoft.asc && \
+    echo "deb [signed-by=/usr/share/keyrings/microsoft.asc] https://packages.microsoft.com/debian/12/prod bookworm main" \
+      > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev && \
+    rm -rf /var/lib/apt/lists/* && \
     pip install --no-cache-dir uv
 
 WORKDIR /opt/sp-notebook
@@ -29,7 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
       sqlglot altair matplotlib plotly pyyaml jinja2 python-dotenv \
       seaborn scikit-learn scipy \
       anthropic openai tiktoken \
-      dbt-postgres dbt-snowflake && \
+      dbt-postgres dbt-snowflake dbt-sqlserver && \
     # Bake dependency .pyc once. The runtime root is read-only, so imports should
     # read precompiled bytecode instead of trying to write it at startup.
     python -m compileall -q -j 0 /opt/sp-notebook/.venv/lib 2>/dev/null || true


### PR DESCRIPTION
The prod notebook image (pinned by digest in `SP_NOTEBOOK_VERCEL_IMAGE`) is built from this branch — it bakes the Microsoft ODBC 18 driver and the `dbt-sqlserver` adapter so MSSQL-backed projects (e.g. the Dumpsters demo) work on Vercel Sandbox runtimes. Merging keeps main in sync with the deployed image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)