### PR TITLE
fix(dashboard): honor forced OAuth for authoring

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/model_client.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/model_client.py
@@ -46,20 +46,28 @@ class AnthropicMessagesClient:
     def __init__(
         self,
         *,
-        api_key: str,
+        api_key: str | None = None,
+        oauth_token: str | None = None,
         timeout_seconds: float,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
+        if api_key and oauth_token:
+            raise ValueError("Configure only one Anthropic credential")
         self.api_key = api_key
+        self.oauth_token = oauth_token
         self.timeout_seconds = max(float(timeout_seconds), 0.1)
         self._http_client = http_client
 
     async def create_message(self, request_body: dict[str, Any]) -> dict[str, Any]:
         headers = {
-            "x-api-key": self.api_key,
             "anthropic-version": ANTHROPIC_VERSION,
             "content-type": "application/json",
         }
+        if self.oauth_token:
+            headers["authorization"] = f"Bearer {self.oauth_token}"
+            headers["anthropic-beta"] = "oauth-2025-04-20"
+        else:
+            headers["x-api-key"] = self.api_key or ""
         if self._http_client is not None:
             return await self._post(self._http_client, headers, request_body)
         async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:

--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -19,6 +20,7 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 
 from gateway.analysis_delivery.model_client import AnthropicMessagesError
+from gateway.config.notebooks import chat_force_oauth_token
 from gateway.dashboard import store as dashboard_store
 from gateway.dashboard.authoring import DashboardAuthoringAgent, materialize_agent_draft
 from gateway.dashboard.cache import dashboard_query_cache_key
@@ -99,6 +101,9 @@ _AUTHORING_PROVIDER_REJECTED = (
 _AUTHORING_PROVIDER_AUTH_REJECTED = (
     "The organization Anthropic key was rejected. Ask an administrator to update it in Integrations."
 )
+_AUTHORING_PROVIDER_OAUTH_REJECTED = (
+    "The configured Claude OAuth token was rejected. Ask an operator to refresh it."
+)
 _AUTHORING_PROVIDER_UNAVAILABLE = "Dashboard authoring is temporarily unavailable. Please try again."
 
 
@@ -106,6 +111,7 @@ def _authoring_provider_http_exception(
     exc: AnthropicMessagesError,
     *,
     model: str,
+    uses_oauth: bool = False,
 ) -> HTTPException:
     logger.error(
         "Dashboard authoring Anthropic request failed status=%s type=%s request_id=%s "
@@ -119,7 +125,8 @@ def _authoring_provider_http_exception(
     )
     headers = {"Retry-After": exc.retry_after} if exc.retry_after else None
     if exc.status_code in {401, 403}:
-        return HTTPException(status_code=502, detail=_AUTHORING_PROVIDER_AUTH_REJECTED)
+        detail = _AUTHORING_PROVIDER_OAUTH_REJECTED if uses_oauth else _AUTHORING_PROVIDER_AUTH_REJECTED
+        return HTTPException(status_code=502, detail=detail)
     if exc.status_code == 429 or exc.status_code >= 500:
         return HTTPException(status_code=503, detail=_AUTHORING_PROVIDER_UNAVAILABLE, headers=headers)
     return HTTPException(status_code=502, detail=_AUTHORING_PROVIDER_REJECTED)
@@ -134,6 +141,23 @@ def _authoring_transport_http_exception(exc: httpx.RequestError, *, model: str) 
     return HTTPException(status_code=503, detail=_AUTHORING_PROVIDER_UNAVAILABLE)
 
 DashboardResultT = TypeVar("DashboardResultT")
+
+
+async def _dashboard_authoring_agent(store: StoreD, org_id: str) -> tuple[DashboardAuthoringAgent, bool]:
+    """Resolve authoring auth with the same fail-closed force-OAuth behavior as Data Chat."""
+    if chat_force_oauth_token():
+        oauth_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN") or os.getenv("OAUTH_TOKEN")
+        if not oauth_token:
+            raise HTTPException(
+                status_code=409,
+                detail="SP_CHAT_FORCE_OAUTH_TOKEN is enabled but no Claude OAuth token is configured",
+            )
+        return DashboardAuthoringAgent(oauth_token=oauth_token), True
+
+    api_key = await org_secrets_store.resolve_anthropic_key(store.session, org_id)
+    if not api_key:
+        raise HTTPException(status_code=409, detail="Dashboard authoring requires the organization Anthropic key")
+    return DashboardAuthoringAgent(api_key=api_key), False
 
 
 def _visualization_type(chart) -> str:
@@ -712,10 +736,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
         context = await resolver.resolve(store, project_id=project_id, commit_sha=commit_sha)
     except DashboardSemanticError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    api_key = await org_secrets_store.resolve_anthropic_key(store.session, org_id)
-    if not api_key:
-        raise HTTPException(status_code=409, detail="Dashboard authoring requires the organization Anthropic key")
-    agent = DashboardAuthoringAgent(api_key=api_key)
+    agent, uses_oauth = await _dashboard_authoring_agent(store, org_id)
     try:
         def validate_candidate(candidate):
             candidate_definition = materialize_agent_draft(candidate, base_definition=base_definition)
@@ -757,7 +778,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
         validate_dashboard_semantics(definition, verified)
         validate_time_series_default_windows(definition, verified)
     except AnthropicMessagesError as exc:
-        raise _authoring_provider_http_exception(exc, model=agent.model) from exc
+        raise _authoring_provider_http_exception(exc, model=agent.model, uses_oauth=uses_oauth) from exc
     except httpx.RequestError as exc:
         raise _authoring_transport_http_exception(exc, model=agent.model) from exc
     except (DashboardCompileError, ValueError) as exc:
@@ -876,10 +897,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
         base_version_id = row.base_version_id
     try:
         context = await _verified_context(store, current_definition)
-        api_key = await org_secrets_store.resolve_anthropic_key(store.session, org_id)
-        if not api_key:
-            raise HTTPException(status_code=409, detail="Dashboard authoring requires the organization Anthropic key")
-        agent = DashboardAuthoringAgent(api_key=api_key)
+        agent, uses_oauth = await _dashboard_authoring_agent(store, org_id)
         def validate_candidate(candidate):
             candidate_definition = materialize_agent_draft(candidate, base_definition=current_definition)
             candidate_definition = canonicalize_dashboard_explore_names(candidate_definition, context)
@@ -902,7 +920,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
     except HTTPException:
         raise
     except AnthropicMessagesError as exc:
-        safe_error = _authoring_provider_http_exception(exc, model=agent.model)
+        safe_error = _authoring_provider_http_exception(exc, model=agent.model, uses_oauth=uses_oauth)
         await dashboard_store.record_authoring_failure(
             store.session,
             org_id=org_id,

--- a/signalpilot/gateway/gateway/config/notebooks.py
+++ b/signalpilot/gateway/gateway/config/notebooks.py
@@ -24,11 +24,12 @@ KNOWN_BACKENDS = ("", "vercel", "direct")
 
 
 def chat_force_oauth_token() -> bool:
-    """Whether standalone chat must use the gateway's Claude OAuth token.
+    """Whether interactive AI product paths must use the gateway's Claude OAuth token.
 
-    Force mode is deliberately separate from normal credential precedence. A
-    user chat fails closed when the token is missing, and its notebook process
-    is launched without the organization's Anthropic API key.
+    Force mode is deliberately separate from normal credential precedence.
+    Data Chat and governed dashboard authoring fail closed when the token is
+    missing, and chat notebooks launch without the organization's Anthropic API
+    key. Automated improvement runs remain separately credentialed.
     """
     return os.getenv("SP_CHAT_FORCE_OAUTH_TOKEN", "").strip().lower() in {
         "1",

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -118,9 +118,19 @@ def charts_missing_usable_drills(
 
 
 class DashboardAuthoringAgent:
-    def __init__(self, *, api_key: str, model_client: MessagesModelClient | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        oauth_token: str | None = None,
+        model_client: MessagesModelClient | None = None,
+    ) -> None:
         self.model = os.getenv("SIGNALPILOT_DASHBOARD_AUTHORING_MODEL") or DEFAULT_DASHBOARD_AUTHORING_MODEL
-        self.model_client = model_client or AnthropicMessagesClient(api_key=api_key, timeout_seconds=90)
+        self.model_client = model_client or AnthropicMessagesClient(
+            api_key=api_key,
+            oauth_token=oauth_token,
+            timeout_seconds=90,
+        )
 
     async def draft(
         self,

--- a/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
@@ -42,3 +42,37 @@ async def test_anthropic_messages_error_preserves_safe_provider_diagnostics() ->
     assert error.request_id == "req-provider-1"
     assert error.request_body_chars > 0
     assert "secret-key" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_client_uses_oauth_bearer_headers() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer oauth-token"
+        assert request.headers["anthropic-beta"] == "oauth-2025-04-20"
+        assert "x-api-key" not in request.headers
+        return httpx.Response(200, json={"content": []})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        model_client = AnthropicMessagesClient(
+            oauth_token="oauth-token",
+            timeout_seconds=1,
+            http_client=client,
+        )
+        response = await model_client.create_message(
+            {
+                "model": "claude-test",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+        )
+
+    assert response == {"content": []}
+
+
+def test_anthropic_messages_client_rejects_conflicting_credentials() -> None:
+    with pytest.raises(ValueError, match="only one Anthropic credential"):
+        AnthropicMessagesClient(
+            api_key="api-key",
+            oauth_token="oauth-token",
+            timeout_seconds=1,
+        )

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -692,6 +692,75 @@ async def test_create_authoring_session_canonicalizes_model_filter_targets(
 
 
 @pytest.mark.asyncio
+async def test_create_authoring_session_force_oauth_never_resolves_org_api_key(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_definition = _definition_with_filter()
+
+    class OAuthAuthoringAgent:
+        model = "test-model"
+
+        def __init__(self, *, oauth_token: str) -> None:
+            assert oauth_token == "oauth-token"
+
+        async def draft(self, **_kwargs) -> DashboardAgentDraft:
+            return DashboardAgentDraft(
+                summary="Created a dashboard using forced OAuth.",
+                definition=model_definition,
+            )
+
+    async def resolve_context(*_args, **_kwargs) -> DashboardSemanticContext:
+        return _orders_context()
+
+    async def reject_org_key(*_args, **_kwargs) -> str:
+        raise AssertionError("organization key must not be resolved")
+
+    monkeypatch.setenv("SP_CHAT_FORCE_OAUTH_TOKEN", "true")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+    monkeypatch.setattr(dashboard_api.resolver, "resolve", resolve_context)
+    monkeypatch.setattr(dashboard_api, "DashboardAuthoringAgent", OAuthAuthoringAgent)
+    monkeypatch.setattr(dashboard_api.org_secrets_store, "resolve_anthropic_key", reject_org_key)
+    store = SimpleNamespace(
+        session=db_session,
+        user_id="owner-a",
+        _require_org_id=lambda: "org-a",
+    )
+
+    session = await dashboard_api.create_dashboard_authoring_session(
+        DashboardAuthoringRequest(
+            prompt="Create an executive dashboard",
+            project_id=model_definition.signalPilot.projectId,
+            commit_sha=model_definition.signalPilot.commitSha,
+        ),
+        store,
+    )
+
+    assert session.summary == "Created a dashboard using forced OAuth."
+
+
+@pytest.mark.asyncio
+async def test_dashboard_authoring_force_oauth_fails_closed_when_token_is_missing(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def reject_org_key(*_args, **_kwargs) -> str:
+        raise AssertionError("organization key must not be resolved")
+
+    monkeypatch.setenv("SP_CHAT_FORCE_OAUTH_TOKEN", "true")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr(dashboard_api.org_secrets_store, "resolve_anthropic_key", reject_org_key)
+    store = SimpleNamespace(session=db_session)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dashboard_api._dashboard_authoring_agent(store, "org-a")
+
+    assert exc_info.value.status_code == 409
+    assert "no Claude OAuth token" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_create_authoring_session_returns_safe_provider_failure(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- route governed dashboard creation and follow-up authoring through Claude OAuth when `SP_CHAT_FORCE_OAUTH_TOKEN=true`
- bypass the organization Anthropic key in forced mode and fail closed when no OAuth token is configured
- add OAuth Bearer transport support and OAuth-specific provider error guidance
- keep normal organization-key behavior and improvement-run credential routing unchanged

## Validation

- `64 passed` across dashboard authoring, shared Anthropic transport, Data Chat forced OAuth, notebook credential isolation, and analysis delivery
- `ruff check` passed
- `git diff --check` passed