### PR TITLE
Preserve raw standalone chat errors

### DIFF
--- a/signalpilot/gateway/gateway/standalone_chat/domain.py
+++ b/signalpilot/gateway/gateway/standalone_chat/domain.py
@@ -6,6 +6,18 @@ import re
 from enum import StrEnum
 from typing import Any
 
+_ERROR_SECRET_VALUE_RE = re.compile(
+    r"(?i)(authorization\s*[:=]\s*(?:bearer\s+)?|"
+    r"(?:api[_-]?key|token|secret|password)\s*[:=]\s*)[^\s,;]+"
+)
+_ERROR_TOKEN_LITERAL_RE = re.compile(
+    r"(?i)\b(?:sk-ant-[A-Za-z0-9_-]+|xox[abprs]-[A-Za-z0-9-]+|"
+    r"gh[pousr]_[A-Za-z0-9_]+|sp_[A-Za-z0-9_-]{16,})\b"
+)
+_ERROR_CONNECTION_LITERAL_RE = re.compile(
+    r"(?i)\b(?:postgres(?:ql)?|mysql|snowflake|redshift|clickhouse)://[^\s]+"
+)
+
 
 class RunStatus(StrEnum):
     queued = "queued"
@@ -126,6 +138,17 @@ def redact_public_payload(value: Any) -> Any:
         )
         return value[:20_000]
     return value
