### PR TITLE
Fix OAuth dashboard authoring runtime on staging

### DIFF
--- a/signalpilot/gateway/gateway/analysis_delivery/model_client.py
+++ b/signalpilot/gateway/gateway/analysis_delivery/model_client.py
@@ -106,6 +106,7 @@ class ClaudeAgentSDKResult:
     provider_message: str | None = None
     request_id: str | None = None
     usage: dict[str, Any] | None = None
+    result_text: str | None = None
 
 
 ClaudeAgentSDKRunner = Callable[[str, dict[str, Any]], Awaitable[ClaudeAgentSDKResult]]
@@ -119,12 +120,14 @@ class ClaudeAgentSDKStructuredClient:
         *,
         oauth_token: str,
         timeout_seconds: float,
+        use_native_structured_output: bool = True,
         query_runner: ClaudeAgentSDKRunner | None = None,
     ) -> None:
         if not oauth_token:
             raise ValueError("Claude OAuth token is required")
         self.oauth_token = oauth_token
         self.timeout_seconds = max(float(timeout_seconds), 0.1)
+        self.use_native_structured_output = use_native_structured_output
         self._query_runner = query_runner or _run_claude_agent_sdk_query
 
     async def create_message(self, request_body: dict[str, Any]) -> dict[str, Any]:
@@ -140,9 +143,11 @@ class ClaudeAgentSDKStructuredClient:
         )
         with tempfile.TemporaryDirectory(prefix="signalpilot-dashboard-authoring-") as runtime_dir:
             agent_env["CLAUDE_CONFIG_DIR"] = runtime_dir
-            options = {
+            options: dict[str, Any] = {
                 "model": request_body.get("model"),
-                "max_turns": 1,
+                # Structured output requires a second SDK turn to emit the
+                # validated JSON result after the initial model response.
+                "max_turns": 2,
                 "permission_mode": "dontAsk",
                 "tools": [],
                 "setting_sources": ["user"],
@@ -151,11 +156,14 @@ class ClaudeAgentSDKStructuredClient:
                     "preset": "claude_code",
                     "append": system,
                 },
-                "output_format": {"type": "json_schema", "schema": schema},
                 "cwd": runtime_dir,
                 "env": agent_env,
                 "effort": _agent_effort(),
             }
+            if self.use_native_structured_output:
+                options["output_format"] = {"type": "json_schema", "schema": schema}
+            else:
+                prompt = _append_json_contract(prompt, tool_name=tool_name, schema=schema)
             try:
                 async with asyncio.timeout(self.timeout_seconds):
                     result = await self._query_runner(prompt, options)
@@ -184,12 +192,17 @@ class ClaudeAgentSDKStructuredClient:
                 provider_message=result.provider_message,
                 request_id=result.request_id,
             )
-        if result.structured_output is None:
+        structured_output = result.structured_output
+        if structured_output is None and not self.use_native_structured_output:
+            structured_output = _parse_json_result(result.result_text)
+        if structured_output is None:
             raise _sdk_error(
                 request_body,
                 status_code=502,
                 error_type="missing_structured_output",
-                provider_message="Claude Agent SDK returned no structured output",
+                provider_message=(
+                    result.provider_message or "Claude Agent SDK returned no structured output"
+                ),
                 request_id=result.request_id,
             )
         return {
@@ -197,7 +210,7 @@ class ClaudeAgentSDKStructuredClient:
                 {
                     "type": "tool_use",
                     "name": tool_name,
-                    "input": result.structured_output,
+                    "input": structured_output,
                 }
             ],
             "usage": result.usage or {},
@@ -225,7 +238,31 @@ async def _run_claude_agent_sdk_query(prompt: str, options: dict[str, Any]) -> C
         provider_message=_clean_detail(provider_message),
         request_id=completed.uuid or completed.session_id,
         usage=completed.usage if isinstance(completed.usage, dict) else None,
