### PR TITLE
Fix Claude SDK error diagnostics

### DIFF
--- a/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
@@ -70,6 +70,42 @@ FILE_EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit", "Bash"]
 _EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 
 
+def _result_message_content(message: Any) -> str:
+    """Preserve the diagnostic fields carried by an SDK ResultMessage."""
+    subtype = str(getattr(message, "subtype", "") or "").strip()
+    if subtype == "error_max_turns":
+        return "The agent reached its turn limit before completing."
+
+    details: list[str] = []
+    result = str(getattr(message, "result", "") or "").strip()
+    if result:
+        details.append(result)
+
+    errors = getattr(message, "errors", None)
+    if isinstance(errors, (list, tuple)):
+        for error in errors:
+            text = str(error or "").strip()
+            if text and text not in details:
+                details.append(text)
+    elif errors:
+        text = str(errors).strip()
+        if text and text not in details:
+            details.append(text)
+
+    stop_reason = str(getattr(message, "stop_reason", "") or "").strip()
+    metadata = []
+    if subtype:
+        metadata.append(f"subtype={subtype}")
+    if stop_reason:
+        metadata.append(f"stop_reason={stop_reason}")
+    if metadata:
+        details.append(f"Claude Agent SDK result: {', '.join(metadata)}")
+
+    if details:
+        return "\n".join(details)
+    return "Claude Agent SDK returned an error without diagnostic details."
+
+
 def _agent_effort() -> str:
     """Reasoning effort for the agent CLI. Defaults to medium."""
     effort = os.getenv("SP_AGENT_EFFORT", "medium").strip().lower()
@@ -308,8 +344,8 @@ def _run_agent_in_thread(
                             AgentEvent(
                                 type="error" if result_is_error else "done",
                                 content=(
-                                    "The agent reached its turn limit before completing."
-                                    if subtype == "error_max_turns"
+                                    _result_message_content(msg)
+                                    if result_is_error
                                     else ""
                                 ),
                                 is_error=result_is_error,

--- a/signalpilot/notebook-server/tests/_server/ai/test_claude_agent.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_claude_agent.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from signalpilot._server.ai.claude_agent import _result_message_content
+
+
+def test_result_message_content_preserves_sdk_error_details() -> None:
+    message = SimpleNamespace(
+        subtype="error_during_execution",
+        stop_reason="authentication_error",
+        result=None,
+        errors=["OAuth token rejected", "Request ID: req_123"],
+    )
+
+    assert _result_message_content(message) == (
+        "OAuth token rejected\n"
+        "Request ID: req_123\n"
+        "Claude Agent SDK result: subtype=error_during_execution, "
+        "stop_reason=authentication_error"
+    )
+
+
+def test_result_message_content_uses_result_and_deduplicates_errors() -> None:
+    message = SimpleNamespace(
+        subtype="error_during_execution",
+        stop_reason=None,
+        result="Credit balance is too low",
+        errors=["Credit balance is too low"],
+    )
+
+    assert _result_message_content(message) == (
+        "Credit balance is too low\n"
+        "Claude Agent SDK result: subtype=error_during_execution"
+    )
+
+
+def test_result_message_content_retains_max_turns_message() -> None:
+    message = SimpleNamespace(
+        subtype="error_max_turns",
+        stop_reason=None,
+        result=None,
+        errors=None,
+    )
+
+    assert (
+        _result_message_content(message)
+        == "The agent reached its turn limit before completing."
+    )
+
+
+def test_result_message_content_has_actionable_empty_fallback() -> None:
+    message = SimpleNamespace(
+        subtype="",
+        stop_reason=None,
+        result=None,
+        errors=None,
+    )
+
+    assert _result_message_content(message) == (
+        "Claude Agent SDK returned an error without diagnostic details."
+    )


### PR DESCRIPTION
## Summary
- preserve Claude Agent SDK result and error details for failed chat runs
- include SDK subtype and stop reason in the expandable trace
- retain the existing max-turn explanation and add an explicit no-details fallback

## Validation
- 21 notebook-server tests passed
- Ruff passed