### PR TITLE
fix(db): reconcile external Alembic 0016 stamp

### DIFF
--- a/signalpilot/gateway/gateway/db/migrations/versions/0016_external_stamp_compatibility.py
+++ b/signalpilot/gateway/gateway/db/migrations/versions/0016_external_stamp_compatibility.py
@@ -1,0 +1,25 @@
+"""reconcile the externally stamped 0016 revision
+
+The staging database reports revision ``0016``, but no migration with that
+identifier exists in repository history. Revision ``0015`` is already tracked
+as a compatibility marker for the same externally managed migration chain.
+
+This compatibility marker intentionally performs no DDL. It lets Alembic
+resolve the database's existing revision without making assumptions about the
+schema operation that originally stamped it.
+"""
+
+from __future__ import annotations
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/signalpilot/gateway/tests/test_alembic_migration_graph.py
+++ b/signalpilot/gateway/tests/test_alembic_migration_graph.py
@@ -7,11 +7,16 @@ from alembic.script import ScriptDirectory
 from gateway.db.migrate import build_alembic_config
 
 
-def test_external_0015_stamp_is_the_tracked_head() -> None:
+def test_external_stamp_compatibility_chain_is_the_tracked_head() -> None:
     config = build_alembic_config("postgresql://unused:unused@localhost/unused")
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_current_head() == "0015"
-    revision = scripts.get_revision("0015")
-    assert revision is not None
-    assert revision.down_revision == "0013"
+    assert scripts.get_current_head() == "0016"
+
+    revision_0016 = scripts.get_revision("0016")
+    assert revision_0016 is not None
+    assert revision_0016.down_revision == "0015"
+
+    revision_0015 = scripts.get_revision("0015")
+    assert revision_0015 is not None
+    assert revision_0015.down_revision == "0013"


### PR DESCRIPTION
## Summary

- add a no-op Alembic compatibility revision for the staging database's confirmed `0016` stamp
- anchor `0016` to the existing `0015` compatibility marker
- update the migration-graph regression test to assert the complete compatibility chain

## Evidence

The staging database currently reports:

```sql
SELECT version_num FROM gateway_alembic_version;
-- 0016
```

No migration with revision `0016` exists on `dev`, `main`, `staging`, `prod`, open/recent branch refs, PR refs, or reachable repository history. This migration intentionally performs no DDL.

## Validation

- `uv run ruff check gateway/db/migrations/versions/0016_external_stamp_compatibility.py tests/test_alembic_migration_graph.py`
- `uv run pytest -q tests/test_alembic_migration_graph.py`
- direct Alembic graph inspection: head `0016`, chain `0016 -> 0015 -> 0013`
- schema-parity tests discovered but skipped because `SP_TEST_MIGRATION_PG_ADMIN_DSN` is unavailable in this session

Follow-up to #292.