### PR TITLE
Repair refusal-shaped dashboard drafts

### DIFF
--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -21,7 +21,7 @@ from gateway.dashboard.operations import DashboardOperation, apply_dashboard_ope
 from gateway.models.dashboards import DashboardSemanticContext
 
 DEFAULT_DASHBOARD_AUTHORING_MODEL = "claude-sonnet-4-5-20250929"
-DASHBOARD_AUTHORING_TIMEOUT_SECONDS = 180
+DASHBOARD_AUTHORING_TIMEOUT_SECONDS = 240
 logger = logging.getLogger(__name__)
 
 FILTER_OPT_OUT_PATTERNS = (
@@ -159,6 +159,10 @@ class DashboardAuthoringAgent:
             "hierarchy only when the explore has no meaningful lower-grain dimension for that chart. "
             "Never emit renderer options, code, HTML, or SQL. For creation return a complete definition. "
             "For updates return typed operations using stable IDs and do not rewrite unrelated charts. "
+            "Never return a refusal-only summary, a null definition, or an empty operation list. When the request "
+            "names a business concept without an exact approved metric, use the closest faithful governed metric or "
+            "dimension when one is available, explain that substitution in the summary, and omit only the unsupported "
+            "element rather than refusing the entire dashboard. "
             "The server validates all output and the user must explicitly apply it."
         )
         payload = {
@@ -224,8 +228,31 @@ class DashboardAuthoringAgent:
                     validator(draft)
                 return draft
             except ValueError as exc:
-                last_error = exc
                 error_text = str(exc)[:6000]
+                empty_payload_feedback: str | None = None
+                if (
+                    isinstance(rejected_draft, dict)
+                    and rejected_draft.get("definition") is None
+                    and not rejected_draft.get("operations")
+                ):
+                    if mode == "create":
+                        empty_payload_feedback = (
+                            "The previous response was a refusal or empty payload. Dashboard creation must return a "
+                            "complete definition; do not return a limitation-only summary, null definition, or empty "
+                            "operations. Build the closest faithful dashboard supported by semantic_context. If a "
+                            "requested concept has no exact approved metric, use a faithful governed dimension or metric "
+                            "when available, explain the substitution in summary, and omit only that unsupported element."
+                        )
+                    else:
+                        empty_payload_feedback = (
+                            "The previous response was a refusal or empty payload. Dashboard updates must return at "
+                            "least one typed operation; do not return a limitation-only summary, null definition, or "
+                            "empty operations. Apply the closest faithful update supported by semantic_context and the "
+                            "base definition without inventing fields or metrics."
+                        )
+                last_error = ValueError(empty_payload_feedback) if empty_payload_feedback else exc
+                if empty_payload_feedback and empty_payload_feedback not in validation_errors:
+                    validation_errors.append(empty_payload_feedback)
                 if error_text not in validation_errors:
                     validation_errors.append(error_text)
                 logger.warning(

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -447,7 +447,7 @@ def test_dashboard_authoring_uses_agent_sdk_for_oauth() -> None:
 
     assert isinstance(agent.model_client, ClaudeAgentSDKStructuredClient)
     assert agent.model_client.oauth_token == "oauth-token"
-    assert agent.model_client.timeout_seconds == 180
+    assert agent.model_client.timeout_seconds == 240
     assert agent.model_client.use_native_structured_output is False
 
 
@@ -667,6 +667,38 @@ async def test_agent_repairs_invalid_tool_contract_before_returning_the_draft() 
     assert len(client.requests) == 2
     repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
     assert "either a complete definition or typed operations" in repair_payload["validation_feedback"]
+
+
+@pytest.mark.asyncio
+async def test_agent_repairs_refusal_shaped_creation_with_mode_specific_feedback() -> None:
+    repaired = _definition_with_filter()
+    client = _ModelClient(
+        [
+            {
+                "summary": "Cannot create customers because no exact customer metric is available.",
+                "definition": None,
+                "operations": [],
+            },
+            {
+                "summary": "Used governed account dimensions as the closest customer representation.",
+                "definition": repaired.model_dump(mode="json", by_alias=True),
+            },
+        ]
+    )
+    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
+
+    draft = await agent.draft(
+        prompt="Create an executive dashboard for revenue, margins and customers",
+        context=_context(),
+        base_definition=None,
+    )
+
+    assert draft.definition is not None
+    assert len(client.requests) == 2
+    repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
+    assert "refusal or empty payload" in repair_payload["validation_feedback"]
+    assert "closest faithful dashboard" in repair_payload["validation_feedback"]
+    assert "omit only that unsupported element" in repair_payload["validation_feedback"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make dashboard creation repair refusal-shaped responses instead of repeating an empty definition/operation payload
- tell the authoring model to use the closest faithful governed representation for unsupported business concepts and disclose the substitution
- preserve fail-closed semantic validation and never invent fields or metrics
- raise the provider call timeout from 180s to 240s; the exact Dumpsters prompt completed locally in 149.1s and staging ALB idle timeout is 300s

## Regression
Exact prompt: `create an executive dashboard for revenue, margins and customers` on the Dumpsters project. The provider may return `definition: null` and `operations: []` when no exact customer metric exists. The repair pass now requires a complete governed definition and permits the account/customer representation already present in semantic context.

## Validation
- `uv run pytest -q tests/test_analysis_delivery_model_client.py tests/test_dashboard_authoring.py tests/test_dashboards.py`
- 69 passed
- exact local live replay returned HTTP 201 with a validated preview in 149.1 seconds

## Scope
- targets `staging`
- excludes local `docker-compose.dev.yml` and `plugin/` changes