### PR TITLE
fix(db): tolerate a schema stamped by newer code at boot

### DIFF
--- a/signalpilot/gateway/gateway/db/engine.py
+++ b/signalpilot/gateway/gateway/db/engine.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from .legacy_bootstrap import run_legacy_bootstrap
-from .migrate import stamp_head, upgrade_to_head
+from .migrate import stamp_head, upgrade_to_head_tolerating_newer
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ async def init_db() -> None:
                 await run_legacy_bootstrap(engine)
                 await asyncio.to_thread(stamp_head, database_url)
             else:
-                await asyncio.to_thread(upgrade_to_head, database_url)
+                await asyncio.to_thread(upgrade_to_head_tolerating_newer, database_url)
         finally:
             await conn.execute(text("SELECT pg_advisory_unlock(hashtext('gateway_schema_migration'))"))
     from gateway.store.chat_reports import backfill_inline_artifact_hashes

--- a/signalpilot/gateway/gateway/db/migrate.py
+++ b/signalpilot/gateway/gateway/db/migrate.py
@@ -44,3 +44,29 @@ def stamp_head(database_url: str) -> None:
     """
     command.stamp(build_alembic_config(database_url), "head")
     logger.info("Gateway schema stamped at Alembic head")
+
+
+def upgrade_to_head_tolerating_newer(database_url: str) -> None:
+    """Upgrade to head, but tolerate a database stamped with a revision this
+    build does not know.
+
+    A shared database can be migrated ahead of a deployment by newer code
+    (another environment, or a developer branch booted against the same
+    database). Migrations are additive and backward-compatible by policy, so
+    running against an unknown-newer schema is safe; crashing at boot would
+    take the environment down with no benefit. Any genuinely incompatible
+    schema change surfaces later as a loud query error instead.
+    """
+    from alembic.util.exc import CommandError
+
+    try:
+        upgrade_to_head(database_url)
+    except CommandError as exc:
+        if "Can't locate revision" not in str(exc):
+            raise
+        logger.warning(
+            "Database schema revision is not known to this build (%s). "
+            "Assuming a newer deployment migrated the schema; continuing "
+            "without running migrations.",
+            exc,
+        )

--- a/signalpilot/gateway/tests/test_migrate_forward_schema_tolerance.py
+++ b/signalpilot/gateway/tests/test_migrate_forward_schema_tolerance.py
@@ -1,0 +1,32 @@
+"""Boot must survive a database stamped by newer code (unknown revision)."""
+
+import pytest
+from alembic.util.exc import CommandError
+
+from gateway.db import migrate
+
+
+def test_unknown_newer_revision_warns_instead_of_raising(monkeypatch, caplog):
+    def _raise_unknown(url: str) -> None:
+        raise CommandError("Can't locate revision identified by '9999'")
+
+    monkeypatch.setattr(migrate, "upgrade_to_head", _raise_unknown)
+    with caplog.at_level("WARNING"):
+        migrate.upgrade_to_head_tolerating_newer("postgresql://x/y")
+    assert "not known to this build" in caplog.text
+
+
+def test_other_alembic_errors_still_raise(monkeypatch):
+    def _raise_other(url: str) -> None:
+        raise CommandError("Target database is not up to date.")
+
+    monkeypatch.setattr(migrate, "upgrade_to_head", _raise_other)
+    with pytest.raises(CommandError):
+        migrate.upgrade_to_head_tolerating_newer("postgresql://x/y")
+
+
+def test_success_path_passes_through(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(migrate, "upgrade_to_head", calls.append)
+    migrate.upgrade_to_head_tolerating_newer("postgresql://x/y")
+    assert calls == ["postgresql://x/y"]


### PR DESCRIPTION
Staging crash-looped today because the shared DB was at revision 0017 (from the notebook-runtime-v2 branch) while staging's build only knows 0016 — Alembic throws "Can't locate revision" at startup. Migrations are additive/backward-compatible by policy, so an unknown-newer revision now logs a warning and boots instead of dying. Any other Alembic error still raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)