### PR TITLE
fix(dashboard): surface authoring provider failures

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/model_client.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/model_client.py
@@ -2,12 +2,36 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Protocol
 
 import httpx
 
 ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
+_ERROR_DETAIL_MAX_CHARS = 1_000
+
+
+class AnthropicMessagesError(RuntimeError):
+    """Structured upstream failure that never includes credentials or request content."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        error_type: str | None,
+        provider_message: str | None,
+        request_id: str | None,
+        request_body_chars: int,
+        retry_after: str | None,
+    ) -> None:
+        super().__init__(f"Anthropic Messages API request failed with status {status_code}")
+        self.status_code = status_code
+        self.error_type = error_type
+        self.provider_message = provider_message
+        self.request_id = request_id
+        self.request_body_chars = request_body_chars
+        self.retry_after = retry_after
 
 
 class MessagesModelClient(Protocol):
@@ -48,8 +72,47 @@ class AnthropicMessagesClient:
         request_body: dict[str, Any],
     ) -> dict[str, Any]:
         response = await client.post(ANTHROPIC_MESSAGES_URL, headers=headers, json=request_body)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            error_type, provider_message = _anthropic_error(response)
+            raise AnthropicMessagesError(
+                status_code=response.status_code,
+                error_type=error_type,
+                provider_message=provider_message,
+                request_id=response.headers.get("request-id"),
+                request_body_chars=_request_body_chars(request_body),
+                retry_after=response.headers.get("retry-after"),
+            ) from exc
         data = response.json()
         if not isinstance(data, dict):
             raise TypeError("Anthropic Messages API returned a non-object response")
         return data
+
+
+def _anthropic_error(response: httpx.Response) -> tuple[str | None, str | None]:
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            return _clean_detail(error.get("type")), _clean_detail(error.get("message"))
+    return None, _clean_detail(response.text)
+
+
+def _clean_detail(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    detail = " ".join(value.split()).strip()
+    if not detail:
+        return None
+    return detail[:_ERROR_DETAIL_MAX_CHARS]
+
+
+def _request_body_chars(request_body: dict[str, Any]) -> int:
+    try:
+        return len(json.dumps(request_body, ensure_ascii=True, separators=(",", ":")))
+    except (TypeError, ValueError):
+        return -1

--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -13,9 +14,11 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import TypeVar
 
+import httpx
 from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 
+from gateway.analysis_delivery.model_client import AnthropicMessagesError
 from gateway.dashboard import store as dashboard_store
 from gateway.dashboard.authoring import DashboardAuthoringAgent, materialize_agent_draft
 from gateway.dashboard.cache import dashboard_query_cache_key
@@ -87,6 +90,48 @@ from .deps import StoreD
 
 router = APIRouter(prefix="/api")
 resolver = DashboardSemanticResolver()
+logger = logging.getLogger(__name__)
+
+_AUTHORING_PROVIDER_REJECTED = (
+    "Dashboard authoring could not complete because Anthropic rejected the request. "
+    "Try again; if this continues, ask an administrator to verify the Anthropic integration."
+)
+_AUTHORING_PROVIDER_AUTH_REJECTED = (
+    "The organization Anthropic key was rejected. Ask an administrator to update it in Integrations."
+)
+_AUTHORING_PROVIDER_UNAVAILABLE = "Dashboard authoring is temporarily unavailable. Please try again."
+
+
+def _authoring_provider_http_exception(
+    exc: AnthropicMessagesError,
+    *,
+    model: str,
+) -> HTTPException:
+    logger.error(
+        "Dashboard authoring Anthropic request failed status=%s type=%s request_id=%s "
+        "model=%s request_body_chars=%s error=%s",
+        exc.status_code,
+        exc.error_type or "unknown",
+        exc.request_id or "unknown",
+        model,
+        exc.request_body_chars,
+        exc.provider_message or "<empty response body>",
+    )
+    headers = {"Retry-After": exc.retry_after} if exc.retry_after else None
+    if exc.status_code in {401, 403}:
+        return HTTPException(status_code=502, detail=_AUTHORING_PROVIDER_AUTH_REJECTED)
+    if exc.status_code == 429 or exc.status_code >= 500:
+        return HTTPException(status_code=503, detail=_AUTHORING_PROVIDER_UNAVAILABLE, headers=headers)
+    return HTTPException(status_code=502, detail=_AUTHORING_PROVIDER_REJECTED)
+
+
+def _authoring_transport_http_exception(exc: httpx.RequestError, *, model: str) -> HTTPException:
+    logger.error(
+        "Dashboard authoring could not reach Anthropic model=%s error_type=%s",
+        model,
+        type(exc).__name__,
+    )
+    return HTTPException(status_code=503, detail=_AUTHORING_PROVIDER_UNAVAILABLE)
 
 DashboardResultT = TypeVar("DashboardResultT")
 
@@ -711,6 +756,10 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
         definition = canonicalize_dashboard_filter_targets(definition, verified)
         validate_dashboard_semantics(definition, verified)
         validate_time_series_default_windows(definition, verified)
+    except AnthropicMessagesError as exc:
+        raise _authoring_provider_http_exception(exc, model=agent.model) from exc
+    except httpx.RequestError as exc:
+        raise _authoring_transport_http_exception(exc, model=agent.model) from exc
     except (DashboardCompileError, ValueError) as exc:
         await record_dashboard_event(
             store.session,
@@ -852,6 +901,28 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
         validate_time_series_default_windows(definition, verified)
     except HTTPException:
         raise
+    except AnthropicMessagesError as exc:
+        safe_error = _authoring_provider_http_exception(exc, model=agent.model)
+        await dashboard_store.record_authoring_failure(
+            store.session,
+            org_id=org_id,
+            user_id=user_id,
+            session_id=session_id,
+            prompt=body.prompt,
+            safe_message=str(safe_error.detail),
+        )
+        raise safe_error from exc
+    except httpx.RequestError as exc:
+        safe_error = _authoring_transport_http_exception(exc, model=agent.model)
+        await dashboard_store.record_authoring_failure(
+            store.session,
+            org_id=org_id,
+            user_id=user_id,
+            session_id=session_id,
+            prompt=body.prompt,
+            safe_message=str(safe_error.detail),
+        )
+        raise safe_error from exc
     except (DashboardCompileError, ValueError) as exc:
         await dashboard_store.record_authoring_failure(
             store.session,

--- a/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
@@ -1,0 +1,44 @@
+"""Anthropic Messages transport error contracts."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from gateway.analysis_delivery.model_client import AnthropicMessagesClient, AnthropicMessagesError
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_error_preserves_safe_provider_diagnostics() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-api-key"] == "secret-key"
+        return httpx.Response(
+            400,
+            headers={"request-id": "req-provider-1"},
+            json={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "messages.0.content: Input is too long for the model context window",
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        model_client = AnthropicMessagesClient(api_key="secret-key", timeout_seconds=1, http_client=client)
+        with pytest.raises(AnthropicMessagesError) as exc_info:
+            await model_client.create_message(
+                {
+                    "model": "claude-test",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            )
+
+    error = exc_info.value
+    assert error.status_code == 400
+    assert error.error_type == "invalid_request_error"
+    assert error.provider_message == "messages.0.content: Input is too long for the model context window"
+    assert error.request_id == "req-provider-1"
+    assert error.request_body_chars > 0
+    assert "secret-key" not in str(error)

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -10,9 +10,11 @@ from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from gateway.analysis_delivery.model_client import AnthropicMessagesError
 from gateway.api import dashboards as dashboard_api
 from gateway.dashboard import store as dashboard_store
 from gateway.dashboard.authoring import DashboardAgentDraft, DashboardAuthoringAgent, materialize_agent_draft
@@ -378,6 +380,23 @@ class _ModelClient:
         }
 
 
+class _ProviderFailingAgent:
+    model = "claude-provider-test"
+
+    def __init__(self, *, api_key: str) -> None:
+        assert api_key == "test-key"
+
+    async def draft(self, **_kwargs) -> DashboardAgentDraft:
+        raise AnthropicMessagesError(
+            status_code=400,
+            error_type="invalid_request_error",
+            provider_message="messages.0.content: Input is too long for the model context window",
+            request_id="req-provider-1",
+            request_body_chars=250_000,
+            retry_after=None,
+        )
+
+
 @pytest.mark.asyncio
 async def test_agent_update_is_forced_through_typed_operations() -> None:
     client = _ModelClient(
@@ -670,6 +689,98 @@ async def test_create_authoring_session_canonicalizes_model_filter_targets(
     )
 
     assert session.definition.filters.dimensions[0].target.fieldId == "orders.order_date"
+
+
+@pytest.mark.asyncio
+async def test_create_authoring_session_returns_safe_provider_failure(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def resolve_context(*_args, **_kwargs) -> DashboardSemanticContext:
+        return _orders_context()
+
+    async def resolve_key(*_args, **_kwargs) -> str:
+        return "test-key"
+
+    monkeypatch.setattr(dashboard_api.resolver, "resolve", resolve_context)
+    monkeypatch.setattr(dashboard_api, "DashboardAuthoringAgent", _ProviderFailingAgent)
+    monkeypatch.setattr(dashboard_api.org_secrets_store, "resolve_anthropic_key", resolve_key)
+    store = SimpleNamespace(
+        session=db_session,
+        user_id="owner-a",
+        _require_org_id=lambda: "org-a",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dashboard_api.create_dashboard_authoring_session(
+            DashboardAuthoringRequest(
+                prompt="Create an executive dashboard",
+                project_id="project-1",
+                commit_sha="a" * 40,
+            ),
+            store,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == dashboard_api._AUTHORING_PROVIDER_REJECTED
+    assert "Input is too long" not in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_follow_up_provider_failure_preserves_draft_and_records_safe_message(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = _definition_with_filter()
+    preview = await dashboard_store.create_authoring_session(
+        db_session,
+        org_id="org-a",
+        user_id="owner-a",
+        dashboard_id=None,
+        base_version_id=None,
+        definition=definition,
+        operations=[],
+        prompt="Create a dashboard",
+        summary="Created the dashboard.",
+        agent_run_id="run-1",
+        model="test-model",
+        requires_custom_sql_confirmation=False,
+        custom_sql_confirmed=False,
+    )
+
+    async def verified_context(*_args, **_kwargs) -> DashboardSemanticContext:
+        return _orders_context()
+
+    async def resolve_key(*_args, **_kwargs) -> str:
+        return "test-key"
+
+    monkeypatch.setattr(dashboard_api, "_verified_context", verified_context)
+    monkeypatch.setattr(dashboard_api, "DashboardAuthoringAgent", _ProviderFailingAgent)
+    monkeypatch.setattr(dashboard_api.org_secrets_store, "resolve_anthropic_key", resolve_key)
+    store = SimpleNamespace(
+        session=db_session,
+        user_id="owner-a",
+        _require_org_id=lambda: "org-a",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dashboard_api.continue_dashboard_authoring_session(
+            preview.id,
+            DashboardAuthoringMessageRequest(prompt="Add a margin chart"),
+            store,
+        )
+
+    assert exc_info.value.status_code == 502
+    restored = await dashboard_store.get_authoring_session(
+        db_session,
+        org_id="org-a",
+        user_id="owner-a",
+        session_id=preview.id,
+    )
+    assert restored is not None
+    assert restored.definition_json == definition.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert restored.events_json[-1]["message"] == dashboard_api._AUTHORING_PROVIDER_REJECTED
+    assert "Input is too long" not in restored.events_json[-1]["message"]
 
 
 @pytest.mark.asyncio

--- a/signalpilot/web/components/dashboard/dashboard-authoring-panel.test.tsx
+++ b/signalpilot/web/components/dashboard/dashboard-authoring-panel.test.tsx
@@ -28,6 +28,7 @@ vi.mock("~/lib/api", () => ({
 import {
   DashboardAuthoringPanel,
   DashboardAuthoringWorkspace,
+  dashboardAuthoringErrorMessage,
   dashboardRepairPrompt,
   type DashboardAuthoringSession,
 } from "~/components/dashboard/dashboard-authoring-panel";
@@ -191,5 +192,27 @@ describe("DashboardAuthoringWorkspace", () => {
     expect(overlay?.textContent).toContain(
       "the saved dashboard changes only after Apply",
     );
+  });
+});
+
+describe("dashboardAuthoringErrorMessage", () => {
+  it("shows a safe API detail without the raw response envelope", () => {
+    expect(
+      dashboardAuthoringErrorMessage(
+        new Error(
+          '502: {"detail":"Dashboard authoring could not complete because Anthropic rejected the request."}',
+        ),
+      ),
+    ).toBe(
+      "Dashboard authoring could not complete because Anthropic rejected the request.",
+    );
+  });
+
+  it("does not expose an unstructured server response", () => {
+    expect(
+      dashboardAuthoringErrorMessage(
+        new Error("500: provider response contained internal details"),
+      ),
+    ).toBe("The dashboard draft could not be updated. Please try again.");
   });
 });

--- a/signalpilot/web/components/dashboard/dashboard-authoring-panel.tsx
+++ b/signalpilot/web/components/dashboard/dashboard-authoring-panel.tsx
@@ -50,6 +50,34 @@ export type DashboardRepairIssue = {
   message: string;
 };
 
+const AUTHORING_ERROR_FALLBACK =
+  "The dashboard draft could not be updated. Please try again.";
+
+export function dashboardAuthoringErrorMessage(cause: unknown): string {
+  if (!(cause instanceof Error)) return AUTHORING_ERROR_FALLBACK;
+  const response = /^\d{3}:\s*([\s\S]*)$/.exec(cause.message);
+  if (!response) return cause.message || AUTHORING_ERROR_FALLBACK;
+  try {
+    const payload = JSON.parse(response[1]) as {
+      detail?: string | { message?: string };
+    };
+    if (typeof payload.detail === "string" && payload.detail.trim()) {
+      return payload.detail;
+    }
+    if (
+      payload.detail &&
+      typeof payload.detail === "object" &&
+      typeof payload.detail.message === "string" &&
+      payload.detail.message.trim()
+    ) {
+      return payload.detail.message;
+    }
+  } catch {
+    // Never show a raw provider or server response in dashboard authoring.
+  }
+  return AUTHORING_ERROR_FALLBACK;
+}
+
 export function dashboardRepairPrompt(issues: DashboardRepairIssue[]): string {
   const errorList = issues
     .map((issue) => `- ${issue.chartTitle}: ${issue.message}`)
@@ -131,11 +159,7 @@ export function DashboardAuthoringWorkspace({
       onSession(updated);
       return updated;
     } catch (cause) {
-      setError(
-        cause instanceof Error
-          ? cause.message
-          : "The draft could not be updated",
-      );
+      setError(dashboardAuthoringErrorMessage(cause));
       await refreshSession();
     } finally {
       setBusy(false);


### PR DESCRIPTION
## Summary
- capture bounded Anthropic error diagnostics and provider request IDs without credentials or request content
- map dashboard authoring provider failures to safe 502/503 responses instead of uncaught 500s
- preserve the last valid conversational draft and show safe API details in the authoring UI

## Validation
- `uv run ruff check gateway/analysis_delivery/model_client.py gateway/api/dashboards.py tests/test_analysis_delivery_model_client.py tests/test_dashboard_authoring.py`
- `uv run pytest tests/test_analysis_delivery_model_client.py tests/test_dashboard_authoring.py -q` (36 passed)
- `uv run pytest tests/test_analysis_delivery.py tests/test_intake_agent.py tests/test_analysis_delivery_model_client.py -q` (33 passed)
- `pnpm test:unit -- components/dashboard/dashboard-authoring-panel.test.tsx` (123 passed)
- `pnpm exec tsc --noEmit -p tsconfig.dashboard-prototype.json --target es2018`
- `npx --yes prettier@3.6.2 --check components/dashboard/dashboard-authoring-panel.tsx components/dashboard/dashboard-authoring-panel.test.tsx`
- `git diff --check`