### PR TITLE
Fix dashboard OAuth authoring through Claude Agent SDK

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/model_client.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/model_client.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import os
+import tempfile
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 import httpx
@@ -41,20 +46,16 @@ class MessagesModelClient(Protocol):
 
 
 class AnthropicMessagesClient:
-    """Call Anthropic Messages with shared auth, timeout, and response handling."""
+    """Call Anthropic Messages with an API key, timeout, and response handling."""
 
     def __init__(
         self,
         *,
         api_key: str | None = None,
-        oauth_token: str | None = None,
         timeout_seconds: float,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
-        if api_key and oauth_token:
-            raise ValueError("Configure only one Anthropic credential")
         self.api_key = api_key
-        self.oauth_token = oauth_token
         self.timeout_seconds = max(float(timeout_seconds), 0.1)
         self._http_client = http_client
 
@@ -62,12 +63,8 @@ class AnthropicMessagesClient:
         headers = {
             "anthropic-version": ANTHROPIC_VERSION,
             "content-type": "application/json",
+            "x-api-key": self.api_key or "",
         }
-        if self.oauth_token:
-            headers["authorization"] = f"Bearer {self.oauth_token}"
-            headers["anthropic-beta"] = "oauth-2025-04-20"
-        else:
-            headers["x-api-key"] = self.api_key or ""
         if self._http_client is not None:
             return await self._post(self._http_client, headers, request_body)
         async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
@@ -96,6 +93,186 @@ class AnthropicMessagesClient:
         if not isinstance(data, dict):
             raise TypeError("Anthropic Messages API returned a non-object response")
         return data
+
+
+@dataclass(frozen=True)
+class ClaudeAgentSDKResult:
+    """Provider-neutral subset of a completed Claude Agent SDK query."""
+
+    structured_output: Any
+    is_error: bool
+    api_error_status: int | None = None
+    error_type: str | None = None
+    provider_message: str | None = None
+    request_id: str | None = None
+    usage: dict[str, Any] | None = None
+
+
+ClaudeAgentSDKRunner = Callable[[str, dict[str, Any]], Awaitable[ClaudeAgentSDKResult]]
+
+
+class ClaudeAgentSDKStructuredClient:
+    """Run OAuth-backed structured output through Claude Code's supported SDK."""
+
+    def __init__(
+        self,
+        *,
+        oauth_token: str,
+        timeout_seconds: float,
+        query_runner: ClaudeAgentSDKRunner | None = None,
+    ) -> None:
+        if not oauth_token:
+            raise ValueError("Claude OAuth token is required")
+        self.oauth_token = oauth_token
+        self.timeout_seconds = max(float(timeout_seconds), 0.1)
+        self._query_runner = query_runner or _run_claude_agent_sdk_query
+
+    async def create_message(self, request_body: dict[str, Any]) -> dict[str, Any]:
+        prompt, system, tool_name, schema = _structured_request(request_body)
+        agent_env = dict(os.environ)
+        agent_env.update(
+            {
+                "ANTHROPIC_API_KEY": "",
+                "ANTHROPIC_AUTH_TOKEN": "",
+                "OAUTH_TOKEN": "",
+                "CLAUDE_CODE_OAUTH_TOKEN": self.oauth_token,
+            }
+        )
+        with tempfile.TemporaryDirectory(prefix="signalpilot-dashboard-authoring-") as runtime_dir:
+            agent_env["CLAUDE_CONFIG_DIR"] = runtime_dir
+            options = {
+                "model": request_body.get("model"),
+                "max_turns": 1,
+                "permission_mode": "dontAsk",
+                "tools": [],
+                "setting_sources": ["user"],
+                "system_prompt": {
+                    "type": "preset",
+                    "preset": "claude_code",
+                    "append": system,
+                },
+                "output_format": {"type": "json_schema", "schema": schema},
+                "cwd": runtime_dir,
+                "env": agent_env,
+                "effort": _agent_effort(),
+            }
+            try:
+                async with asyncio.timeout(self.timeout_seconds):
+                    result = await self._query_runner(prompt, options)
+            except TimeoutError as exc:
+                raise _sdk_error(
+                    request_body,
+                    status_code=504,
+                    error_type="claude_agent_sdk_timeout",
+                    provider_message="Claude Agent SDK request timed out",
+                ) from exc
+            except AnthropicMessagesError:
+                raise
+            except Exception as exc:
+                raise _sdk_error(
+                    request_body,
+                    status_code=503,
+                    error_type="claude_agent_sdk_transport_error",
+                    provider_message=type(exc).__name__,
+                ) from exc
+
+        if result.is_error:
+            raise _sdk_error(
+                request_body,
+                status_code=result.api_error_status or 502,
+                error_type=result.error_type or "claude_agent_sdk_error",
+                provider_message=result.provider_message,
+                request_id=result.request_id,
+            )
+        if result.structured_output is None:
+            raise _sdk_error(
+                request_body,
+                status_code=502,
+                error_type="missing_structured_output",
+                provider_message="Claude Agent SDK returned no structured output",
+                request_id=result.request_id,
+            )
+        return {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": tool_name,
+                    "input": result.structured_output,
+                }
+            ],
+            "usage": result.usage or {},
+        }
+
+
+async def _run_claude_agent_sdk_query(prompt: str, options: dict[str, Any]) -> ClaudeAgentSDKResult:
+    from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
+
+    completed = None
+    async for message in query(prompt=prompt, options=ClaudeAgentOptions(**options)):
+        if isinstance(message, ResultMessage):
+            completed = message
+    if completed is None:
+        raise RuntimeError("Claude Agent SDK query ended without a result")
+    errors = getattr(completed, "errors", None)
+    provider_message = completed.result
+    if not provider_message and isinstance(errors, list):
+        provider_message = "; ".join(str(error) for error in errors)
+    return ClaudeAgentSDKResult(
+        structured_output=completed.structured_output,
+        is_error=completed.is_error,
+        api_error_status=completed.api_error_status,
+        error_type=completed.subtype,
+        provider_message=_clean_detail(provider_message),
+        request_id=completed.uuid or completed.session_id,
+        usage=completed.usage if isinstance(completed.usage, dict) else None,
+    )
+
+
+def _structured_request(request_body: dict[str, Any]) -> tuple[str, str, str, dict[str, Any]]:
+    system = request_body.get("system")
+    messages = request_body.get("messages")
+    tools = request_body.get("tools")
+    tool_choice = request_body.get("tool_choice")
+    if not isinstance(system, str) or not isinstance(messages, list) or not messages:
+        raise ValueError("Claude Agent SDK structured request requires system and messages")
+    if not isinstance(tool_choice, dict) or not isinstance(tool_choice.get("name"), str):
+        raise ValueError("Claude Agent SDK structured request requires a named tool choice")
+    tool_name = tool_choice["name"]
+    tool = next(
+        (item for item in tools or [] if isinstance(item, dict) and item.get("name") == tool_name),
+        None,
+    )
+    if not isinstance(tool, dict) or not isinstance(tool.get("input_schema"), dict):
+        raise ValueError("Claude Agent SDK structured request requires a tool input schema")
+    prompt_parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict) or not isinstance(message.get("content"), str):
+            raise ValueError("Claude Agent SDK structured request supports text messages only")
+        prompt_parts.append(message["content"])
+    return "\n\n".join(prompt_parts), system, tool_name, tool["input_schema"]
+
+
+def _agent_effort() -> str:
+    effort = os.getenv("SP_AGENT_EFFORT", "medium").strip().lower()
+    return effort if effort in {"low", "medium", "high", "xhigh", "max"} else "medium"
+
+
+def _sdk_error(
+    request_body: dict[str, Any],
+    *,
+    status_code: int,
+    error_type: str,
+    provider_message: str | None,
+    request_id: str | None = None,
+) -> AnthropicMessagesError:
+    return AnthropicMessagesError(
+        status_code=status_code,
+        error_type=error_type,
+        provider_message=_clean_detail(provider_message),
+        request_id=request_id,
+        request_body_chars=_request_body_chars(request_body),
+        retry_after=None,
+    )
 
 
 def _anthropic_error(response: httpx.Response) -> tuple[str | None, str | None]:

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -10,7 +10,11 @@ from typing import Any
 
 from pydantic import Field, model_validator
 
