### PR TITLE
feat(chat): runtime_env claim affinity for shared-DB environments

### DIFF
--- a/signalpilot/gateway/gateway/db/migrations/versions/0013_run_runtime_env.py
+++ b/signalpilot/gateway/gateway/db/migrations/versions/0013_run_runtime_env.py
@@ -1,0 +1,29 @@
+"""runtime_env on chat runs
+
+Runs are stamped with the environment that created them (SP_RUNTIME_ENV) so
+workers in different environments sharing one database — e.g. staging and a
+local developer stack — only claim their own runs. NULL means unstamped
+(legacy rows or an environment with no SP_RUNTIME_ENV); any worker may claim
+those.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "gateway_chat_runs",
+        sa.Column("runtime_env", sa.String(length=50), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("gateway_chat_runs", "runtime_env")

--- a/signalpilot/gateway/gateway/db/models.py
+++ b/signalpilot/gateway/gateway/db/models.py
@@ -1021,6 +1021,9 @@ class GatewayChatRun(GatewayBase):
     project_id: Mapped[str] = mapped_column(String, nullable=False)
     user_message_id: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="queued", server_default="queued")
+    # Environment that created the run (SP_RUNTIME_ENV). Workers only claim runs
+    # from their own environment; NULL rows are claimable by any worker.
+    runtime_env: Mapped[str | None] = mapped_column(String(50))
     retry_of_run_id: Mapped[str | None] = mapped_column(String)
     execution_session_id: Mapped[str | None] = mapped_column(String)
     runtime_archive_id: Mapped[str | None] = mapped_column(String)

--- a/signalpilot/gateway/gateway/standalone_chat/config.py
+++ b/signalpilot/gateway/gateway/standalone_chat/config.py
@@ -54,6 +54,16 @@ def enterprise_chat_feature_flags() -> EnterpriseChatFeatureFlags:
     )
 
 
+def runtime_env() -> str | None:
+    """Environment label stamped on runs and used for worker claim affinity.
+
+    Unset/empty means unpartitioned: runs are stamped NULL and the worker
+    claims every run regardless of label (the pre-partitioning behavior).
+    """
+    value = os.getenv("SP_RUNTIME_ENV", "").strip()
+    return value[:50] or None
+
+
 def worker_concurrency() -> int:
     raw = os.getenv("CHAT_WORKER_CONCURRENCY", "4")
     try:

--- a/signalpilot/gateway/gateway/store/standalone_chat.py
+++ b/signalpilot/gateway/gateway/store/standalone_chat.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.connectors.schema_cache import _schema_fingerprint, schema_cache
+from gateway.standalone_chat import config as chat_config
 from gateway.db.models import (
     GatewayChatArtifact,
     GatewayChatConversation,
@@ -336,6 +337,7 @@ async def create_conversation_with_run(
         project_id=project.id,
         user_message_id=user_message.id,
         status=RunStatus.queued.value,
+        runtime_env=chat_config.runtime_env(),
     )
     db.add_all([conversation, user_message, run])
     if not commit:
@@ -1133,6 +1135,7 @@ async def create_run(
         project_id=conversation.project_id or "",
         user_message_id=user_message.id,
         status=RunStatus.queued.value,
+        runtime_env=chat_config.runtime_env(),
     )
     db.add_all([user_message, run])
     conversation.message_count = sequence
@@ -1283,6 +1286,7 @@ async def retry_run(
         user_message_id=failed.user_message_id,
         status=RunStatus.queued.value,
         retry_of_run_id=failed.id,
+        runtime_env=chat_config.runtime_env(),
     )
     db.add(retry)
     from gateway.store.chat_reports import rebind_refresh_retry
@@ -1385,20 +1389,26 @@ async def claim_runs(
     lease_seconds: int,
 ) -> list[str]:
     now = _now()
+    query = select(GatewayChatRun).where(
+        or_(
+            GatewayChatRun.status == RunStatus.queued.value,
+            and_(
+                GatewayChatRun.status == RunStatus.running.value,
+                GatewayChatRun.lease_expires_at < now,
+            ),
+        )
+    )
+    # Environment affinity: a labeled worker claims only its own runs plus
+    # unlabeled (NULL) rows; an unlabeled worker claims everything.
+    own_env = chat_config.runtime_env()
+    if own_env is not None:
+        query = query.where(
+            or_(GatewayChatRun.runtime_env == own_env, GatewayChatRun.runtime_env.is_(None))
+        )
     candidates = (
         (
             await db.execute(
-                select(GatewayChatRun)
-                .where(
-                    or_(
-                        GatewayChatRun.status == RunStatus.queued.value,
-                        and_(
-                            GatewayChatRun.status == RunStatus.running.value,
-                            GatewayChatRun.lease_expires_at < now,
-                        ),
-                    )
-                )
-                .order_by(GatewayChatRun.created_at)
+                query.order_by(GatewayChatRun.created_at)
                 .with_for_update(skip_locked=True)
                 .limit(limit)
             )

--- a/signalpilot/gateway/tests/test_standalone_chat.py
+++ b/signalpilot/gateway/tests/test_standalone_chat.py
@@ -1542,3 +1542,52 @@ def test_standalone_session_claims_and_mcp_allowlist(monkeypatch):
     finally:
         mcp_execution_identity_var.reset(identity_token)
         mcp_allowed_connection_var.reset(connection_token)
+
+
+@pytest.mark.asyncio
+async def test_workers_only_claim_runs_from_their_own_runtime_env(db_session, monkeypatch):
+    project = await _project(db_session)
+
+    async def _run_for(user_id: str) -> GatewayChatRun:
+        _, run = await chat_store.create_conversation_with_run(
+            db_session,
+            org_id="org-a",
+            user_id=user_id,
+            project=project,
+            branch="main",
+            message="What changed in revenue?",
+            commit_sha="a" * 40,
+        )
+        return run
+
+    monkeypatch.setenv("SP_RUNTIME_ENV", "staging")
+    staging_run = await _run_for("user-env-a")
+
+    monkeypatch.delenv("SP_RUNTIME_ENV", raising=False)
+    legacy_run = await _run_for("user-env-b")
+
+    monkeypatch.setenv("SP_RUNTIME_ENV", "local-dev")
+    local_run = await _run_for("user-env-c")
+
+    assert staging_run.runtime_env == "staging"
+    assert legacy_run.runtime_env is None
+    assert local_run.runtime_env == "local-dev"
+
+    # A labeled worker claims its own runs plus unlabeled ones — never another env's.
+    claimed = await chat_store.claim_runs(
+        db_session,
+        worker_id="worker-local",
+        limit=10,
+        lease_seconds=45,
+    )
+    assert set(claimed) == {legacy_run.id, local_run.id}
+
+    # An unlabeled worker claims whatever remains, regardless of label.
+    monkeypatch.delenv("SP_RUNTIME_ENV", raising=False)
+    claimed_rest = await chat_store.claim_runs(
+        db_session,
+        worker_id="worker-any",
+        limit=10,
+        lease_seconds=45,
+    )
+    assert claimed_rest == [staging_run.id]


### PR DESCRIPTION
Runs get stamped with `SP_RUNTIME_ENV` at creation (Alembic 0013, `gateway_chat_runs.runtime_env`); labeled workers claim only their own environment's runs plus unlabeled legacy rows. Unlabeled workers keep today's claim-everything behavior, so rollout order doesn't matter.

Staging/prod task definitions set the label via Terraform; local dev uses `SP_RUNTIME_ENV=local-<name>` so a local stack sharing the staging DB stops racing the staging worker for runs.

Tested: new claim-affinity test + full standalone-chat suite (only the known pre-existing local failure remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)