### PR TITLE
fix(dashboard): repair invalid agent drafts

### DIFF
--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -671,7 +671,18 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
         raise HTTPException(status_code=409, detail="Dashboard authoring requires the organization Anthropic key")
     agent = DashboardAuthoringAgent(api_key=api_key)
     try:
-        draft = await agent.draft(prompt=body.prompt, context=context, base_definition=base_definition)
+        def validate_candidate(candidate):
+            candidate_definition = materialize_agent_draft(candidate, base_definition=base_definition)
+            candidate_definition = canonicalize_dashboard_filter_targets(candidate_definition, context)
+            validate_dashboard_semantics(candidate_definition, context)
+            validate_time_series_default_windows(candidate_definition, context)
+
+        draft = await agent.draft(
+            prompt=body.prompt,
+            context=context,
+            base_definition=base_definition,
+            validator=validate_candidate,
+        )
         definition = materialize_agent_draft(draft, base_definition=base_definition)
         if base_definition is None:
             binding = definition.signalPilot.model_copy(
@@ -817,7 +828,18 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
         if not api_key:
             raise HTTPException(status_code=409, detail="Dashboard authoring requires the organization Anthropic key")
         agent = DashboardAuthoringAgent(api_key=api_key)
-        draft = await agent.draft(prompt=body.prompt, context=context, base_definition=current_definition)
+        def validate_candidate(candidate):
+            candidate_definition = materialize_agent_draft(candidate, base_definition=current_definition)
+            candidate_definition = canonicalize_dashboard_filter_targets(candidate_definition, context)
+            validate_dashboard_semantics(candidate_definition, context)
+            validate_time_series_default_windows(candidate_definition, context)
+
+        draft = await agent.draft(
+            prompt=body.prompt,
+            context=context,
+            base_definition=current_definition,
+            validator=validate_candidate,
+        )
         definition = materialize_agent_draft(draft, base_definition=current_definition)
         verified = await _verified_context(store, definition)
         definition = canonicalize_dashboard_filter_targets(definition, verified)

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from collections.abc import Callable
 from typing import Any
 
 from pydantic import Field, model_validator
@@ -27,6 +28,7 @@ FILTER_OPT_OUT_PATTERNS = (
     r"\bn[aã]o (?:adicione|inclua|crie|use) filtros?\b",
     r"\bn[aã]o quero filtros?\b",
 )
+MAX_DRAFT_ATTEMPTS = 3
 
 
 class DashboardAgentDraft(ContractModel):
@@ -126,6 +128,7 @@ class DashboardAuthoringAgent:
         prompt: str,
         context: DashboardSemanticContext,
         base_definition: DashboardDefinition | None,
+        validator: Callable[[DashboardAgentDraft], None] | None = None,
     ) -> DashboardAgentDraft:
         mode = "update" if base_definition is not None else "create"
         contract = DashboardAgentDraft.model_json_schema(by_alias=True)
@@ -181,12 +184,12 @@ class DashboardAuthoringAgent:
             "tool_choice": {"type": "tool", "name": "submit_dashboard_draft"},
         }
 
-        async def request_draft(body: dict[str, Any]) -> DashboardAgentDraft:
+        async def request_tool_input(body: dict[str, Any]) -> Any:
             response = await self.model_client.create_message(body)
             content = response.get("content")
             if not isinstance(content, list):
                 raise ValueError("Dashboard authoring model returned no tool result")
