### PR TITLE
fix(dashboard): use durable project snapshots for authoring

### DIFF
--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -33,6 +33,7 @@ from gateway.dashboard.operations import (
     validate_dashboard_semantics,
     validate_time_series_default_windows,
 )
+from gateway.dashboard.project_snapshot import ensure_branch_snapshot
 from gateway.dashboard.semantic_resolver import DashboardSemanticError, DashboardSemanticResolver
 from gateway.dashboard.telemetry import DashboardTelemetryEvent, record_dashboard_event
 from gateway.db.models import (
@@ -79,6 +80,7 @@ from gateway.standalone_chat.projects import evaluate_project_readiness
 from gateway.store import org_secrets as org_secrets_store
 from gateway.store import standalone_chat as chat_store
 from gateway.verification import compare_columns
+from gateway.workspace_store.objects import workspace_object_storage
 
 from .deps import StoreD
 
@@ -247,6 +249,33 @@ def _dashboard_failure(
 
 def _user_id(store: StoreD) -> str:
     return store.user_id or "local"
+
+
+async def _resolve_project_immutable_head(
+    store: StoreD,
+    *,
+    org_id: str,
+    project_id: str,
+    branch: str,
+) -> str | None:
+    storage = workspace_object_storage()
+    durable = await ensure_branch_snapshot(
+        store.session,
+        storage,
+        org_id=org_id,
+        project_id=project_id,
+        branch=branch,
+    )
+    if durable:
+        return durable
+    if storage.enabled:
+        # Never persist a gateway-local commit as cloud dashboard lineage. A
+        # later replica would be unable to resolve it after this pod exits.
+        return None
+    # Compatibility for local/self-hosted projects that predate the durable
+    # workspace store. Cloud authoring uses the snapshot path above and
+    # therefore survives gateway replacement.
+    return branch_head_sha(project_id, branch)
 
 
 async def _verified_context(store: StoreD, definition: DashboardDefinition) -> DashboardSemanticContext:
@@ -622,9 +651,17 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
             if project is None:
                 raise HTTPException(status_code=404, detail="Dashboard project not found")
             branch = body.branch or project.default_branch or "main"
-            commit_sha = branch_head_sha(project.id, branch)
+            commit_sha = await _resolve_project_immutable_head(
+                store,
+                org_id=org_id,
+                project_id=project.id,
+                branch=branch,
+            )
             if not commit_sha:
-                raise HTTPException(status_code=409, detail="The selected project branch has no immutable head")
+                raise HTTPException(
+                    status_code=409,
+                    detail="The selected project branch has no durable workspace snapshot or immutable Git head",
+                )
     try:
         context = await resolver.resolve(store, project_id=project_id, commit_sha=commit_sha)
     except DashboardSemanticError as exc:

--- a/signalpilot/gateway/gateway/dashboard/project_snapshot.py
+++ b/signalpilot/gateway/gateway/dashboard/project_snapshot.py
@@ -1,0 +1,210 @@
+"""Durable dashboard project snapshots backed by the workspace object store.
+
+Dashboard versions historically pinned a git commit from the gateway-local
+bare-repository cache.  Cloud gateways are replaceable, so that cache is not a
+durable authority.  Workspace revisions are.  This module gives an immutable
+workspace revision a 40-character reference that fits the existing dashboard
+lineage contract and can be resolved without a local git repository.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import logging
+import tarfile
+from pathlib import Path
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.db.models import GatewayWorkspaceRevision
+from gateway.workspace_store.model import Manifest
+from gateway.workspace_store.objects import WorkspaceObjectStorage
+from gateway.workspace_store.store import RevisionNotFound, WorkspaceStore
+
+_SNAPSHOT_REF_DOMAIN = b"signalpilot-dashboard-workspace-snapshot-v1\0"
+_REVISION_HEX_LENGTH = 8
+_hydrate_locks: dict[tuple[str, str], asyncio.Lock] = {}
+logger = logging.getLogger(__name__)
+
+
+def workspace_snapshot_ref(manifest: Manifest) -> str:
+    """Return a stable 40-character reference for one immutable manifest."""
+    if manifest.revision < 0 or manifest.revision > 0xFFFFFFFF:
+        raise ValueError("Workspace revision is outside the dashboard snapshot range")
+    digest = hashlib.sha256(_SNAPSHOT_REF_DOMAIN + manifest.to_bytes()).hexdigest()
+    return f"{manifest.revision:0{_REVISION_HEX_LENGTH}x}{digest[:32]}"
+
+
+async def resolve_branch_snapshot(
+    db: AsyncSession,
+    storage: WorkspaceObjectStorage,
+    *,
+    org_id: str,
+    project_id: str,
+    branch: str,
+) -> str | None:
+    """Resolve the branch's durable workspace head, if one exists."""
+    if not storage.enabled:
+        return None
+    try:
+        manifest = await WorkspaceStore(storage).load_manifest(
+            db,
+            org_id=org_id,
+            project_id=project_id,
+            branch=branch,
+        )
+    except RevisionNotFound:
+        return None
+    return workspace_snapshot_ref(manifest)
+
+
+async def hydrate_github_mirror(
+    db: AsyncSession,
+    *,
+    org_id: str,
+    project_id: str,
+) -> bool:
+    """Lazily restore one replaceable local GitHub mirror."""
+    from gateway.git.repos import clone_from_remote
+    from gateway.store import github as github_store
+
+    lock = _hydrate_locks.setdefault((org_id, project_id), asyncio.Lock())
+    async with lock:
+        link = await github_store.get_repo_link_for_project(db, org_id=org_id, project_id=project_id)
+        if link is None:
+            return False
+        installation = await github_store.get_installation(
+            db,
+            org_id=org_id,
+            installation_id=link.installation_id,
+        )
+        if installation is None:
+            return False
+        try:
+            token = await github_store.get_valid_token(db, installation)
+            remote_url = f"https://x-access-token:{token}@github.com/{link.repo_full_name}.git"
+            await asyncio.to_thread(clone_from_remote, project_id, remote_url)
+            return True
+        except Exception as exc:
+            logger.warning("Dashboard GitHub mirror recovery failed for project %s: %s", project_id, type(exc).__name__)
+            return False
+
+
+async def ensure_branch_snapshot(
+    db: AsyncSession,
+    storage: WorkspaceObjectStorage,
+    *,
+    org_id: str,
+    project_id: str,
+    branch: str,
+) -> str | None:
+    """Return a durable branch snapshot, importing or hydrating when needed."""
+    durable = await resolve_branch_snapshot(
+        db,
+        storage,
+        org_id=org_id,
+        project_id=project_id,
+        branch=branch,
+    )
+    if durable or not storage.enabled:
+        return durable
+
+    from gateway.git.repos import branch_head_sha
+    from gateway.workspace_store.github_sync import import_repo_to_revisions
+
+    if branch_head_sha(project_id, branch) is None and not await hydrate_github_mirror(
+        db,
+        org_id=org_id,
+        project_id=project_id,
+    ):
+        return None
+    try:
+        await import_repo_to_revisions(
+            db,
+            storage,
+            org_id=org_id,
+            project_id=project_id,
+            branch=branch,
+        )
+    except Exception as exc:
+        logger.warning("Dashboard workspace import failed for project %s: %s", project_id, type(exc).__name__)
+        return None
+    return await resolve_branch_snapshot(
+        db,
+        storage,
+        org_id=org_id,
+        project_id=project_id,
+        branch=branch,
+    )
+
+
+def _snapshot_revision(snapshot_ref: str) -> int | None:
+    if len(snapshot_ref) != 40 or any(ch not in "0123456789abcdef" for ch in snapshot_ref.lower()):
+        return None
+    try:
+        return int(snapshot_ref[:_REVISION_HEX_LENGTH], 16)
+    except ValueError:
+        return None
+
+
+async def materialize_workspace_snapshot(
+    db: AsyncSession,
+    storage: WorkspaceObjectStorage,
+    *,
+    org_id: str,
+    project_id: str,
+    snapshot_ref: str,
+    destination: Path,
+) -> bool:
+    """Extract a pinned workspace snapshot and return whether it resolved.
+
+    Revision numbers are branch-local, so all rows at the encoded revision are
+    checked and the manifest digest selects the exact immutable snapshot.
+    Legacy Git SHAs exported from a workspace revision resolve through the
+    existing export mapping as well.
+    """
+    revision = _snapshot_revision(snapshot_ref)
+    if revision is None or not storage.enabled:
+        return False
+
+    rows = list(
+        (
+            await db.execute(
+                select(GatewayWorkspaceRevision).where(
+                    GatewayWorkspaceRevision.org_id == org_id,
+                    GatewayWorkspaceRevision.project_id == project_id,
+                    or_(
+                        GatewayWorkspaceRevision.revision == revision,
+                        GatewayWorkspaceRevision.export_commit_sha == snapshot_ref,
+                    ),
+                )
+            )
+        ).scalars()
+    )
+    workspace = WorkspaceStore(storage)
+    for row in rows:
+        manifest_bytes = await storage.get_bytes(row.manifest_key)
+        if manifest_bytes is None:
+            continue
+        manifest = Manifest.from_bytes(manifest_bytes)
+        if workspace_snapshot_ref(manifest) != snapshot_ref and row.export_commit_sha != snapshot_ref:
+            continue
+
+        _, key = await workspace.build_snapshot(
+            db,
+            org_id=org_id,
+            project_id=project_id,
+            branch=row.branch,
+            revision=row.revision,
+        )
+        archive_bytes = await storage.get_bytes(key)
+        if archive_bytes is None:
+            raise RevisionNotFound(f"Snapshot object missing for revision {row.revision}")
+        destination.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
+            archive.extractall(destination, filter="data")
+        return True
+    return False

--- a/signalpilot/gateway/gateway/dashboard/semantic_resolver.py
+++ b/signalpilot/gateway/gateway/dashboard/semantic_resolver.py
@@ -27,6 +27,9 @@ from gateway.models.dashboards import (
 )
 from gateway.store import Store
 from gateway.verification import compare_columns
+from gateway.workspace_store.objects import workspace_object_storage
+
+from .project_snapshot import hydrate_github_mirror, materialize_workspace_snapshot
 
 SUPPORTED_AGGREGATIONS = {"sum", "count", "count_distinct", "average", "min", "max"}
 
@@ -255,6 +258,40 @@ def _scan_commit(project_id: str, commit_sha: str) -> ProjectMap:
         return scan_project(checkout_path)
 
 
+async def _scan_pinned_project(
+    store: Store,
+    *,
+    org_id: str,
+    project_id: str,
+    commit_sha: str,
+) -> ProjectMap:
+    """Scan a durable workspace snapshot, with git commits kept for compatibility."""
+    with tempfile.TemporaryDirectory(prefix="sp-dashboard-workspace-") as temp_dir:
+        checkout_path = Path(temp_dir) / "project"
+        if await materialize_workspace_snapshot(
+            store.session,
+            workspace_object_storage(),
+            org_id=org_id,
+            project_id=project_id,
+            snapshot_ref=commit_sha,
+            destination=checkout_path,
+        ):
+            return scan_project(checkout_path)
+    try:
+        return _scan_commit(project_id, commit_sha)
+    except DashboardSemanticError as original:
+        # Older dashboard versions store a real Git commit rather than a
+        # workspace snapshot reference. Rehydrate the replaceable GitHub
+        # mirror lazily so those versions survive gateway replacement too.
+        if await hydrate_github_mirror(
+            store.session,
+            org_id=org_id,
+            project_id=project_id,
+        ):
+            return _scan_commit(project_id, commit_sha)
+        raise original
+
+
 class DashboardSemanticResolver:
     async def resolve(self, store: Store, *, project_id: str, commit_sha: str) -> DashboardSemanticContext:
         org_id = store._require_org_id()
@@ -306,7 +343,12 @@ class DashboardSemanticResolver:
             )
             and not any(fnmatch.fnmatch(str(value.get("schema") or "").lower(), item.lower()) for item in excludes)
         }