+        result_text=completed.result,
     )
+
+
+def _append_json_contract(prompt: str, *, tool_name: str, schema: dict[str, Any]) -> str:
+    return (
+        f"{prompt}\n\nReturn only the JSON object for {tool_name}. Do not use Markdown fences or add "
+        "commentary. The object must match this JSON Schema:\n"
+        f"{json.dumps(schema, ensure_ascii=True, separators=(',', ':'))}"
+    )
+
+
+def _parse_json_result(value: str | None) -> dict[str, Any] | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if candidate.startswith("```") and candidate.endswith("```"):
+        lines = candidate.splitlines()
+        if len(lines) >= 3:
+            candidate = "\n".join(lines[1:-1]).strip()
+    try:
+        parsed = json.loads(candidate)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 def _structured_request(request_body: dict[str, Any]) -> tuple[str, str, str, dict[str, Any]]:

--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -35,6 +35,7 @@ from gateway.dashboard.domain import DashboardDefinition, FieldTarget, FilterRul
 from gateway.dashboard.operations import (
     canonicalize_dashboard_explore_names,
     canonicalize_dashboard_filter_targets,
+    canonicalize_dashboard_time_series_defaults,
     has_custom_sql,
     validate_dashboard_semantics,
     validate_time_series_default_windows,
@@ -742,6 +743,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
             candidate_definition = materialize_agent_draft(candidate, base_definition=base_definition)
             candidate_definition = canonicalize_dashboard_explore_names(candidate_definition, context)
             candidate_definition = canonicalize_dashboard_filter_targets(candidate_definition, context)
+            candidate_definition = canonicalize_dashboard_time_series_defaults(candidate_definition, context)
             validate_dashboard_semantics(candidate_definition, context)
             validate_time_series_default_windows(candidate_definition, context)
 
@@ -775,6 +777,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
         verified = await _verified_context(store, definition)
         definition = canonicalize_dashboard_explore_names(definition, verified)
         definition = canonicalize_dashboard_filter_targets(definition, verified)
+        definition = canonicalize_dashboard_time_series_defaults(definition, verified)
         validate_dashboard_semantics(definition, verified)
         validate_time_series_default_windows(definition, verified)
     except AnthropicMessagesError as exc:
@@ -902,6 +905,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
             candidate_definition = materialize_agent_draft(candidate, base_definition=current_definition)
             candidate_definition = canonicalize_dashboard_explore_names(candidate_definition, context)
             candidate_definition = canonicalize_dashboard_filter_targets(candidate_definition, context)
+            candidate_definition = canonicalize_dashboard_time_series_defaults(candidate_definition, context)
             validate_dashboard_semantics(candidate_definition, context)
             validate_time_series_default_windows(candidate_definition, context)
 
@@ -915,6 +919,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
         verified = await _verified_context(store, definition)
         definition = canonicalize_dashboard_explore_names(definition, verified)
         definition = canonicalize_dashboard_filter_targets(definition, verified)
+        definition = canonicalize_dashboard_time_series_defaults(definition, verified)
         validate_dashboard_semantics(definition, verified)
         validate_time_series_default_windows(definition, verified)
     except HTTPException:

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 from collections.abc import Callable
@@ -20,6 +21,8 @@ from gateway.dashboard.operations import DashboardOperation, apply_dashboard_ope
 from gateway.models.dashboards import DashboardSemanticContext
 
 DEFAULT_DASHBOARD_AUTHORING_MODEL = "claude-sonnet-4-5-20250929"
+DASHBOARD_AUTHORING_TIMEOUT_SECONDS = 180
+logger = logging.getLogger(__name__)
 
 FILTER_OPT_OUT_PATTERNS = (
     r"\bwithout (?:any )?(?:dashboard )?filters?\b",
@@ -89,38 +92,6 @@ def compact_semantic_projection(context: DashboardSemanticContext) -> dict[str, 
     }
 
 
-def charts_missing_usable_drills(
-    definition: DashboardDefinition,
-    context: DashboardSemanticContext,
-) -> list[str]:
-    """Return applicable Cartesian charts without a distinct next drill level."""
-    dimensions_by_explore = {
-        explore.name: {field.field_id for field in explore.dimensions} for explore in context.explores
-    }
-    missing: list[str] = []
-    for chart in definition.charts:
-        if not isinstance(chart.query, SemanticChartQuery) or not isinstance(chart.visualization, CartesianChartConfig):
-            continue
-        query_dimensions = set(chart.query.dimensions)
-        if not query_dimensions:
-            continue
-        explore_dimensions = dimensions_by_explore.get(chart.query.exploreName, set())
-        candidates = explore_dimensions - query_dimensions
-        if not candidates:
-            continue
-        drill_dimensions = chart.signalPilot.drillDimensions or []
-        if (
-            not drill_dimensions
-            or len(drill_dimensions) != len(set(drill_dimensions))
-            or any(field_id not in explore_dimensions for field_id in drill_dimensions)
-        ):
-            missing.append(chart.id)
-            continue
-        if any(field_id in query_dimensions for field_id in drill_dimensions):
-            missing.append(chart.id)
-    return missing
-
-
 class DashboardAuthoringAgent:
     def __init__(
         self,
@@ -137,10 +108,17 @@ class DashboardAuthoringAgent:
         elif oauth_token:
             self.model_client = ClaudeAgentSDKStructuredClient(
                 oauth_token=oauth_token,
-                timeout_seconds=90,
+                timeout_seconds=DASHBOARD_AUTHORING_TIMEOUT_SECONDS,
+                # The dashboard schema is too large for Claude Code's native
+                # constrained decoder. Pydantic and compiler validation below
+                # remain authoritative for the returned JSON object.
+                use_native_structured_output=False,
             )
         else:
-            self.model_client = AnthropicMessagesClient(api_key=api_key, timeout_seconds=90)
+            self.model_client = AnthropicMessagesClient(
+                api_key=api_key,
+                timeout_seconds=DASHBOARD_AUTHORING_TIMEOUT_SECONDS,
+            )
 
     async def draft(
         self,
@@ -165,7 +143,9 @@ class DashboardAuthoringAgent:
             "requested dashboard composition allows it. Arrange every dashboard row on the 36-column grid so tile "
             "widths sum to exactly 36, tiles use increasing x and y positions, and no row leaves unused horizontal space. "
             "Every dashboard must include useful global filter controls unless the user's request explicitly says to omit "
-            "filters. Prefer a date filter when a governed date or timestamp dimension is available, then add a small "
+            "filters. For dashboards with time-series charts, include an applicable governed date or timestamp filter "
+            "with a valid bounded default window and use a time aggregation coarse enough for that window. Otherwise, "
+            "prefer a date filter when a governed date or timestamp dimension is available, then add a small "
             "number of business-relevant categorical controls. Use explicit per-tile targets across explores and mark "
             "incompatible tiles as false. Copy each filter target exactly from the dimension's filter_target object; fieldId "
             "must remain the complete supplied field_id, including its explore prefix. When updating a draft that has no "
@@ -223,6 +203,7 @@ class DashboardAuthoringAgent:
             )
 
         last_error: ValueError | None = None
+        validation_errors: list[str] = []
         for attempt in range(MAX_DRAFT_ATTEMPTS):
             rejected_draft: Any = None
             try:
@@ -239,19 +220,20 @@ class DashboardAuthoringAgent:
                         "Dashboard authoring requires at least one governed filter control. Add a useful governed "
                         "filter, prefer a bounded date filter when available, and include explicit per-tile targets."
                     )
-                if base_definition is None and draft.definition is not None:
-                    missing_drills = charts_missing_usable_drills(draft.definition, context)
-                    if missing_drills:
-                        raise ValueError(
-                            "Dashboard authoring requires usable drill hierarchies for applicable charts: "
-                            f"{', '.join(missing_drills)}. Add a meaningful lower-grain drill hierarchy using exact "
-                            "same-explore field_id values without repeating query dimensions or drill levels."
-                        )
                 if validator is not None:
                     validator(draft)
                 return draft
             except ValueError as exc:
                 last_error = exc
+                error_text = str(exc)[:6000]
+                if error_text not in validation_errors:
+                    validation_errors.append(error_text)
+                logger.warning(
+                    "Dashboard authoring draft rejected attempt=%s/%s error=%s",
+                    attempt + 1,
+                    MAX_DRAFT_ATTEMPTS,
+                    str(exc)[:1000],
+                )
                 if attempt + 1 >= MAX_DRAFT_ATTEMPTS:
                     raise
                 repair_payload = {
@@ -261,7 +243,9 @@ class DashboardAuthoringAgent:
                         "copy explore and field identifiers exactly from semantic_context, preserve otherwise valid "
                         f"work, and resubmit the complete {mode} payload. Valid exploreName values: "
                         f"{', '.join(explore.name for explore in context.explores) or 'none'}. Never use <UNKNOWN> "
-                        f"or another placeholder.\n{str(exc)[:6000]}"
+                        "or another placeholder. Preserve every correction from earlier attempts. All validation "
+                        "failures reported so far must be fixed together:\n- "
+                        + "\n- ".join(validation_errors)
                     ),
                 }
                 if rejected_draft is not None:

--- a/signalpilot/gateway/gateway/dashboard/operations.py
+++ b/signalpilot/gateway/gateway/dashboard/operations.py
@@ -15,6 +15,7 @@ from gateway.dashboard.domain import (
     DashboardFieldTarget,
     DashboardFilterRule,
     DashboardTileDefinition,
+    FilterSettings,
     SemanticChartQuery,
 )
 from gateway.models.dashboards import DashboardSemanticContext
@@ -359,6 +360,37 @@ def _has_bounded_default(rule: DashboardFilterRule) -> bool:
         and rule.settings is not None
         and rule.settings.unitOfTime is not None
     )