-            tool_input = next(
+            return next(
                 (
                     block.get("input")
                     for block in content
@@ -196,55 +199,55 @@ class DashboardAuthoringAgent:
                 ),
                 None,
             )
-            return DashboardAgentDraft.model_validate(tool_input)
 
-        draft = await request_draft(request_body)
-        if not explicitly_omits_filters(prompt) and not draft_has_filters(draft, base_definition=base_definition):
-            repair_payload = {
-                **payload,
-                "rejected_draft": draft.model_dump(mode="json", by_alias=True, exclude_none=True),
-                "validation_feedback": (
-                    "The previous draft was rejected because it omitted dashboard filter controls. Add useful governed "
-                    "filters now. Prefer a date filter when available, include explicit per-tile targets, and preserve "
-                    "all otherwise valid chart and layout work."
-                ),
-            }
-            request_body = {
-                **request_body,
-                "messages": [{"role": "user", "content": json.dumps(repair_payload, default=str)}],
-            }
-            draft = await request_draft(request_body)
-            if not draft_has_filters(draft, base_definition=base_definition):
-                raise ValueError("Dashboard authoring requires at least one governed filter control")
-        if base_definition is None and draft.definition is not None:
-            missing_drills = charts_missing_usable_drills(draft.definition, context)
-            if missing_drills:
+        last_error: ValueError | None = None
+        for attempt in range(MAX_DRAFT_ATTEMPTS):
+            rejected_draft: Any = None
+            try:
+                rejected_draft = await request_tool_input(request_body)
+                draft = DashboardAgentDraft.model_validate(rejected_draft)
+                if base_definition is None and draft.definition is None:
+                    raise ValueError("Dashboard creation requires a complete definition")
+                if base_definition is not None and draft.definition is not None:
+                    raise ValueError("Dashboard updates require typed operations")
+                if not explicitly_omits_filters(prompt) and not draft_has_filters(
+                    draft, base_definition=base_definition
+                ):
+                    raise ValueError(
+                        "Dashboard authoring requires at least one governed filter control. Add a useful governed "
+                        "filter, prefer a bounded date filter when available, and include explicit per-tile targets."
+                    )
+                if base_definition is None and draft.definition is not None:
+                    missing_drills = charts_missing_usable_drills(draft.definition, context)
+                    if missing_drills:
+                        raise ValueError(
+                            "Dashboard authoring requires usable drill hierarchies for applicable charts: "
+                            f"{', '.join(missing_drills)}. Add a meaningful lower-grain drill hierarchy using exact "
+                            "same-explore field_id values without repeating query dimensions or drill levels."
+                        )
+                if validator is not None:
+                    validator(draft)
+                return draft
+            except ValueError as exc:
+                last_error = exc
+                if attempt + 1 >= MAX_DRAFT_ATTEMPTS:
+                    raise
                 repair_payload = {
                     **payload,
-                    "rejected_draft": draft.model_dump(mode="json", by_alias=True, exclude_none=True),
                     "validation_feedback": (
-                        "The previous draft was rejected because applicable charts omitted a usable lower-grain drill "
-                        f"hierarchy: {', '.join(missing_drills)}. Add meaningful signalPilot.drillDimensions using exact "
-                        "same-explore field_id values. Do not repeat query dimensions or drill levels, and preserve all "
-                        "otherwise valid filters, charts, and layout work."
+                        "The server rejected the previous draft. Correct every reported contract or semantic error, "
+                        "copy explore and field identifiers exactly from semantic_context, preserve otherwise valid "
+                        f"work, and resubmit the complete {mode} payload.\n{str(exc)[:6000]}"
                     ),
                 }
+                if rejected_draft is not None:
+                    repair_payload["rejected_draft"] = rejected_draft
                 request_body = {
                     **request_body,
                     "messages": [{"role": "user", "content": json.dumps(repair_payload, default=str)}],
                 }
-                draft = await request_draft(request_body)
-                if draft.definition is None or charts_missing_usable_drills(draft.definition, context):
-                    raise ValueError("Dashboard authoring requires usable drill hierarchies for applicable charts")
-                if not explicitly_omits_filters(prompt) and not draft_has_filters(
-                    draft, base_definition=base_definition
-                ):
-                    raise ValueError("Dashboard authoring requires at least one governed filter control")
-        if base_definition is None and draft.definition is None:
-            raise ValueError("Dashboard creation requires a complete definition")
-        if base_definition is not None and draft.definition is not None:
-            raise ValueError("Dashboard updates require typed operations")
-        return draft
+        assert last_error is not None
+        raise last_error
 
 
 def explicitly_omits_filters(prompt: str) -> bool:

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -431,7 +431,7 @@ async def test_agent_rejects_a_second_creation_without_usable_drills() -> None:
             base_definition=None,
         )
 
-    assert len(client.requests) == 2
+    assert len(client.requests) == 3
 
 
 @pytest.mark.asyncio
@@ -500,7 +500,77 @@ async def test_agent_rejects_a_second_filterless_response() -> None:
             context=_context(),
             base_definition=None,
         )
+    assert len(client.requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_agent_repairs_semantic_validation_failures_before_returning_the_draft() -> None:
+    invalid_payload = _single_bar_definition(drill_dimensions=["orders.customer"]).model_dump(
+        mode="json", by_alias=True
+    )
+    invalid_payload["charts"][0]["query"]["exploreName"] = "sales"
+    repaired = _single_bar_definition(drill_dimensions=["orders.customer"])
+    client = _ModelClient(
+        [
+            {
+                "summary": "Created the dashboard.",
+                "definition": invalid_payload,
+            },
+            {
+                "summary": "Created the dashboard with governed identifiers.",
+                "definition": repaired.model_dump(mode="json", by_alias=True),
+            },
+        ]
+    )
+    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
+
+    def validate_candidate(draft: DashboardAgentDraft) -> None:
+        assert draft.definition is not None
+        validate_dashboard_semantics(draft.definition, _orders_context())
+
+    draft = await agent.draft(
+        prompt="Create an executive revenue dashboard",
+        context=_orders_context(),
+        base_definition=None,
+        validator=validate_candidate,
+    )
+
+    assert draft.definition is not None
+    assert draft.definition.charts[0].query.exploreName == "orders"
     assert len(client.requests) == 2
+    repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
+    assert "Unknown explore: sales" in repair_payload["validation_feedback"]
+    assert repair_payload["rejected_draft"]["definition"]["charts"][0]["query"]["exploreName"] == "sales"
+
+
+@pytest.mark.asyncio
+async def test_agent_repairs_invalid_tool_contract_before_returning_the_draft() -> None:
+    repaired = _definition_with_filter()
+    client = _ModelClient(
+        [
+            {
+                "summary": "Returned both payload types.",
+                "definition": repaired.model_dump(mode="json", by_alias=True),
+                "operations": [{"operation": "rename_dashboard", "name": "Wrong mode"}],
+            },
+            {
+                "summary": "Created one complete dashboard definition.",
+                "definition": repaired.model_dump(mode="json", by_alias=True),
+            },
+        ]
+    )
+    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
+
+    draft = await agent.draft(
+        prompt="Create an executive revenue dashboard",
+        context=_context(),
+        base_definition=None,
+    )
+
+    assert draft.definition is not None
+    assert len(client.requests) == 2
+    repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
+    assert "either a complete definition or typed operations" in repair_payload["validation_feedback"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retry malformed dashboard-agent tool payloads and governed draft validation failures before returning a 422
- feed exact compiler feedback back into a bounded three-attempt repair loop for create and follow-up authoring
- cover unknown explores and invalid tool contracts while retaining final server-side semantic validation

## Validation

- `signalpilot/gateway/.venv/bin/pytest -q tests/test_dashboard_authoring.py tests/test_dashboards.py` (53 passed)
- `signalpilot/gateway/.venv/bin/ruff check gateway/dashboard/authoring.py gateway/api/dashboards.py tests/test_dashboard_authoring.py`
- `git diff --check`