### PR TITLE
fix(dashboard): recover unknown explore placeholders

### DIFF
--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -28,6 +28,7 @@ from gateway.dashboard.compiler import (
 from gateway.dashboard.confidence import semantic_query_signature
 from gateway.dashboard.domain import DashboardDefinition, FieldTarget, FilterRule, SemanticChartQuery
 from gateway.dashboard.operations import (
+    canonicalize_dashboard_explore_names,
     canonicalize_dashboard_filter_targets,
     has_custom_sql,
     validate_dashboard_semantics,
@@ -673,6 +674,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
     try:
         def validate_candidate(candidate):
             candidate_definition = materialize_agent_draft(candidate, base_definition=base_definition)
+            candidate_definition = canonicalize_dashboard_explore_names(candidate_definition, context)
             candidate_definition = canonicalize_dashboard_filter_targets(candidate_definition, context)
             validate_dashboard_semantics(candidate_definition, context)
             validate_time_series_default_windows(candidate_definition, context)
@@ -705,6 +707,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
                 definition.model_copy(update={"signalPilot": binding, "charts": charts})
             )
         verified = await _verified_context(store, definition)
+        definition = canonicalize_dashboard_explore_names(definition, verified)
         definition = canonicalize_dashboard_filter_targets(definition, verified)
         validate_dashboard_semantics(definition, verified)
         validate_time_series_default_windows(definition, verified)
@@ -830,6 +833,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
         agent = DashboardAuthoringAgent(api_key=api_key)
         def validate_candidate(candidate):
             candidate_definition = materialize_agent_draft(candidate, base_definition=current_definition)
+            candidate_definition = canonicalize_dashboard_explore_names(candidate_definition, context)
             candidate_definition = canonicalize_dashboard_filter_targets(candidate_definition, context)
             validate_dashboard_semantics(candidate_definition, context)
             validate_time_series_default_windows(candidate_definition, context)
@@ -842,6 +846,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
         )
         definition = materialize_agent_draft(draft, base_definition=current_definition)
         verified = await _verified_context(store, definition)
+        definition = canonicalize_dashboard_explore_names(definition, verified)
         definition = canonicalize_dashboard_filter_targets(definition, verified)
         validate_dashboard_semantics(definition, verified)
         validate_time_series_default_windows(definition, verified)

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -134,7 +134,9 @@ class DashboardAuthoringAgent:
         contract = DashboardAgentDraft.model_json_schema(by_alias=True)
         system = (
             "You are SignalPilot's governed dashboard author. Use only the supplied explores, fields, and metrics. "
-            "Use only KPI, table, bar, line, and area visualizations. Each semantic chart queries one explore. "
+            "Use only KPI, table, bar, line, and area visualizations. Each semantic chart queries one explore. Copy "
+            "exploreName exactly from semantic_context.explores[].name; never invent an explore or use placeholders "
+            "such as <UNKNOWN>. "
             "For every chart, write three distinct pieces of business copy: question is a concise natural-language "
             "question shown at the top left and ending in a question mark; title is a short 2-5 word business label "
             "such as Total Revenue or Net Revenue; description is one useful sentence. For Cartesian charts, begin "
@@ -237,7 +239,9 @@ class DashboardAuthoringAgent:
                     "validation_feedback": (
                         "The server rejected the previous draft. Correct every reported contract or semantic error, "
                         "copy explore and field identifiers exactly from semantic_context, preserve otherwise valid "
-                        f"work, and resubmit the complete {mode} payload.\n{str(exc)[:6000]}"
+                        f"work, and resubmit the complete {mode} payload. Valid exploreName values: "
+                        f"{', '.join(explore.name for explore in context.explores) or 'none'}. Never use <UNKNOWN> "
+                        f"or another placeholder.\n{str(exc)[:6000]}"
                     ),
                 }
                 if rejected_draft is not None:

