### PR TITLE
fix(db): reconcile external Alembic 0015 stamp

### DIFF
--- a/signalpilot/gateway/gateway/db/migrations/versions/0015_external_stamp_compatibility.py
+++ b/signalpilot/gateway/gateway/db/migrations/versions/0015_external_stamp_compatibility.py
@@ -1,0 +1,26 @@
+"""reconcile the externally stamped 0015 revision
+
+The shared staging database was stamped at revision ``0015`` by an image or
+manual operation whose migration files never entered repository history. The
+tracked migration chain ends at ``0013``; the only known ``0014`` belongs to an
+unmerged feature and was not part of the deployed application schema.
+
+This compatibility marker intentionally performs no DDL. Its exact revision ID
+allows Alembic-managed processes to resolve the existing database state and
+keeps future migrations anchored to tracked history again.
+"""
+
+from __future__ import annotations
+
+revision = "0015"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/signalpilot/gateway/tests/test_alembic_migration_graph.py
+++ b/signalpilot/gateway/tests/test_alembic_migration_graph.py
@@ -1,0 +1,17 @@
+"""Fast checks for the packaged gateway Alembic graph."""
+
+from __future__ import annotations
+
+from alembic.script import ScriptDirectory
+
+from gateway.db.migrate import build_alembic_config
+
+
+def test_external_0015_stamp_is_the_tracked_head() -> None:
+    config = build_alembic_config("postgresql://unused:unused@localhost/unused")
+    scripts = ScriptDirectory.from_config(config)
+
+    assert scripts.get_current_head() == "0015"
+    revision = scripts.get_revision("0015")
+    assert revision is not None
+    assert revision.down_revision == "0013"


### PR DESCRIPTION
## Summary
- add a no-op Alembic revision with the exact `0015` ID already recorded by the staging database
- link the compatibility marker directly to tracked head `0013`; the only known `0014` belongs to an unmerged backup branch
- add a fast migration-graph regression test

## Why no DDL
No current branch or historical PR contains revision `0015`. This marker only restores Alembic graph resolution for the externally stamped database; it does not claim or recreate the abandoned `0014_dbt_manifests` feature.

## Validation
- `uv run ruff check gateway/db/migrations/versions/0015_external_stamp_compatibility.py tests/test_alembic_migration_graph.py`
- `uv run pytest tests/test_alembic_migration_graph.py -q` (1 passed)
- `SP_TEST_MIGRATION_PG_ADMIN_DSN=... uv run pytest tests/test_alembic_schema_parity.py -q` (3 passed against local PostgreSQL 17)
- `git diff --check`