-        project_map = _scan_commit(project_id, commit_sha)
+        project_map = await _scan_pinned_project(
+            store,
+            org_id=org_id,
+            project_id=project_id,
+            commit_sha=commit_sha,
+        )
         from gateway.api.schema._semantic_store import _load_semantic_model
 
         return resolve_from_authorities(

--- a/signalpilot/gateway/tests/test_dashboard_project_snapshot.py
+++ b/signalpilot/gateway/tests/test_dashboard_project_snapshot.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.api import dashboards as dashboard_api
+from gateway.dashboard import project_snapshot, semantic_resolver
+from gateway.dashboard.project_snapshot import (
+    ensure_branch_snapshot,
+    materialize_workspace_snapshot,
+    resolve_branch_snapshot,
+)
+from gateway.dashboard.semantic_resolver import DashboardSemanticError
+from gateway.db.models import GatewayBase, GatewayWorkspaceRevision
+from gateway.workspace_store.store import Upsert, WorkspaceStore
+
+
+class MemoryWorkspaceStorage:
+    bucket = "test-workspace"
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    async def put_bytes(self, key: str, data: bytes, **_kwargs) -> None:
+        self.objects[key] = data
+
+    async def get_bytes(self, key: str) -> bytes | None:
+        return self.objects.get(key)
+
+    async def exists(self, key: str) -> bool:
+        return key in self.objects
+
+    async def head_size(self, key: str) -> int | None:
+        value = self.objects.get(key)
+        return len(value) if value is not None else None
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(GatewayBase.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_workspace(db: AsyncSession, storage: MemoryWorkspaceStorage) -> str:
+    manifest = await WorkspaceStore(storage).commit(
+        db,
+        org_id="org-a",
+        project_id="project-a",
+        branch="main",
+        base_revision=None,
+        upserts=[
+            Upsert(
+                path="dbt_project.yml",
+                content=b"name: revenue\nversion: '1.0'\nprofile: revenue\nmodel-paths: ['models']\n",
+            ),
+            Upsert(
+                path="models/orders.sql",
+                content=b"select 1 as order_id\n",
+            ),
+        ],
+        deletes=[],
+        created_by="test",
+        message="durable dashboard fixture",
+    )
+    return str(manifest.revision)
+
+
+@pytest.mark.asyncio
+async def test_workspace_snapshot_resolves_and_materializes_without_git(
+    db_session: AsyncSession,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryWorkspaceStorage()
+    await _seed_workspace(db_session, storage)
+
+    snapshot_ref = await resolve_branch_snapshot(
+        db_session,
+        storage,
+        org_id="org-a",
+        project_id="project-a",
+        branch="main",
+    )
+
+    assert snapshot_ref is not None
+    assert len(snapshot_ref) == 40
+    assert await materialize_workspace_snapshot(
+        db_session,
+        storage,
+        org_id="org-a",
+        project_id="project-a",
+        snapshot_ref=snapshot_ref,
+        destination=tmp_path,
+    )
+    assert (tmp_path / "dbt_project.yml").read_text().startswith("name: revenue")
+    assert (tmp_path / "models/orders.sql").read_text() == "select 1 as order_id\n"
+
+
+@pytest.mark.asyncio
+async def test_exported_legacy_git_sha_materializes_from_its_workspace_revision(
+    db_session: AsyncSession,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryWorkspaceStorage()
+    await _seed_workspace(db_session, storage)
+    legacy_commit_sha = "a" * 40
+    await db_session.execute(
+        update(GatewayWorkspaceRevision)
+        .where(
+            GatewayWorkspaceRevision.org_id == "org-a",
+            GatewayWorkspaceRevision.project_id == "project-a",
+            GatewayWorkspaceRevision.branch == "main",
+            GatewayWorkspaceRevision.revision == 0,
+        )
+        .values(export_commit_sha=legacy_commit_sha)
+    )
+    await db_session.commit()
+
+    assert await materialize_workspace_snapshot(
+        db_session,
+        storage,
+        org_id="org-a",
+        project_id="project-a",
+        snapshot_ref=legacy_commit_sha,
+        destination=tmp_path,
+    )
+    assert (tmp_path / "models/orders.sql").read_text() == "select 1 as order_id\n"
+
+
+@pytest.mark.asyncio
+async def test_semantic_scan_uses_workspace_snapshot_when_local_repo_is_absent(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MemoryWorkspaceStorage()
+    await _seed_workspace(db_session, storage)
+    snapshot_ref = await resolve_branch_snapshot(
+        db_session,
+        storage,
+        org_id="org-a",
+        project_id="project-a",
+        branch="main",
+    )
+    assert snapshot_ref is not None
+    monkeypatch.setattr(semantic_resolver, "workspace_object_storage", lambda: storage)
+    monkeypatch.setattr(
+        semantic_resolver,
+        "_scan_commit",
+        lambda *_args, **_kwargs: pytest.fail("local git fallback must not run"),
+    )
+
+    project_map = await semantic_resolver._scan_pinned_project(
+        SimpleNamespace(session=db_session),
+        org_id="org-a",
+        project_id="project-a",
+        commit_sha=snapshot_ref,
+    )
+
+    assert project_map.project_name == "revenue"
+    assert "orders" in project_map.models
+
+
+@pytest.mark.asyncio
+async def test_authoring_head_prefers_durable_snapshot_over_local_git(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MemoryWorkspaceStorage()
+    await _seed_workspace(db_session, storage)
+    monkeypatch.setattr(dashboard_api, "workspace_object_storage", lambda: storage)
+    monkeypatch.setattr(
+        dashboard_api,
+        "branch_head_sha",
+        lambda *_args, **_kwargs: pytest.fail("local git fallback must not run"),
+    )
+
+    resolved = await dashboard_api._resolve_project_immutable_head(
+        SimpleNamespace(session=db_session),
+        org_id="org-a",
+        project_id="project-a",
+        branch="main",
+    )
+
+    assert resolved == await resolve_branch_snapshot(
+        db_session,
+        storage,
+        org_id="org-a",
+        project_id="project-a",
+        branch="main",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cloud_authoring_never_persists_an_ephemeral_git_head(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MemoryWorkspaceStorage()
+
+    async def no_durable_snapshot(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(dashboard_api, "workspace_object_storage", lambda: storage)
+    monkeypatch.setattr(dashboard_api, "ensure_branch_snapshot", no_durable_snapshot)
+    monkeypatch.setattr(
+        dashboard_api,
+        "branch_head_sha",
+        lambda *_args, **_kwargs: pytest.fail("cloud must not use an ephemeral git head"),
+    )
+
+    assert (
+        await dashboard_api._resolve_project_immutable_head(
+            SimpleNamespace(session=db_session),
+            org_id="org-a",
+            project_id="project-a",
+            branch="main",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_mirror_is_hydrated_and_imported_to_a_durable_snapshot(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MemoryWorkspaceStorage()
+    resolved_snapshots = iter([None, "d" * 40])
+    imported: list[str] = []
+
+    async def fake_resolve(*_args, **_kwargs):
+        return next(resolved_snapshots)
+
+    async def fake_hydrate(*_args, **_kwargs):
+        return True
+
+    async def fake_import(*_args, **kwargs):
+        imported.append(kwargs["branch"])
+
+    from gateway.git import repos
+    from gateway.workspace_store import github_sync
+
+    monkeypatch.setattr(project_snapshot, "resolve_branch_snapshot", fake_resolve)
+    monkeypatch.setattr(project_snapshot, "hydrate_github_mirror", fake_hydrate)
+    monkeypatch.setattr(repos, "branch_head_sha", lambda *_args: None)
+    monkeypatch.setattr(github_sync, "import_repo_to_revisions", fake_import)
+
+    assert (
+        await ensure_branch_snapshot(
+            db_session,
+            storage,
+            org_id="org-a",
+            project_id="project-a",
+            branch="main",
+        )
+        == "d" * 40
+    )
+    assert imported == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_git_commit_rehydrates_missing_mirror(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scans = 0
+
+    async def no_workspace_snapshot(*_args, **_kwargs):
+        return False
+
+    def scan_after_recovery(*_args, **_kwargs):
+        nonlocal scans
+        scans += 1
+        if scans == 1:
+            raise DashboardSemanticError("The pinned project commit is unavailable")
+        return "recovered-project-map"
+
+    async def fake_hydrate(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(semantic_resolver, "workspace_object_storage", MemoryWorkspaceStorage)
+    monkeypatch.setattr(semantic_resolver, "materialize_workspace_snapshot", no_workspace_snapshot)
+    monkeypatch.setattr(semantic_resolver, "_scan_commit", scan_after_recovery)
+    monkeypatch.setattr(semantic_resolver, "hydrate_github_mirror", fake_hydrate)
+
+    assert (
+        await semantic_resolver._scan_pinned_project(
+            SimpleNamespace(session=db_session),
+            org_id="org-a",
+            project_id="project-a",
+            commit_sha="a" * 40,
+        )
+        == "recovered-project-map"
+    )
+    assert scans == 2


### PR DESCRIPTION
## Summary

- pin new dashboard authoring sessions to immutable workspace manifests in durable object storage
- import an existing local project mirror, or lazily restore a linked GitHub mirror, when a durable branch snapshot has not been created yet
- resolve legacy Git-pinned dashboards from their durable exported revision mapping or recover the GitHub mirror as a compatibility fallback
- retain the local Git-head path only for self-hosted environments without workspace object storage

## Root cause

Dashboard authoring read the selected branch head only from the gateway-local bare repository under `/repos`. Hosted gateway replicas are replaceable and do not share that filesystem, while the project row and workspace revisions remain durable. After a restart or when a request reached another replica, `branch_head_sha` returned no head and authoring responded with `409: The selected project branch has no immutable head`.

## Behavior after this change

Cloud authoring persists a deterministic 40-character reference derived from the immutable workspace manifest. Semantic resolution reconstructs that exact revision from object storage, so it does not depend on the gateway instance that created the dashboard. If durable content cannot be found or recovered, authoring still fails closed instead of persisting an ephemeral local SHA.

## Validation

- `ruff check gateway/dashboard/project_snapshot.py gateway/dashboard/semantic_resolver.py gateway/api/dashboards.py tests/test_dashboard_project_snapshot.py`
- `pytest -q tests/test_dashboard_project_snapshot.py tests/test_dashboard_authoring.py tests/test_dashboards.py tests/test_github_pull_store.py tests/test_notebook_workspace_v2_scaffold.py tests/test_dashboard_http_authorization.py`
- 116 tests passed
- `git diff --check`