### PR TITLE
fix(dbt): dbt panel poisons the file-tree root (prod empty-files bug)

### DIFF
--- a/signalpilot/web/notebook/components/editor/dbt/use-dbt.ts
+++ b/signalpilot/web/notebook/components/editor/dbt/use-dbt.ts
@@ -124,8 +124,15 @@ export function useDbtActions() {
           projectDir: dir || projectDir,
         });
         setProjectInfo(info);
-        if (info.found && info.projectDir) {
-          setProjectDir(info.projectDir);
+        // Deliberately NOT persisting info.projectDir: in cloud mode it is
+        // the runtime's materialized exec-scratch path (…/{branch}/rev-NNN),
+        // and dbtProjectDirAtom re-roots the FILE TREE — poisoning it makes
+        // every file open target a path that isn't in the workspace store
+        // (files render empty). Server-side dbt commands resolve their own
+        // project dir; only an explicit user setting should live in the atom.
+        if (info.found && info.projectDir && dir) {
+          // user explicitly chose a dir — keep their choice
+          setProjectDir(dir);
         }
         return info;
       } catch {


### PR DESCRIPTION
## Problem (live in prod)
Opening the dbt panel writes `project_info.projectDir` — in cloud mode the runtime's materialized exec-scratch path (`{branch}/rev-NNN/...`) — into the localStorage-persisted `dbtProjectDirAtom`. `treeAtom` roots the file tree at that dir, so every subsequent file click targets a path that does not exist in the workspace store and renders **empty**. Observed on app.signalpilot.ai with the dumpsters GitHub project (requests for `file=main/rev-000000000000/models/...`).

Same bug class as the edit-app seeding removed in 33578b56; this was the remaining write site.

## Fix
Only keep an explicit user-chosen dir; never persist the server's resolved path. Server-side dbt commands resolve their own project dir.

## Verified
- Prod diagnosis: sandbox is in S3 mode with correct project binding; store holds all 2,827 files at revision 0; the only broken layer was this client-side atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)