+
+
+def canonicalize_dashboard_time_series_defaults(
+    definition: DashboardDefinition,
+    context: DashboardSemanticContext,
+) -> DashboardDefinition:
+    """Give an existing governed date filter a safe bounded default."""
+
+    logical_types = {
+        (explore.name, field.field_id): field.logical_type
+        for explore in context.explores
+        for field in explore.dimensions
+    }
+    changed = False
+    dimensions: list[DashboardFilterRule] = []
+    for rule in definition.filters.dimensions:
+        logical_type = logical_types.get((rule.target.tableName, rule.target.fieldId))
+        if logical_type in {"date", "timestamp"} and not _has_bounded_default(rule):
+            changed = True
+            rule = rule.model_copy(
+                update={
+                    "operator": "inThePast",
+                    "values": [30],
+                    "settings": FilterSettings(unitOfTime="days"),
+                }
+            )
+        dimensions.append(rule)
+    if not changed:
+        return definition
+    filters = definition.filters.model_copy(update={"dimensions": dimensions})
+    return definition.model_copy(update={"filters": filters})
 
 
 def validate_time_series_default_windows(

--- a/signalpilot/gateway/gateway/dashboard/semantic_resolver.py
+++ b/signalpilot/gateway/gateway/dashboard/semantic_resolver.py
@@ -32,6 +32,7 @@ from gateway.workspace_store.objects import workspace_object_storage
 from .project_snapshot import hydrate_github_mirror, materialize_workspace_snapshot
 
 SUPPORTED_AGGREGATIONS = {"sum", "count", "count_distinct", "average", "min", "max"}
+SUPPORTED_METRIC_FORMATS = {"integer", "decimal", "compact", "percentage"}
 
 
 class DashboardSemanticError(ValueError):
@@ -71,13 +72,23 @@ def parse_approved_metrics(settings: dict | None) -> list[dict[str, Any]]:
         aggregation = str(raw["aggregation"]).lower()
         if aggregation not in SUPPORTED_AGGREGATIONS:
             raise DashboardSemanticError(f"Unsupported approved metric aggregation: {aggregation}")
+        metric_format = str(raw["format"]) if raw.get("format") else None
+        if metric_format == "number":
+            metric_format = "decimal"
+        if metric_format and metric_format not in SUPPORTED_METRIC_FORMATS:
+            if not (
+                metric_format.startswith("currency:")
+                and len(metric_format) == 12
+                and metric_format[9:].isupper()
+            ):
+                raise DashboardSemanticError(f"Unsupported approved metric format: {metric_format}")
         parsed.append(
             {
                 "model": str(raw["model"]),
                 "column": str(raw["column"]),
                 "aggregation": aggregation,
                 "label": str(raw["label"]),
-                "format": str(raw["format"]) if raw.get("format") else None,
+                "format": metric_format,
                 "field_id": str(raw.get("field_id") or f"{raw['model']}.{raw['column']}"),
                 "approval_source": str(raw.get("approval_source") or "project_settings"),
             }

--- a/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
+++ b/signalpilot/gateway/tests/test_analysis_delivery_model_client.py
@@ -91,6 +91,7 @@ async def test_claude_agent_sdk_client_uses_claude_code_contract_for_oauth() -> 
     assert options["setting_sources"] == ["user"]
     assert options["tools"] == []
     assert options["permission_mode"] == "dontAsk"
+    assert options["max_turns"] == 2
     assert options["output_format"] == {"type": "json_schema", "schema": {"type": "object"}}
     assert options["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-token"
     assert options["env"]["ANTHROPIC_API_KEY"] == ""
@@ -142,3 +143,71 @@ async def test_claude_agent_sdk_client_preserves_safe_api_failure_status() -> No
     assert error.error_type == "rate_limit_error"
     assert error.request_id == "sdk-request-1"
     assert "oauth-token" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_sdk_client_preserves_result_when_structured_output_is_missing() -> None:
+    async def runner(_prompt: str, _options: dict) -> ClaudeAgentSDKResult:
+        return ClaudeAgentSDKResult(
+            structured_output=None,
+            is_error=False,
+            provider_message="The generated response did not match the requested schema",
+            request_id="sdk-request-2",
+        )
+
+    client = ClaudeAgentSDKStructuredClient(
+        oauth_token="oauth-token",
+        timeout_seconds=1,
+        query_runner=runner,
+    )
+    with pytest.raises(AnthropicMessagesError) as exc_info:
+        await client.create_message(
+            {
+                "model": "claude-test",
+                "system": "Stay governed.",
+                "messages": [{"role": "user", "content": "build a dashboard"}],
+                "tools": [{"name": "submit", "input_schema": {"type": "object"}}],
+                "tool_choice": {"type": "tool", "name": "submit"},
+            }
+        )
+
+    error = exc_info.value
+    assert error.error_type == "missing_structured_output"
+    assert error.provider_message == "The generated response did not match the requested schema"
+    assert error.request_id == "sdk-request-2"
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_sdk_client_can_parse_bounded_json_without_native_output() -> None:
+    captured: dict = {}
+
+    async def runner(prompt: str, options: dict) -> ClaudeAgentSDKResult:
+        captured.update(prompt=prompt, options=options)
+        return ClaudeAgentSDKResult(
+            structured_output=None,
+            is_error=False,
+            result_text='{"summary":"Created it","definition":{"name":"Revenue"}}',
+        )
+
+    client = ClaudeAgentSDKStructuredClient(
+        oauth_token="oauth-token",
+        timeout_seconds=1,
+        use_native_structured_output=False,
+        query_runner=runner,
+    )
+    response = await client.create_message(
+        {
+            "model": "claude-test",
+            "system": "Stay governed.",
+            "messages": [{"role": "user", "content": "build a dashboard"}],
+            "tools": [{"name": "submit", "input_schema": {"type": "object"}}],
+            "tool_choice": {"type": "tool", "name": "submit"},
+        }
+    )
+
+    assert "output_format" not in captured["options"]
+    assert "Return only the JSON object for submit" in captured["prompt"]
+    assert response["content"][0]["input"] == {
+        "summary": "Created it",
+        "definition": {"name": "Revenue"},
+    }

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -26,6 +26,7 @@ from gateway.dashboard.operations import (
     apply_dashboard_operations,
     canonicalize_dashboard_explore_names,
     canonicalize_dashboard_filter_targets,
+    canonicalize_dashboard_time_series_defaults,
     validate_dashboard_semantics,
     validate_time_series_default_windows,
 )
@@ -338,6 +339,23 @@ def test_time_series_authoring_accepts_a_bounded_relative_date_window() -> None:
     validate_time_series_default_windows(_definition_with_filter(), _orders_context())
 
 
+def test_time_series_authoring_canonicalizes_an_unbounded_governed_date_filter() -> None:
+    payload = _definition_with_filter().model_dump(mode="json", by_alias=True)
+    payload["filters"]["dimensions"][0].update({"operator": "inBetween", "values": []})
+
+    canonical = canonicalize_dashboard_time_series_defaults(
+        DashboardDefinition.model_validate(payload),
+        _orders_context(),
+    )
+
+    rule = canonical.filters.dimensions[0]
+    assert rule.operator == "inThePast"
+    assert rule.values == [30]
+    assert rule.settings is not None
+    assert rule.settings.unitOfTime == "days"
+    validate_time_series_default_windows(canonical, _orders_context())
+
+
 @pytest.mark.parametrize(
     ("drill_dimensions", "message"),
     [
@@ -429,6 +447,8 @@ def test_dashboard_authoring_uses_agent_sdk_for_oauth() -> None:
 
     assert isinstance(agent.model_client, ClaudeAgentSDKStructuredClient)
     assert agent.model_client.oauth_token == "oauth-token"
+    assert agent.model_client.timeout_seconds == 180
+    assert agent.model_client.use_native_structured_output is False
 
 
 @pytest.mark.asyncio
@@ -459,17 +479,10 @@ async def test_agent_repairs_filterless_creation_before_returning_the_draft() ->
 
 
 @pytest.mark.asyncio
-async def test_agent_repairs_creation_without_usable_drills() -> None:
+async def test_agent_allows_omitted_drills_without_a_declared_hierarchy() -> None:
     missing = _single_bar_definition(drill_dimensions=None)
-    repaired = _single_bar_definition(drill_dimensions=["orders.customer"])
     client = _ModelClient(
-        [
-            {"summary": "Created the dashboard.", "definition": missing.model_dump(mode="json", by_alias=True)},
-            {
-                "summary": "Created the dashboard with a region-to-customer drill.",
-                "definition": repaired.model_dump(mode="json", by_alias=True),
-            },
-        ]
+        {"summary": "Created the dashboard.", "definition": missing.model_dump(mode="json", by_alias=True)}
     )
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
@@ -480,29 +493,8 @@ async def test_agent_repairs_creation_without_usable_drills() -> None:
     )
 
     assert draft.definition is not None
-    assert draft.definition.charts[0].signalPilot.drillDimensions == ["orders.customer"]
-    assert len(client.requests) == 2
-    repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
-    assert "chart-bar" in repair_payload["validation_feedback"]
-    assert "lower-grain drill hierarchy" in repair_payload["validation_feedback"]
-
-
-@pytest.mark.asyncio
-async def test_agent_rejects_a_second_creation_without_usable_drills() -> None:
-    missing = _single_bar_definition(drill_dimensions=None)
-    client = _ModelClient(
-        {"summary": "Created the dashboard.", "definition": missing.model_dump(mode="json", by_alias=True)}
-    )
-    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
-
-    with pytest.raises(ValueError, match="requires usable drill hierarchies for applicable charts"):
-        await agent.draft(
-            prompt="Create an executive revenue dashboard",
-            context=_orders_context(),
-            base_definition=None,
-        )
-
-    assert len(client.requests) == 3
+    assert draft.definition.charts[0].signalPilot.drillDimensions is None
+    assert len(client.requests) == 1
 
 
 @pytest.mark.asyncio
@@ -614,6 +606,37 @@ async def test_agent_repairs_semantic_validation_failures_before_returning_the_d
     assert "Valid exploreName values: orders" in repair_payload["validation_feedback"]
     assert "Never use <UNKNOWN>" in repair_payload["validation_feedback"]
     assert repair_payload["rejected_draft"]["definition"]["charts"][0]["query"]["exploreName"] == "sales"
+
+
+@pytest.mark.asyncio
+async def test_agent_preserves_all_validation_failures_across_repair_attempts() -> None:
+    definition = _single_bar_definition(drill_dimensions=["orders.customer"])
+    response = {
+        "summary": "Created the dashboard.",
+        "definition": definition.model_dump(mode="json", by_alias=True),
+    }
+    client = _ModelClient([response, response, response])
+    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
+    validation_attempt = 0
+
+    def validate_candidate(_draft: DashboardAgentDraft) -> None:
+        nonlocal validation_attempt
+        validation_attempt += 1
+        if validation_attempt == 1:
+            raise ValueError("first governed validation failure")
+        if validation_attempt == 2:
+            raise ValueError("second governed validation failure")
+
+    await agent.draft(
+        prompt="Create an executive revenue dashboard",
+        context=_orders_context(),
+        base_definition=None,
+        validator=validate_candidate,
+    )
+
+    final_repair_payload = json.loads(client.requests[2]["messages"][0]["content"])
+    assert "first governed validation failure" in final_repair_payload["validation_feedback"]
+    assert "second governed validation failure" in final_repair_payload["validation_feedback"]
 
 
 @pytest.mark.asyncio

--- a/signalpilot/gateway/tests/test_dashboards.py
+++ b/signalpilot/gateway/tests/test_dashboards.py
@@ -111,6 +111,25 @@ def _authorities():
     )
 
 
+def test_approved_metric_number_format_is_canonicalized_for_dashboard_rendering() -> None:
+    metrics = parse_approved_metrics(
+        {
+            "dashboard_metrics": [
+                {
+                    "model": "orders",
+                    "column": "quantity",
+                    "aggregation": "sum",
+                    "label": "Orders",
+                    "format": "number",
+                    "approved": True,
+                }
+            ]
+        }
+    )
+
+    assert metrics[0]["format"] == "decimal"
+
+
 def _fixture_definition() -> DashboardDefinition:
     fixture = json.loads(FIXTURE.read_text())
     return DashboardDefinition.model_validate(


### PR DESCRIPTION
## Summary
- replace the oversized native structured-output path with bounded raw JSON plus existing Pydantic/compiler validation
- raise dashboard authoring timeout from 90s to 180s and allow the SDK turn needed to finish structured results
- canonicalize approved metric formats and bounded time-series defaults before final semantic validation
- retain cumulative repair feedback while removing the false mandatory-drill rejection

## Validation
- `uv run pytest -q tests/test_analysis_delivery_model_client.py tests/test_dashboard_authoring.py tests/test_dashboards.py`
- 68 passed
- local forced-OAuth Agent SDK probe returned `OK`
- local dashboard authoring API returned HTTP 201 with a validated preview session

## Scope
- targets `staging`
- excludes local `docker-compose.dev.yml` and `plugin/` changes