+
+
+def redact_error_text(raw: str) -> str:
+    """Redact credential values without paraphrasing or truncating an error."""
+    redacted = _ERROR_CONNECTION_LITERAL_RE.sub(
+        "[REDACTED_CONNECTION]", str(raw)
+    )
+    redacted = _ERROR_SECRET_VALUE_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]", redacted
+    )
+    return _ERROR_TOKEN_LITERAL_RE.sub("[REDACTED]", redacted)
 
 
 def select_context_for_summary(

--- a/signalpilot/gateway/gateway/standalone_chat/execution.py
+++ b/signalpilot/gateway/gateway/standalone_chat/execution.py
@@ -40,6 +40,18 @@ from gateway.store.standalone_chat import set_execution_session
 logger = logging.getLogger(__name__)
 
 
+class NotebookExecutionHTTPError(RuntimeError):
+    """An HTTP failure whose message is the notebook runtime's raw body."""
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.diagnostic_context = {
+            "error_type": type(self).__name__,
+            "operation": "execute_notebook_analysis",
+            "http_status": status_code,
+        }
+
+
 def _join_base_path(base: str, path: str) -> str:
     return f"{base.rstrip('/')}/{path.lstrip('/')}"
 
@@ -265,16 +277,19 @@ async def stream_execution(execution: PreparedExecution) -> AsyncGenerator[dict[
             # notebook runtime. Read them before the streaming context closes;
             # otherwise every 4xx collapses to an opaque HTTPStatusError and
             # the real authorization/workspace failure is lost.
-            error_body = (await response.aread()).decode(errors="replace")[:500]
+            error_body = (await response.aread()).decode(errors="replace")
             logger.warning(
-                "Notebook execute failed status=%s url=%s bearer=%s body=%r",
+                "Notebook execute failed status=%s url=%s bearer=%s body_bytes=%s",
                 response.status_code,
                 execution.url,
                 _bearer_fingerprint(execution.headers),
-                error_body,
+                len(error_body.encode("utf-8")),
             )
-            reason = error_body.strip() or response.reason_phrase
-            raise RuntimeError(f"Notebook runtime returned HTTP {response.status_code}: {reason}")
+            reason = error_body if error_body else response.reason_phrase
+            raise NotebookExecutionHTTPError(
+                reason,
+                status_code=response.status_code,
+            )
         async for line in response.aiter_lines():
             if not line.strip():
                 continue

--- a/signalpilot/gateway/gateway/standalone_chat/worker.py
+++ b/signalpilot/gateway/gateway/standalone_chat/worker.py
@@ -14,7 +14,6 @@ from typing import Any
 import httpx
 
 from gateway.db.engine import get_session_factory, init_db
-from gateway.errors.mcp import sanitize_mcp_error
 from gateway.standalone_chat.config import (
     lease_seconds,
     standalone_chat_enabled,
@@ -22,6 +21,7 @@ from gateway.standalone_chat.config import (
     worker_poll_seconds,
 )
 from gateway.standalone_chat.domain import (
+    redact_error_text,
     redact_public_payload,
     select_context_for_summary,
 )
@@ -55,14 +55,6 @@ from gateway.store import standalone_chat as chat_store
 
 logger = logging.getLogger(__name__)
 _CLARIFICATION_PREFIX = "CLARIFICATION_REQUESTED:"
-_SECRET_VALUE_RE = re.compile(
-    r"(?i)(authorization\s*[:=]\s*(?:bearer\s+)?|"
-    r"(?:api[_-]?key|token|secret|password)\s*[:=]\s*)[^\s,;]+"
-)
-_TOKEN_LITERAL_RE = re.compile(
-    r"(?i)\b(?:sk-ant-[A-Za-z0-9_-]+|xox[abprs]-[A-Za-z0-9-]+|"
-    r"gh[pousr]_[A-Za-z0-9_]+|sp_[A-Za-z0-9_-]{16,})\b"
-)
 
 
 class _AnalysisRuntimeError(RuntimeError):
@@ -78,31 +70,16 @@ class _AnalysisRuntimeError(RuntimeError):
         self.diagnostic_context = diagnostic_context
 
 
-def _sanitize_error_text(raw: str, *, cap: int) -> str:
-    redacted = str(redact_public_payload(raw))
-    redacted = _SECRET_VALUE_RE.sub(lambda match: f"{match.group(1)}[REDACTED]", redacted)
-    redacted = _TOKEN_LITERAL_RE.sub("[REDACTED]", redacted)
-    return sanitize_mcp_error(redacted, cap=cap).strip()
-
-
 def _public_error_message(exc: Exception) -> str:
-    """Return the real root cause without exposing a traceback or credentials."""
-    raw = str(exc).strip() or type(exc).__name__
-    # Agent errors include a useful exception/stderr header followed by a full
-    # Python traceback. The traceback is operator detail, not useful chat UI.
-    raw = re.split(r"\nTraceback \(most recent call last\):", raw, maxsplit=1)[0]
-    lines = [line.rstrip() for line in raw.splitlines()]
-    while lines and (not lines[-1].strip() or lines[-1].strip().lower() == "stderr:"):
-        lines.pop()
-    diagnostic = "\n".join(lines).strip() or type(exc).__name__
-    return _sanitize_error_text(diagnostic, cap=1000) or type(exc).__name__
+    """Return the upstream error verbatim except for credential redaction."""
+    return redact_error_text(str(exc))
 
 
 def _public_full_trace(exc: Exception) -> str:
-    raw = str(getattr(exc, "full_trace", "") or "").strip()
+    raw = str(getattr(exc, "full_trace", "") or "")
     if not raw:
         raw = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-    return _sanitize_error_text(raw, cap=12_000)
+    return redact_error_text(raw)
 
 
 def _public_diagnostic_context(exc: Exception) -> dict[str, Any]:
@@ -117,16 +94,31 @@ def _public_diagnostic_context(exc: Exception) -> dict[str, Any]:
         "resume_requested",
         "notebook_analysis_enabled",
         "max_turns",
+        "result_subtype",
+        "stop_reason",
+        "api_error_status",
+        "duration_ms",
+        "duration_api_ms",
+        "sdk_session_id",
+        "operation",
+        "http_status",
     }
     root = _public_error_message(exc)
     root_type = re.match(r"^([A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception)):", root)
+    source_error_type = source.get("error_type")
     result: dict[str, Any] = {
-        "error_type": root_type.group(1) if root_type else type(exc).__name__
+        "error_type": (
+            redact_error_text(source_error_type)
+            if isinstance(source_error_type, str) and source_error_type
+            else root_type.group(1)
+            if root_type
+            else type(exc).__name__
+        )
     }
     for key in allowed:
         value = source.get(key)
         if isinstance(value, (str, bool, int, float)):
-            result[key] = _sanitize_error_text(value, cap=200) if isinstance(value, str) else value
+            result[key] = redact_error_text(value) if isinstance(value, str) else value
     environment = source.get("environment")
     if isinstance(environment, dict):
         result["environment"] = {
@@ -141,6 +133,9 @@ def _public_diagnostic_context(exc: Exception) -> dict[str, Any]:
             }
             and value in {"configured", "cleared", "defaulted", "missing"}
         }
+    rate_limit = source.get("rate_limit")
+    if isinstance(rate_limit, dict):
+        result["rate_limit"] = redact_public_payload(rate_limit)
     return result
 
 
@@ -461,7 +456,7 @@ async def _execute_claimed_run(run_id: str, worker_id: str) -> None:
                         await _announce_notebook(run_id, recovery_payload)
                     elif event_type == "error":
                         raise _AnalysisRuntimeError(
-                            content or "Notebook analysis failed",
+                            content,
                             full_trace=str(event.get("full_trace") or content or ""),
                             diagnostic_context=event.get("diagnostic_context"),
                         )

--- a/signalpilot/gateway/gateway/store/standalone_chat/lifecycle.py
+++ b/signalpilot/gateway/gateway/store/standalone_chat/lifecycle.py
@@ -20,7 +20,7 @@ from gateway.standalone_chat.domain import (
     RunStatus,
     assert_run_transition,
     fallback_conversation_title,
-    redact_public_payload,
+    redact_error_text,
 )
 from gateway.store.standalone_chat.helpers import (
     _append_status_message,
@@ -297,7 +297,7 @@ async def fail_run(
     assert_run_transition(run.status, target)
     run.status = target
     run.public_error_code = str(code)[:100]
-    run.public_error_message = str(redact_public_payload(message))[:1000]
+    run.public_error_message = redact_error_text(message)
     run.terminal_at = _now()
     run.lease_owner = None
     run.lease_expires_at = None
@@ -305,7 +305,7 @@ async def fail_run(
         db,
         run=run,
         status=target,
-        content=run.public_error_message or "The run could not be completed.",
+        content=run.public_error_message,
     )
     _stage_run_event(
         db,

--- a/signalpilot/gateway/tests/test_standalone_chat.py
+++ b/signalpilot/gateway/tests/test_standalone_chat.py
@@ -1529,6 +1529,37 @@ async def test_cancelled_and_failed_runs_leave_inspectable_status_messages(
 
 
 @pytest.mark.asyncio
+async def test_fail_run_preserves_the_complete_upstream_error(db_session):
+    conversation_id, run = await _conversation_and_run(db_session)
+    await chat_store.claim_runs(
+        db_session,
+        worker_id="worker-a",
+        limit=1,
+        lease_seconds=45,
+    )
+    upstream = "provider error: " + ("x" * 2_000)
+
+    assert await chat_store.fail_run(
+        db_session,
+        run_id=run.id,
+        worker_id="worker-a",
+        code="analysis_failed",
+        message=upstream,
+    )
+    detail = await chat_store.get_conversation_detail(
+        db_session,
+        org_id="org-a",
+        user_id="user-a",
+        conversation_id=conversation_id,
+    )
+
+    assert detail is not None
+    assert detail.current_run is not None
+    assert detail.current_run.public_error_message == upstream
+    assert detail.messages[-1].content == upstream
+
+
+@pytest.mark.asyncio
 async def test_running_cancellation_wins_over_a_late_final_answer(db_session):
     conversation_id, run = await _conversation_and_run(db_session)
     await chat_store.claim_runs(

--- a/signalpilot/gateway/tests/test_standalone_chat_worker.py
+++ b/signalpilot/gateway/tests/test_standalone_chat_worker.py
@@ -11,7 +11,7 @@ import pytest
 from gateway.standalone_chat import worker, worker_context
 
 
-def test_public_error_message_preserves_root_cause_and_removes_traceback() -> None:
+def test_public_error_message_preserves_upstream_text_verbatim() -> None:
     error = RuntimeError(
         "CLIConnectionError: OAuth token expired\n"
         "stderr: authentication failed\n"
@@ -22,9 +22,7 @@ def test_public_error_message_preserves_root_cause_and_removes_traceback() -> No
 
     message = worker._public_error_message(error)
 
-    assert message == ("CLIConnectionError: OAuth token expired\nstderr: authentication failed")
-    assert "Traceback" not in message
-    assert "/opt/runtime" not in message
+    assert message == str(error)
 
 
 def test_public_error_message_redacts_credentials() -> None:
@@ -32,6 +30,12 @@ def test_public_error_message_redacts_credentials() -> None:
 
     assert message == "Database failed: [REDACTED_CONNECTION]"
     assert "hunter2" not in message
+
+
+def test_public_error_message_is_not_truncated_or_paraphrased() -> None:
+    upstream = "provider error: " + ("x" * 2_000)
+
+    assert worker._public_error_message(RuntimeError(upstream)) == upstream
 
 
 def test_public_full_trace_is_expandable_safe_diagnostic_content() -> None:
@@ -47,6 +51,12 @@ def test_public_full_trace_is_expandable_safe_diagnostic_content() -> None:
             "model": "claude-sonnet-test",
             "auth_mode": "oauth",
             "credential_present": True,
+            "api_error_status": 429,
+            "rate_limit": {
+                "status": "rejected",
+                "resets_at": 1788213000,
+                "raw": {"unknownFutureField": "preserved"},
+            },
             "environment": {
                 "CLAUDE_CONFIG_DIR": "configured",
                 "SECRET_TOKEN": "must-not-pass",
@@ -60,10 +70,16 @@ def test_public_full_trace_is_expandable_safe_diagnostic_content() -> None:
     assert "oauth-secret" not in trace
     assert "very-secret-token" not in trace
     assert "Authorization: Bearer [REDACTED]" in trace
-    assert "/opt/runtime" not in trace
+    assert '/opt/runtime/agent.py' in trace
     assert context["auth_mode"] == "oauth"
     assert context["error_type"] == "CLIConnectionError"
     assert context["credential_present"] is True
+    assert context["api_error_status"] == 429
+    assert context["rate_limit"] == {
+        "status": "rejected",
+        "resets_at": 1788213000,
+        "raw": {"unknownFutureField": "preserved"},
+    }
     assert context["environment"] == {"CLAUDE_CONFIG_DIR": "configured"}
 
 

--- a/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
@@ -71,39 +71,38 @@ _EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 
 
 def _result_message_content(message: Any) -> str:
-    """Preserve the diagnostic fields carried by an SDK ResultMessage."""
-    subtype = str(getattr(message, "subtype", "") or "").strip()
-    if subtype == "error_max_turns":
-        return "The agent reached its turn limit before completing."
-
-    details: list[str] = []
-    result = str(getattr(message, "result", "") or "").strip()
-    if result:
-        details.append(result)
+    """Return the SDK's error text without replacing or paraphrasing it."""
+    result = getattr(message, "result", None)
+    if result is not None and str(result):
+        return str(result)
 
     errors = getattr(message, "errors", None)
     if isinstance(errors, (list, tuple)):
-        for error in errors:
-            text = str(error or "").strip()
-            if text and text not in details:
-                details.append(text)
+        details = [str(error) for error in errors if error is not None]
+        if details:
+            return "\n".join(details)
     elif errors:
-        text = str(errors).strip()
-        if text and text not in details:
-            details.append(text)
+        return str(errors)
 
-    stop_reason = str(getattr(message, "stop_reason", "") or "").strip()
-    metadata = []
-    if subtype:
-        metadata.append(f"subtype={subtype}")
-    if stop_reason:
-        metadata.append(f"stop_reason={stop_reason}")
-    if metadata:
-        details.append(f"Claude Agent SDK result: {', '.join(metadata)}")
+    # An SDK result with no textual error still has an exact structured
+    # representation. Surface it instead of inventing a human-friendly cause.
+    return repr(message)
 
-    if details:
-        return "\n".join(details)
-    return "Claude Agent SDK returned an error without diagnostic details."
+
+def _rate_limit_diagnostic(info: Any) -> dict[str, Any]:
+    """Copy the SDK rate-limit payload without interpreting its meaning."""
+    return {
+        "status": getattr(info, "status", None),
+        "resets_at": getattr(info, "resets_at", None),
+        "rate_limit_type": getattr(info, "rate_limit_type", None),
+        "utilization": getattr(info, "utilization", None),
+        "overage_status": getattr(info, "overage_status", None),
+        "overage_resets_at": getattr(info, "overage_resets_at", None),
+        "overage_disabled_reason": getattr(
+            info, "overage_disabled_reason", None
+        ),
+        "raw": getattr(info, "raw", None),
+    }
 
 
 def _agent_effort() -> str:
@@ -160,6 +159,7 @@ def _run_agent_in_thread(
     async def _run() -> None:
         agent_state.task = asyncio.current_task()
         turn_count = 0
+        latest_rate_limit_info: dict[str, Any] | None = None
 
         agent_env = dict(os.environ)
         _apply_auth_config(agent_env, auth_config)
@@ -359,6 +359,27 @@ def _run_agent_in_thread(
                                 num_turns=int(
                                     getattr(msg, "num_turns", turn_count) or 0
                                 ),
+                                diagnostic_context={
+                                    "result_subtype": subtype,
+                                    "stop_reason": str(
+                                        getattr(msg, "stop_reason", "") or ""
+                                    ),
+                                    "api_error_status": getattr(
+                                        msg, "api_error_status", None
+                                    ),
+                                    "duration_ms": getattr(msg, "duration_ms", None),
+                                    "duration_api_ms": getattr(
+                                        msg, "duration_api_ms", None
+                                    ),
+                                    "sdk_session_id": str(
+                                        getattr(msg, "session_id", "") or ""
+                                    ),
+                                    **(
+                                        {"rate_limit": latest_rate_limit_info}
+                                        if latest_rate_limit_info
+                                        else {}
+                                    ),
+                                },
                             )
                         )
                         # A ResultMessage terminates one SDK query, not
@@ -373,17 +394,13 @@ def _run_agent_in_thread(
                         break  # Session complete for this query
 
                     elif isinstance(msg, RateLimitEvent):
-                        info = msg.rate_limit_info
-                        status = getattr(info, "status", None)
-                        if status != "allowed":
-                            event_queue.put(
-                                AgentEvent(
-                                    type="error",
-                                    content="Rate limited. Try again shortly.",
-                                    is_error=True,
-                                    turn=turn_count,
-                                )
-                            )
+                        # This is state, not an error message. A rejected event
+                        # is followed by the SDK ResultMessage containing the
+                        # provider's actual text. Retain the raw state for the
+                        # diagnostic panel and do not pre-empt that result.
+                        latest_rate_limit_info = _rate_limit_diagnostic(
+                            msg.rate_limit_info
+                        )
 
                     elif isinstance(msg, StreamEvent):
                         event = msg.event
@@ -432,7 +449,9 @@ def _run_agent_in_thread(
             event_queue.put(
                 AgentEvent(
                     type="error",
-                    content=full_error,
+                    content=str(e) if str(e) else repr(e),
+                    full_trace=full_error,
+                    diagnostic_context={"error_type": type(e).__name__},
                     is_error=True,
                     turn=turn_count,
                 )
@@ -455,7 +474,9 @@ def _run_agent_in_thread(
         event_queue.put(
             AgentEvent(
                 type="error",
-                content=f"Thread error: {e}\n{tb}",
+                content=str(e) if str(e) else repr(e),
+                full_trace=tb,
+                diagnostic_context={"error_type": type(e).__name__},
                 is_error=True,
             )
         )

--- a/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent.py
@@ -70,6 +70,42 @@ FILE_EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit", "Bash"]
 _EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 
 
+def _result_message_content(message: Any) -> str:
+    """Preserve the diagnostic fields carried by an SDK ResultMessage."""
+    subtype = str(getattr(message, "subtype", "") or "").strip()
+    if subtype == "error_max_turns":
+        return "The agent reached its turn limit before completing."
+
+    details: list[str] = []
+    result = str(getattr(message, "result", "") or "").strip()
+    if result:
+        details.append(result)
+
+    errors = getattr(message, "errors", None)
+    if isinstance(errors, (list, tuple)):
+        for error in errors:
+            text = str(error or "").strip()
+            if text and text not in details:
+                details.append(text)
+    elif errors:
+        text = str(errors).strip()
+        if text and text not in details:
+            details.append(text)
+
+    stop_reason = str(getattr(message, "stop_reason", "") or "").strip()
+    metadata = []
+    if subtype:
+        metadata.append(f"subtype={subtype}")
+    if stop_reason:
+        metadata.append(f"stop_reason={stop_reason}")
+    if metadata:
+        details.append(f"Claude Agent SDK result: {', '.join(metadata)}")
+
+    if details:
+        return "\n".join(details)
+    return "Claude Agent SDK returned an error without diagnostic details."
+
+
 def _agent_effort() -> str:
     """Reasoning effort for the agent CLI. Defaults to medium."""
     effort = os.getenv("SP_AGENT_EFFORT", "medium").strip().lower()
@@ -308,8 +344,8 @@ def _run_agent_in_thread(
                             AgentEvent(
                                 type="error" if result_is_error else "done",
                                 content=(
-                                    "The agent reached its turn limit before completing."
-                                    if subtype == "error_max_turns"
+                                    _result_message_content(msg)
+                                    if result_is_error
                                     else ""
                                 ),
                                 is_error=result_is_error,

--- a/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent_state.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/claude_agent_state.py
@@ -58,6 +58,8 @@ class AgentEvent:
     result_subtype: str = ""
     stop_reason: str = ""
     num_turns: int = 0
+    diagnostic_context: dict[str, Any] | None = None
+    full_trace: str = ""
 
 
 @dataclass

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat_execution.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat_execution.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import shutil
+import traceback
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -258,7 +259,7 @@ async def execute(*, request: Request) -> StreamingResponse:
                         lifecycle.session_id = _start_analysis_kernel(
                             request.app, analysis_notebook_path
                         )
-                    except Exception:
+                    except Exception as exc:
                         LOGGER.exception(
                             "Clean notebook kernel start failed run_id=%s attempt=%s",
                             run_id,
@@ -268,7 +269,12 @@ async def execute(*, request: Request) -> StreamingResponse:
                             json.dumps(
                                 {
                                     "type": "error",
-                                    "content": "The failed notebook kernel could not be restarted safely.",
+                                    "content": str(exc) if str(exc) else repr(exc),
+                                    "full_trace": traceback.format_exc(),
+                                    "diagnostic_context": {
+                                        "error_type": type(exc).__name__,
+                                        "operation": "start_recovery_notebook_kernel",
+                                    },
                                     "is_error": True,
                                 }
                             )
@@ -466,6 +472,7 @@ async def execute(*, request: Request) -> StreamingResponse:
                         continue
                     if event.type == "error":
                         agent_failed = True
+                        sdk_diagnostics = dict(event.diagnostic_context or {})
                         yield (
                             json.dumps(
                                 {
@@ -475,10 +482,10 @@ async def execute(*, request: Request) -> StreamingResponse:
                                     # displaying it. Do not discard the SDK's root
                                     # cause here or every failure becomes impossible
                                     # for the user to diagnose.
-                                    "content": event.content.strip()
-                                    or "AgentError: empty error response",
-                                    "full_trace": event.content.strip(),
+                                    "content": event.content,
+                                    "full_trace": event.full_trace or event.content,
                                     "diagnostic_context": {
+                                        **sdk_diagnostics,
                                         "model": agent_model,
                                         "auth_mode": (
                                             auth_config_override.get("type")
@@ -711,7 +718,12 @@ async def execute(*, request: Request) -> StreamingResponse:
                             json.dumps(
                                 {
                                     "type": "error",
-                                    "content": "The validated notebook could not be archived; the answer was rejected.",
+                                    "content": str(exc) if str(exc) else repr(exc),
+                                    "full_trace": traceback.format_exc(),
+                                    "diagnostic_context": {
+                                        "error_type": type(exc).__name__,
+                                        "operation": "archive_analysis_notebook",
+                                    },
                                     "is_error": True,
                                 }
                             )

--- a/signalpilot/notebook-server/tests/_server/ai/test_claude_agent.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_claude_agent.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
-from signalpilot._server.ai.claude_agent import _result_message_content
+from signalpilot._server.ai.claude_agent import (
+    _rate_limit_diagnostic,
+    _result_message_content,
+)
 
 
 def test_result_message_content_preserves_sdk_error_details() -> None:
@@ -12,10 +15,7 @@ def test_result_message_content_preserves_sdk_error_details() -> None:
     )
 
     assert _result_message_content(message) == (
-        "OAuth token rejected\n"
-        "Request ID: req_123\n"
-        "Claude Agent SDK result: subtype=error_during_execution, "
-        "stop_reason=authentication_error"
+        "OAuth token rejected\nRequest ID: req_123"
     )
 
 
@@ -27,13 +27,10 @@ def test_result_message_content_uses_result_and_deduplicates_errors() -> None:
         errors=["Credit balance is too low"],
     )
 
-    assert _result_message_content(message) == (
-        "Credit balance is too low\n"
-        "Claude Agent SDK result: subtype=error_during_execution"
-    )
+    assert _result_message_content(message) == "Credit balance is too low"
 
 
-def test_result_message_content_retains_max_turns_message() -> None:
+def test_result_message_content_does_not_invent_max_turns_message() -> None:
     message = SimpleNamespace(
         subtype="error_max_turns",
         stop_reason=None,
@@ -41,13 +38,10 @@ def test_result_message_content_retains_max_turns_message() -> None:
         errors=None,
     )
 
-    assert (
-        _result_message_content(message)
-        == "The agent reached its turn limit before completing."
-    )
+    assert _result_message_content(message) == repr(message)
 
 
-def test_result_message_content_has_actionable_empty_fallback() -> None:
+def test_result_message_content_uses_raw_sdk_repr_when_text_is_empty() -> None:
     message = SimpleNamespace(
         subtype="",
         stop_reason=None,
@@ -55,6 +49,34 @@ def test_result_message_content_has_actionable_empty_fallback() -> None:
         errors=None,
     )
 
-    assert _result_message_content(message) == (
-        "Claude Agent SDK returned an error without diagnostic details."
+    assert _result_message_content(message) == repr(message)
+
+
+def test_rate_limit_diagnostic_preserves_raw_sdk_fields() -> None:
+    raw = {
+        "status": "rejected",
+        "resetsAt": 1788213000,
+        "rateLimitType": "five_hour",
+        "unknownFutureField": "preserved",
+    }
+    info = SimpleNamespace(
+        status="rejected",
+        resets_at=1788213000,
+        rate_limit_type="five_hour",
+        utilization=1.0,
+        overage_status="rejected",
+        overage_resets_at=None,
+        overage_disabled_reason="not_enabled",
+        raw=raw,
     )
+
+    assert _rate_limit_diagnostic(info) == {
+        "status": "rejected",
+        "resets_at": 1788213000,
+        "rate_limit_type": "five_hour",
+        "utilization": 1.0,
+        "overage_status": "rejected",
+        "overage_resets_at": None,
+        "overage_disabled_reason": "not_enabled",
+        "raw": raw,
+    }

--- a/signalpilot/notebook-server/tests/_server/ai/test_claude_agent.py
+++ b/signalpilot/notebook-server/tests/_server/ai/test_claude_agent.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from signalpilot._server.ai.claude_agent import _result_message_content
+
+
+def test_result_message_content_preserves_sdk_error_details() -> None:
+    message = SimpleNamespace(
+        subtype="error_during_execution",
+        stop_reason="authentication_error",
+        result=None,
+        errors=["OAuth token rejected", "Request ID: req_123"],
+    )
+
+    assert _result_message_content(message) == (
+        "OAuth token rejected\n"
+        "Request ID: req_123\n"
+        "Claude Agent SDK result: subtype=error_during_execution, "
+        "stop_reason=authentication_error"
+    )
+
+
+def test_result_message_content_uses_result_and_deduplicates_errors() -> None:
+    message = SimpleNamespace(
+        subtype="error_during_execution",
+        stop_reason=None,
+        result="Credit balance is too low",
+        errors=["Credit balance is too low"],
+    )
+
+    assert _result_message_content(message) == (
+        "Credit balance is too low\n"
+        "Claude Agent SDK result: subtype=error_during_execution"
+    )
+
+
+def test_result_message_content_retains_max_turns_message() -> None:
+    message = SimpleNamespace(
+        subtype="error_max_turns",
+        stop_reason=None,
+        result=None,
+        errors=None,
+    )
+
+    assert (
+        _result_message_content(message)
+        == "The agent reached its turn limit before completing."
+    )
+
+
+def test_result_message_content_has_actionable_empty_fallback() -> None:
+    message = SimpleNamespace(
+        subtype="",
+        stop_reason=None,
+        result=None,
+        errors=None,
+    )
+
+    assert _result_message_content(message) == (
+        "Claude Agent SDK returned an error without diagnostic details."
+    )

--- a/signalpilot/web/components/chat/run-timeline.tsx
+++ b/signalpilot/web/components/chat/run-timeline.tsx
@@ -27,6 +27,7 @@ import { ChatCode, CopyButton, type ChatCodeLanguage } from "~/components/chat/c
 import { AgentThinkingIndicator } from "~/components/chat/agent-thinking-indicator";
 import {
   describeSubagentWork,
+  formatErrorSupportBundle,
   formatStepDuration,
   shouldShowAgentThinking,
   summarizeRunSteps,
@@ -226,13 +227,7 @@ function StepBody({ step }: { step: RunStep }) {
           `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`,
         )
       : [];
-    const supportBundle = [
-      step.detail ? `Root cause: ${step.detail}` : "",
-      diagnostics.length ? `Diagnostics:\n${diagnostics.join("\n")}` : "",
-      step.fullTrace ? `Full trace:\n${step.fullTrace}` : "",
-    ]
-      .filter(Boolean)
-      .join("\n\n");
+    const supportBundle = formatErrorSupportBundle(step);
     return (
       <CardShell label="Full trace" copyText={supportBundle} accent="error">
         {diagnostics.length > 0 && (

--- a/signalpilot/web/lib/chat-run-steps.test.ts
+++ b/signalpilot/web/lib/chat-run-steps.test.ts
@@ -4,6 +4,7 @@ import {
   extractRuntimeBoot,
   foldRunBlocks,
   foldRunSteps,
+  formatErrorSupportBundle,
   formatStepDuration,
   normalizeToolName,
   shouldShowAgentThinking,
@@ -74,7 +75,7 @@ describe("foldRunSteps", () => {
     expect(foldRunSteps(allEvents, "other-run")).toEqual([]);
   });
 
-  it("keeps the redacted trace and safe diagnostics on run errors", () => {
+  it("keeps the exact upstream message, trace, and safe diagnostics", () => {
     const error = foldRunSteps(
       [
         {
@@ -82,11 +83,16 @@ describe("foldRunSteps", () => {
           sequence: 1,
           type: "error" as const,
           payload: {
-            message: "CLIConnectionError: authentication failed",
+            message: "You've hit your session limit · resets 2:50pm (America/Los_Angeles)",
             full_trace: "CLIConnectionError: authentication failed\n[traceback]",
             diagnostic_context: {
               auth_mode: "oauth",
               credential_present: true,
+              api_error_status: 429,
+              rate_limit: {
+                status: "rejected",
+                resets_at: 1788213000,
+              },
             },
           },
           created_at: "2026-08-31T00:00:00Z",
@@ -95,12 +101,28 @@ describe("foldRunSteps", () => {
       "failed-run",
     )[0];
 
-    expect(error.detail).toBe("CLIConnectionError: authentication failed");
+    expect(error.detail).toBe(
+      "You've hit your session limit · resets 2:50pm (America/Los_Angeles)",
+    );
     expect(error.fullTrace).toContain("[traceback]");
     expect(error.diagnostics).toEqual({
       auth_mode: "oauth",
       credential_present: true,
+      api_error_status: 429,
+      rate_limit: {
+        status: "rejected",
+        resets_at: 1788213000,
+      },
     });
+    expect(formatErrorSupportBundle(error)).toBe(
+      "Root cause: You've hit your session limit · resets 2:50pm (America/Los_Angeles)\n\n" +
+        "Diagnostics:\n" +
+        "auth_mode: oauth\n" +
+        "credential_present: true\n" +
+        "api_error_status: 429\n" +
+        'rate_limit: {"status":"rejected","resets_at":1788213000}\n\n' +
+        "Full trace:\nCLIConnectionError: authentication failed\n[traceback]",
+    );
   });
 
   it("leaves an unmatched tool start running", () => {

--- a/signalpilot/web/lib/chat-run-steps.ts
+++ b/signalpilot/web/lib/chat-run-steps.ts
@@ -76,6 +76,22 @@ export type RunStepSummary = {
   running: boolean;
 };
 
+export function formatErrorSupportBundle(step: RunStep): string {
+  const diagnostics = step.diagnostics
+    ? Object.entries(step.diagnostics).map(
+        ([key, value]) =>
+          `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`,
+      )
+    : [];
+  return [
+    step.detail ? `Root cause: ${step.detail}` : "",
+    diagnostics.length ? `Diagnostics:\n${diagnostics.join("\n")}` : "",
+    step.fullTrace ? `Full trace:\n${step.fullTrace}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
 const SQL_TOOLS = new Set([
   "query_database",
   "explain_query",
@@ -553,7 +569,7 @@ export function foldRunSteps(
         code: null,
         file: null,
         sources: [],
-        detail: text(event.payload.message) ?? "The run hit an error.",
+        detail: text(event.payload.message),
         startedAt: event.created_at,
         endedAt: event.created_at,
         durationMs: null,


### PR DESCRIPTION
## Summary
- preserve Claude Agent SDK and notebook runtime error text end to end
- retain structured rate-limit diagnostics and wait for the SDK result instead of emitting a generic rate-limit error
- remove error truncation and synthetic frontend/backend fallback messages
- redact only credential-shaped values and include exact root cause, diagnostics, and full trace in the copy bundle

## Verification
- notebook runtime focused tests: 22 passed
- gateway standalone-chat tests: 51 passed
- frontend chat-run tests: 28 passed
- production Next.js build passed

Merged latest main and staging before verification.