--- a/signalpilot/gateway/gateway/dashboard/operations.py
+++ b/signalpilot/gateway/gateway/dashboard/operations.py
@@ -282,6 +282,52 @@ def validate_dashboard_semantics(definition: DashboardDefinition, context: Dashb
                 raise ValueError(f"Unknown dashboard filter target: {target.tableName}.{target.fieldId}")
 
 
+def canonicalize_dashboard_explore_names(
+    definition: DashboardDefinition,
+    context: DashboardSemanticContext,
+) -> DashboardDefinition:
+    """Recover an unknown explore only when exact field IDs identify one explore.
+
+    Agent drafts occasionally use a placeholder such as ``<UNKNOWN>`` for
+    ``exploreName`` while still copying every governed dimension, metric, and
+    drill field exactly. Those exact IDs are sufficient to recover the explore
+    without guessing. Ambiguous or invented field sets remain unchanged so the
+    semantic validator still rejects them.
+    """
+    dimensions_by_explore = {
+        explore.name: {field.field_id for field in explore.dimensions} for explore in context.explores
+    }
+    metrics_by_explore = {explore.name: {metric.field_id for metric in explore.metrics} for explore in context.explores}
+    known_explores = set(dimensions_by_explore)
+    changed = False
+    charts: list[ChartDefinition] = []
+    for chart in definition.charts:
+        query = chart.query
+        if not isinstance(query, SemanticChartQuery) or query.exploreName in known_explores:
+            charts.append(chart)
+            continue
+        dimension_ids = {
+            *query.dimensions,
+            *(chart.signalPilot.drillDimensions or []),
+            *(chart.signalPilot.tableGroups or []),
+        }
+        metric_ids = set(query.metrics)
+        if not dimension_ids and not metric_ids:
+            charts.append(chart)
+            continue
+        candidates = [
+            explore_name
+            for explore_name in known_explores
+            if dimension_ids <= dimensions_by_explore[explore_name] and metric_ids <= metrics_by_explore[explore_name]
+        ]
+        if len(candidates) != 1:
+            charts.append(chart)
+            continue
+        changed = True
+        charts.append(chart.model_copy(update={"query": query.model_copy(update={"exploreName": candidates[0]})}))
+    return definition.model_copy(update={"charts": charts}) if changed else definition
+
+
 class DashboardTimeSeriesWindowError(ValueError):
     """A line or area chart cannot prove a complete bounded initial view."""
 
@@ -384,9 +430,14 @@ def canonicalize_dashboard_filter_targets(
     unchanged so semantic validation still rejects them.
     """
     aliases_by_explore: dict[str, dict[str, str | None]] = {}
+    explore_by_field_id: dict[str, str | None] = {}
     for explore in context.explores:
         aliases: dict[str, str | None] = {}
         for field in explore.dimensions:
+            if field.field_id in explore_by_field_id and explore_by_field_id[field.field_id] != explore.name:
+                explore_by_field_id[field.field_id] = None
+            else:
+                explore_by_field_id[field.field_id] = explore.name
             if field.column in aliases and aliases[field.column] != field.field_id:
                 aliases[field.column] = None
             else:
@@ -396,10 +447,18 @@ def canonicalize_dashboard_filter_targets(
     def canonicalize(target: DashboardFieldTarget) -> DashboardFieldTarget:
         if target.isSqlColumn:
             return target
-        canonical_field_id = aliases_by_explore.get(target.tableName, {}).get(target.fieldId)
-        if canonical_field_id is None or canonical_field_id == target.fieldId:
+        table_name = target.tableName
+        if table_name not in aliases_by_explore:
+            table_name = explore_by_field_id.get(target.fieldId) or table_name
+        canonical_field_id = aliases_by_explore.get(table_name, {}).get(target.fieldId)
+        updates = {}
+        if table_name != target.tableName:
+            updates["tableName"] = table_name
+        if canonical_field_id is not None and canonical_field_id != target.fieldId:
+            updates["fieldId"] = canonical_field_id
+        if not updates:
             return target
-        return target.model_copy(update={"fieldId": canonical_field_id})
+        return target.model_copy(update=updates)
 
     changed = False
     dimensions: list[DashboardFilterRule] = []

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -22,6 +22,7 @@ from gateway.dashboard.operations import (
     DashboardTimeSeriesWindowError,
     RenameDashboard,
     apply_dashboard_operations,
+    canonicalize_dashboard_explore_names,
     canonicalize_dashboard_filter_targets,
     validate_dashboard_semantics,
     validate_time_series_default_windows,
@@ -272,6 +273,53 @@ def test_unknown_dashboard_filter_target_still_fails_after_canonicalization() ->
         validate_dashboard_semantics(definition, _orders_context())
 
 
+def test_unknown_filter_explore_is_recovered_from_an_exact_field_id() -> None:
+    payload = _definition_with_filter().model_dump(mode="json", by_alias=True)
+    payload["filters"]["dimensions"][0]["target"]["tableName"] = "<UNKNOWN>"
+    payload["filters"]["dimensions"][0]["tileTargets"] = {
+        "tile-bar": {"tableName": "<UNKNOWN>", "fieldId": "orders.order_date"}
+    }
+
+    canonical = canonicalize_dashboard_filter_targets(
+        DashboardDefinition.model_validate(payload),
+        _orders_context(),
+    )
+
+    rule = canonical.filters.dimensions[0]
+    assert rule.target.tableName == "orders"
+    assert rule.tileTargets is not None
+    assert rule.tileTargets["tile-bar"] is not False
+    assert rule.tileTargets["tile-bar"].tableName == "orders"
+    validate_dashboard_semantics(canonical, _orders_context())
+
+
+def test_unknown_explore_is_recovered_from_exact_unambiguous_field_ids() -> None:
+    payload = _single_bar_definition(drill_dimensions=["orders.customer"]).model_dump(mode="json", by_alias=True)
+    payload["charts"][0]["query"]["exploreName"] = "<UNKNOWN>"
+
+    canonical = canonicalize_dashboard_explore_names(
+        DashboardDefinition.model_validate(payload),
+        _orders_context(),
+    )
+
+    assert canonical.charts[0].query.exploreName == "orders"
+    validate_dashboard_semantics(canonical, _orders_context())
+
+
+def test_unknown_explore_is_not_recovered_from_invented_fields() -> None:
+    payload = _single_bar_definition(drill_dimensions=["orders.customer"]).model_dump(mode="json", by_alias=True)
+    payload["charts"][0]["query"].update({"exploreName": "<UNKNOWN>", "metrics": ["unknown.revenue"]})
+    payload["charts"][0]["visualization"]["config"]["layout"]["yField"] = ["unknown.revenue"]
+    definition = canonicalize_dashboard_explore_names(
+        DashboardDefinition.model_validate(payload),
+        _orders_context(),
+    )
+
+    assert definition.charts[0].query.exploreName == "<UNKNOWN>"
+    with pytest.raises(ValueError, match="Unknown explore: <UNKNOWN>"):
+        validate_dashboard_semantics(definition, _orders_context())
+
+
 def test_time_series_authoring_rejects_an_empty_applicable_date_window() -> None:
     payload = _definition_with_filter().model_dump(mode="json", by_alias=True)
     payload["filters"]["dimensions"][0].update(
@@ -349,6 +397,7 @@ async def test_agent_update_is_forced_through_typed_operations() -> None:
     assert client.request is not None
     assert client.request["tool_choice"] == {"type": "tool", "name": "submit_dashboard_draft"}
     assert "question is a concise natural-language question" in client.request["system"]
+    assert "never invent an explore or use placeholders" in client.request["system"]
     assert "Copy each filter target exactly" in client.request["system"]
     assert "meaningful lower-grain drill hierarchy" in client.request["system"]
     request_payload = json.loads(client.request["messages"][0]["content"])
@@ -540,6 +589,8 @@ async def test_agent_repairs_semantic_validation_failures_before_returning_the_d
     assert len(client.requests) == 2
     repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
     assert "Unknown explore: sales" in repair_payload["validation_feedback"]
+    assert "Valid exploreName values: orders" in repair_payload["validation_feedback"]
+    assert "Never use <UNKNOWN>" in repair_payload["validation_feedback"]
     assert repair_payload["rejected_draft"]["definition"]["charts"][0]["query"]["exploreName"] == "sales"
 
 


### PR DESCRIPTION
## Summary

- recover placeholder chart explore names only when exact governed field IDs identify one unambiguous explore
- recover placeholder filter table names from exact governed dimension IDs
- explicitly list valid explore names in repair feedback and forbid `<UNKNOWN>` placeholders
- retain fail-closed validation for ambiguous or invented fields

## Validation

- `signalpilot/gateway/.venv/bin/pytest -q tests/test_dashboard_authoring.py tests/test_dashboards.py` (56 passed)
- `signalpilot/gateway/.venv/bin/ruff check gateway/dashboard/operations.py gateway/dashboard/authoring.py gateway/api/dashboards.py tests/test_dashboard_authoring.py`
- `git diff --check`