-from gateway.analysis_delivery.model_client import AnthropicMessagesClient, MessagesModelClient
+from gateway.analysis_delivery.model_client import (
+    AnthropicMessagesClient,
+    ClaudeAgentSDKStructuredClient,
+    MessagesModelClient,
+)
 from gateway.dashboard.domain import CartesianChartConfig, ContractModel, DashboardDefinition, SemanticChartQuery
 from gateway.dashboard.operations import DashboardOperation, apply_dashboard_operations
 from gateway.models.dashboards import DashboardSemanticContext
@@ -125,12 +129,18 @@ class DashboardAuthoringAgent:
         oauth_token: str | None = None,
         model_client: MessagesModelClient | None = None,
     ) -> None:
+        if api_key and oauth_token:
+            raise ValueError("Configure only one dashboard authoring credential")
         self.model = os.getenv("SIGNALPILOT_DASHBOARD_AUTHORING_MODEL") or DEFAULT_DASHBOARD_AUTHORING_MODEL
-        self.model_client = model_client or AnthropicMessagesClient(
-            api_key=api_key,
-            oauth_token=oauth_token,
-            timeout_seconds=90,
-        )
+        if model_client is not None:
+            self.model_client = model_client
+        elif oauth_token:
+            self.model_client = ClaudeAgentSDKStructuredClient(
+                oauth_token=oauth_token,
+                timeout_seconds=90,
+            )
+        else:
+            self.model_client = AnthropicMessagesClient(api_key=api_key, timeout_seconds=90)
 
     async def draft(
         self,

--- a/signalpilot/gateway/gateway/standalone_chat/dbt_executor.py
+++ b/signalpilot/gateway/gateway/standalone_chat/dbt_executor.py
@@ -463,10 +463,17 @@ async def sync_from_agent_sandbox(agent_sandbox_id: str, executor_sandbox_id: st
         size = -1
     if size > _MAX_SYNC_TAR_BYTES:
         raise DbtExecutorError(f"workspace too large to sync ({size} bytes)")
-    data = await runtime.read_file(agent_sandbox_id, "/tmp/sp-sync.tgz")
+    data = await runtime.read_file(
+        agent_sandbox_id,
+        "/tmp/sp-sync.tgz",  # nosec B108 - fixed path is inside an isolated sandbox
+    )
     if data is None:
         raise DbtExecutorError("agent workspace tarball disappeared")
-    await runtime.write_file(executor_sandbox_id, "/tmp/sp-sync.tgz", data)
+    await runtime.write_file(
+        executor_sandbox_id,
+        "/tmp/sp-sync.tgz",  # nosec B108 - fixed path is inside an isolated sandbox
+        data,
+    )
     unpack = await runtime.exec(
         executor_sandbox_id,
         "tar xzf /tmp/sp-sync.tgz -C /workspace && rm -f /tmp/sp-sync.tgz",

--- a/signalpilot/gateway/pyproject.toml
+++ b/signalpilot/gateway/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     # Vercel Sandbox runtime for automated improvement runs
     "vercel>=0.9.0,<1",
     "alembic>=1.13",
+    # Match the proven notebook/Data Chat OAuth runtime.
+    "claude-agent-sdk==0.1.81",
 ]
 
 [project.optional-dependencies]

--- a/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import os
+
 import httpx
 import pytest
 
-from gateway.analysis_delivery.model_client import AnthropicMessagesClient, AnthropicMessagesError
+from gateway.analysis_delivery.model_client import (
+    AnthropicMessagesClient,
+    AnthropicMessagesError,
+    ClaudeAgentSDKResult,
+    ClaudeAgentSDKStructuredClient,
+)
 
 
 @pytest.mark.asyncio
@@ -45,34 +52,93 @@ async def test_anthropic_messages_error_preserves_safe_provider_diagnostics() ->
 
 
 @pytest.mark.asyncio
-async def test_anthropic_messages_client_uses_oauth_bearer_headers() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        assert request.headers["authorization"] == "Bearer oauth-token"
-        assert request.headers["anthropic-beta"] == "oauth-2025-04-20"
-        assert "x-api-key" not in request.headers
-        return httpx.Response(200, json={"content": []})
+async def test_claude_agent_sdk_client_uses_claude_code_contract_for_oauth() -> None:
+    captured: dict = {}
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        model_client = AnthropicMessagesClient(
-            oauth_token="oauth-token",
-            timeout_seconds=1,
-            http_client=client,
+    async def runner(prompt: str, options: dict) -> ClaudeAgentSDKResult:
+        captured.update(prompt=prompt, options=options)
+        assert os.path.isdir(options["cwd"])
+        assert options["env"]["CLAUDE_CONFIG_DIR"] == options["cwd"]
+        return ClaudeAgentSDKResult(
+            structured_output={"summary": "Created it", "definition": {"name": "Revenue"}},
+            is_error=False,
+            usage={"input_tokens": 10},
         )
-        response = await model_client.create_message(
+
+    client = ClaudeAgentSDKStructuredClient(
+        oauth_token="oauth-token",
+        timeout_seconds=1,
+        query_runner=runner,
+    )
+    response = await client.create_message(
+        {
+            "model": "claude-test",
+            "max_tokens": 100,
+            "system": "Stay governed.",
+            "messages": [{"role": "user", "content": "build a dashboard"}],
+            "tools": [{"name": "submit", "input_schema": {"type": "object"}}],
+            "tool_choice": {"type": "tool", "name": "submit"},
+        }
+    )
+
+    options = captured["options"]
+    assert captured["prompt"] == "build a dashboard"
+    assert options["system_prompt"] == {
+        "type": "preset",
+        "preset": "claude_code",
+        "append": "Stay governed.",
+    }
+    assert options["setting_sources"] == ["user"]
+    assert options["tools"] == []
+    assert options["permission_mode"] == "dontAsk"
+    assert options["output_format"] == {"type": "json_schema", "schema": {"type": "object"}}
+    assert options["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-token"
+    assert options["env"]["ANTHROPIC_API_KEY"] == ""
+    assert options["env"]["ANTHROPIC_AUTH_TOKEN"] == ""
+    assert options["env"]["OAUTH_TOKEN"] == ""
+    assert not os.path.exists(options["cwd"])
+    assert response == {
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "submit",
+                "input": {"summary": "Created it", "definition": {"name": "Revenue"}},
+            }
+        ],
+        "usage": {"input_tokens": 10},
+    }
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_sdk_client_preserves_safe_api_failure_status() -> None:
+    async def runner(_prompt: str, _options: dict) -> ClaudeAgentSDKResult:
+        return ClaudeAgentSDKResult(
+            structured_output=None,
+            is_error=True,
+            api_error_status=429,
+            error_type="rate_limit_error",
+            provider_message="Rate limited",
+            request_id="sdk-request-1",
+        )
+
+    client = ClaudeAgentSDKStructuredClient(
+        oauth_token="oauth-token",
+        timeout_seconds=1,
+        query_runner=runner,
+    )
+    with pytest.raises(AnthropicMessagesError) as exc_info:
+        await client.create_message(
             {
                 "model": "claude-test",
-                "max_tokens": 100,
-                "messages": [{"role": "user", "content": "hello"}],
+                "system": "Stay governed.",
+                "messages": [{"role": "user", "content": "build a dashboard"}],
+                "tools": [{"name": "submit", "input_schema": {"type": "object"}}],
+                "tool_choice": {"type": "tool", "name": "submit"},
             }
         )
 
-    assert response == {"content": []}
-
-
-def test_anthropic_messages_client_rejects_conflicting_credentials() -> None:
-    with pytest.raises(ValueError, match="only one Anthropic credential"):
-        AnthropicMessagesClient(
-            api_key="api-key",
-            oauth_token="oauth-token",
-            timeout_seconds=1,
-        )
+    error = exc_info.value
+    assert error.status_code == 429
+    assert error.error_type == "rate_limit_error"
+    assert error.request_id == "sdk-request-1"
+    assert "oauth-token" not in str(error)

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from gateway.analysis_delivery.model_client import AnthropicMessagesError
+from gateway.analysis_delivery.model_client import AnthropicMessagesError, ClaudeAgentSDKStructuredClient
 from gateway.api import dashboards as dashboard_api
 from gateway.dashboard import store as dashboard_store
 from gateway.dashboard.authoring import DashboardAgentDraft, DashboardAuthoringAgent, materialize_agent_draft
@@ -156,9 +156,7 @@ async def _seed_apply_receipts(
     receipt_dashboard_id = dashboard_id or preview.dashboard_id or f"draft:{preview.id}"
     receipt_version_id = version_id or f"draft:{preview.id}"
     requested_filters = [
-        rule
-        for rule in definition.filters.dimensions
-        if rule.values or rule.operator in {"isNull", "notNull"}
+        rule for rule in definition.filters.dimensions if rule.values or rule.operator in {"isNull", "notNull"}
     ]
     rows = []
     for chart in definition.charts:
@@ -324,9 +322,7 @@ def test_unknown_explore_is_not_recovered_from_invented_fields() -> None:
 
 def test_time_series_authoring_rejects_an_empty_applicable_date_window() -> None:
     payload = _definition_with_filter().model_dump(mode="json", by_alias=True)
-    payload["filters"]["dimensions"][0].update(
-        {"operator": "inBetween", "values": []}
-    )
+    payload["filters"]["dimensions"][0].update({"operator": "inBetween", "values": []})
 
     with pytest.raises(
         DashboardTimeSeriesWindowError,
@@ -426,6 +422,13 @@ async def test_agent_update_is_forced_through_typed_operations() -> None:
     }
     chart_schema = client.request["tools"][0]["input_schema"]["$defs"]["ChartDefinition"]
     assert "question" in chart_schema["properties"]
+
+
+def test_dashboard_authoring_uses_agent_sdk_for_oauth() -> None:
+    agent = DashboardAuthoringAgent(oauth_token="oauth-token")
+
+    assert isinstance(agent.model_client, ClaudeAgentSDKStructuredClient)
+    assert agent.model_client.oauth_token == "oauth-token"
 
 
 @pytest.mark.asyncio
@@ -1029,12 +1032,14 @@ async def test_apply_reuses_complete_base_receipts_for_unchanged_charts(
     )
 
     all_results = (
-        await db_session.execute(
-            select(GatewayDashboardResult).where(
-                GatewayDashboardResult.dashboard_id == created.dashboard.id
+        (
+            await db_session.execute(
+                select(GatewayDashboardResult).where(GatewayDashboardResult.dashboard_id == created.dashboard.id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert {row.version_id for row in base_receipts} == {created.version.id}
     assert sum(row.version_id == applied.version.id for row in all_results) == len(definition.charts)
 
@@ -1164,12 +1169,14 @@ async def test_new_dashboard_apply_promotes_only_the_exact_complete_preview_resu
         visible_complete_result_ids=[result.id for result in results],
     )
     promoted = (
-        await db_session.execute(
-            select(GatewayDashboardResult).where(
-                GatewayDashboardResult.id.in_([result.id for result in results])
+        (
+            await db_session.execute(
+                select(GatewayDashboardResult).where(GatewayDashboardResult.id.in_([result.id for result in results]))
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert {row.dashboard_id for row in promoted} == {applied.dashboard.id}
     assert {row.version_id for row in promoted} == {applied.version.id}
     assert {row.chart_id for row in promoted} == {chart.id for chart in applied.version.definition.charts}

--- a/signalpilot/gateway/uv.lock
+++ b/signalpilot/gateway/uv.lock
@@ -402,6 +402,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.1.81"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ce/e7a02076df66dd7dd48764321a7b103fe13a2bdabd48e2eb25f45e6d1f9e/claude_agent_sdk-0.1.81.tar.gz", hash = "sha256:9a3e873c99cd98b2e11ae5e65fd250f38ea192c3a8ddd117ed69a10bbf2b913b", size = 250295, upload-time = "2026-05-11T18:56:44.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/89/454cb0c45baf0776cc3f61d10d4bafdd55a7a56963266c3a843882ba2a64/claude_agent_sdk-0.1.81-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4bc8797cc2bc882031cf6b287a550ae2bb38a3822aa081e9ffc81bb4bed51da", size = 61076865, upload-time = "2026-05-11T18:56:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/1d895e20cae4cd767a714622825e2752257cdd3887586dea966afbb65aaf/claude_agent_sdk-0.1.81-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:a3cdbc00e18ed6b0f11387833bf2d4b7779e0f5f3a9ea63f27b6d6e62f304256", size = 63129573, upload-time = "2026-05-11T18:56:52.059Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/09/4ea3baf9deaa098dd5bc5fc4aeb93a116ab879f0d63992a8ffa000b61afe/claude_agent_sdk-0.1.81-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e08a03b414af5814573cf89646653c1398193557f536914103f8f0708068ed27", size = 70801456, upload-time = "2026-05-11T18:56:56.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/0a/2d5325d3961b0896f41bcf74136350a2a54b3e4b9c3bd35f006b0adeb7b4/claude_agent_sdk-0.1.81-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:a75b3421eeabc57c31ee2515a7c58ddf17886a3166ee9481f0750ddb27eba8d8", size = 70988920, upload-time = "2026-05-11T18:57:01.024Z" },
+    { url = "https://files.pythonhosted.org/packages/30/dc/b925ae2f0bbd4783ef28f72871a9e59248f9df2f3ecb8ac6a937ad4b01f9/claude_agent_sdk-0.1.81-py3-none-win_amd64.whl", hash = "sha256:4214cef9c4fb4f6b850d23f5f931e0e556803f4c32c1ae9f87206d2327b4a1a8", size = 71616000, upload-time = "2026-05-11T18:57:05.723Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2181,6 +2199,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "boto3" },
+    { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "duckdb" },
     { name = "fastapi" },
@@ -2253,6 +2272,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'dev'", specifier = ">=1.34.0" },
+    { name = "claude-agent-sdk", specifier = "==0.1.81" },
     { name = "clickhouse-connect", marker = "extra == 'all-connectors'", specifier = ">=0.7.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.7.0" },
     { name = "clickhouse-driver", marker = "extra == 'all-connectors'", specifier = ">=0.2.7" },
@@ -2303,6 +2323,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]

--- a/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent_config.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent_config.py
@@ -191,7 +191,7 @@ def _is_local_url(url: str) -> bool:
         "localhost",
         "127.0.0.1",
         "::1",
-        "0.0.0.0",
+        "0.0.0.0",  # nosec B104 - URL hostname comparison, not a socket bind
         "gateway",
     }
 


### PR DESCRIPTION
## Summary
- route forced-OAuth dashboard authoring through the Claude Agent SDK instead of treating a Claude Code OAuth token as a Messages API bearer token
- preserve the existing API-key Messages transport and dashboard validation/repair loop
- use the Claude Code preset, isolated user settings, no tools, and JSON-schema structured output
- pin the gateway to the same Agent SDK version used by Data Chat and preserve safe upstream error mapping
- annotate three pre-existing Bandit false positives on isolated sandbox paths and a URL hostname comparison

## Verification
- Python 3.12 focused tests: 41 passed
- focused Ruff checks passed
- full Bandit command passed with the repository baseline
- gateway Docker image built successfully from the frozen lockfile
- container smoke test confirmed Agent SDK 0.1.81 and the new adapter are installed

## Notes
- no live provider call was made because no OAuth token was present in the test environment
