### PR TITLE
Normalize dashboard agent drafts before validation

### DIFF
--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -17,7 +17,7 @@ from gateway.analysis_delivery.model_client import (
     ClaudeAgentSDKStructuredClient,
     MessagesModelClient,
 )
-from gateway.dashboard.domain import ContractModel, DashboardDefinition
+from gateway.dashboard.domain import ContractModel, DashboardDefinition, SemanticChartQuery
 from gateway.dashboard.operations import DashboardOperation, apply_dashboard_operations
 from gateway.models.dashboards import DashboardSemanticContext
 
@@ -294,6 +294,8 @@ class DashboardAuthoringAgent:
                     raise ValueError("Dashboard creation requires a complete definition")
                 if base_definition is not None and draft.definition is not None:
                     raise ValueError("Dashboard updates require typed operations")
+                if not explicitly_omits_filters(prompt):
+                    draft = add_default_governed_date_filter(draft, context)
                 if not explicitly_omits_filters(prompt) and not draft_has_filters(
                     draft, base_definition=base_definition
                 ):
@@ -365,6 +367,75 @@ class DashboardAuthoringAgent:
 def explicitly_omits_filters(prompt: str) -> bool:
     normalized = " ".join(prompt.casefold().split())
     return any(re.search(pattern, normalized) for pattern in FILTER_OPT_OUT_PATTERNS)
+
+
+def add_default_governed_date_filter(
+    draft: DashboardAgentDraft,
+    context: DashboardSemanticContext,
+) -> DashboardAgentDraft:
+    """Add a bounded date control when creation omitted filters and the mapping is governed."""
+    definition = draft.definition
+    if definition is None or definition.filters.dimensions or definition.filters.metrics:
+        return draft
+    date_fields_by_explore = {
+        explore.name: [field for field in explore.dimensions if field.logical_type in {"date", "timestamp"}]
+        for explore in context.explores
+    }
+    selected_explore: str | None = None
+    selected_field = None
+    for chart in definition.charts:
+        if not isinstance(chart.query, SemanticChartQuery):
+            continue
+        candidates = {
+            field.field_id: field for field in date_fields_by_explore.get(chart.query.exploreName, [])
+        }
+        selected_field = next(
+            (candidates[field_id] for field_id in chart.query.dimensions if field_id in candidates),
+            None,
+        )
+        if selected_field is not None:
+            selected_explore = chart.query.exploreName
+            break
+    if selected_field is None:
+        for explore in context.explores:
+            fields = date_fields_by_explore.get(explore.name, [])
+            if fields:
+                selected_explore = explore.name
+                selected_field = fields[0]
+                break
+    if selected_explore is None or selected_field is None:
+        return draft
+
+    charts_by_id = {chart.id: chart for chart in definition.charts}
+    tile_targets: dict[str, dict[str, str] | bool] = {}
+    for tile in definition.tiles:
+        chart = charts_by_id.get(tile.chartId)
+        if chart is None or not isinstance(chart.query, SemanticChartQuery):
+            tile_targets[tile.uuid] = False
+            continue
+        target_fields = date_fields_by_explore.get(chart.query.exploreName, [])
+        if not target_fields:
+            tile_targets[tile.uuid] = False
+            continue
+        target_field = selected_field if chart.query.exploreName == selected_explore else target_fields[0]
+        tile_targets[tile.uuid] = {
+            "tableName": chart.query.exploreName,
+            "fieldId": target_field.field_id,
+        }
+
+    payload = definition.model_dump(mode="json", by_alias=True)
+    payload["filters"]["dimensions"] = [
+        {
+            "id": "date-filter",
+            "operator": "inThePast",
+            "values": [30],
+            "target": {"tableName": selected_explore, "fieldId": selected_field.field_id},
+            "tileTargets": tile_targets,
+            "label": selected_field.label or selected_field.column.replace("_", " ").title(),
+            "settings": {"unitOfTime": "days"},
+        }
+    ]
+    return draft.model_copy(update={"definition": DashboardDefinition.model_validate(payload)})
 
 
 def draft_has_filters(draft: DashboardAgentDraft, *, base_definition: DashboardDefinition | None) -> bool:

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 from collections.abc import Callable
+from copy import deepcopy
 from typing import Any
 
 from pydantic import Field, model_validator
@@ -16,7 +17,7 @@ from gateway.analysis_delivery.model_client import (
     ClaudeAgentSDKStructuredClient,
     MessagesModelClient,
 )
-from gateway.dashboard.domain import CartesianChartConfig, ContractModel, DashboardDefinition, SemanticChartQuery
+from gateway.dashboard.domain import ContractModel, DashboardDefinition
 from gateway.dashboard.operations import DashboardOperation, apply_dashboard_operations
 from gateway.models.dashboards import DashboardSemanticContext
 
@@ -48,6 +49,78 @@ class DashboardAgentDraft(ContractModel):
         if (self.definition is None) == (not self.operations):
             raise ValueError("Agent draft must contain either a complete definition or typed operations")
         return self
+
+
+def canonicalize_agent_draft_query_encodings(
+    value: Any,
+    context: DashboardSemanticContext,
+) -> Any:
+    """Repair only unambiguous raw visualization references before contract validation."""
+    if not isinstance(value, dict) or not isinstance(value.get("definition"), dict):
+        return value
+    normalized = deepcopy(value)
+    charts = normalized["definition"].get("charts")
+    if not isinstance(charts, list):
+        return normalized
+    metric_formats = {
+        metric.field_id: metric.format
+        for explore in context.explores
+        for metric in explore.metrics
+        if metric.format
+    }
+
+    def resolve(reference: Any, candidates: list[str], *, singleton: bool = False) -> Any:
+        if not isinstance(reference, str) or reference in candidates:
+            return reference
+        folded = reference.casefold()
+        matches = [
+            candidate
+            for candidate in candidates
+            if candidate.casefold() == folded or candidate.rsplit(".", 1)[-1].casefold() == folded
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if singleton and len(candidates) == 1:
+            return candidates[0]
+        return reference
+
+    for chart in charts:
+        if not isinstance(chart, dict):
+            continue
+        query = chart.get("query")
+        visualization = chart.get("visualization")
+        if (
+            not isinstance(query, dict)
+            or query.get("kind") != "semantic"
+            or not isinstance(visualization, dict)
+        ):
+            continue
+        dimensions = [item for item in query.get("dimensions", []) if isinstance(item, str)]
+        metrics = [item for item in query.get("metrics", []) if isinstance(item, str)]
+        config = visualization.get("config")
+        if not isinstance(config, dict):
+            continue
+        if visualization.get("type") == "big_number":
+            config["field"] = resolve(config.get("field"), metrics, singleton=True)
+            governed_format = metric_formats.get(config["field"])
+            if governed_format:
+                config["format"] = "decimal" if governed_format == "number" else governed_format
+        elif visualization.get("type") == "cartesian":
+            layout = config.get("layout")
+            if not isinstance(layout, dict):
+                continue
+            layout["xField"] = resolve(layout.get("xField"), dimensions, singleton=True)
+            y_fields = layout.get("yField")
+            if isinstance(y_fields, list):
+                singleton = len(y_fields) == 1
+                layout["yField"] = [resolve(item, metrics, singleton=singleton) for item in y_fields]
+        elif visualization.get("type") == "table":
+            outputs = [*dimensions, *metrics]
+            for key in ("columns", "groups"):
+                references = config.get(key)
+                if isinstance(references, list):
+                    config[key] = [resolve(item, outputs) for item in references]
+    return normalized
 
 
 def compact_semantic_projection(context: DashboardSemanticContext) -> dict[str, Any]:
@@ -151,6 +224,9 @@ class DashboardAuthoringAgent:
             "must remain the complete supplied field_id, including its explore prefix. When updating a draft that has no "
             "controls, add them in the same typed operation "
             "set unless the current request explicitly opts out. Do not treat silence about filters as an opt-out. "
+            "Every visualization encoding must copy an exact field ID already present in that chart's query: KPI field "
+            "and Cartesian yField values come from query.metrics, while Cartesian xField comes from query.dimensions. "
+            "For KPI format, copy the governed metric format when supplied; use percentage, never percent. "
             "For every applicable semantic bar, line, or area chart, configure a meaningful lower-grain drill hierarchy "
             "in signalPilot.drillDimensions when the same explore supplies a dimension below the chart's current business "
             "grain. Order drill dimensions from the immediate next level to the deepest level and copy complete field_id "
@@ -212,6 +288,7 @@ class DashboardAuthoringAgent:
             rejected_draft: Any = None
             try:
                 rejected_draft = await request_tool_input(request_body)
+                rejected_draft = canonicalize_agent_draft_query_encodings(rejected_draft, context)
                 draft = DashboardAgentDraft.model_validate(rejected_draft)
                 if base_definition is None and draft.definition is None:
                     raise ValueError("Dashboard creation requires a complete definition")

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -551,6 +551,37 @@ async def test_explicit_filter_opt_out_allows_a_filterless_draft() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_adds_a_governed_bounded_date_filter_without_an_extra_model_turn() -> None:
+    empty = _definition()
+    client = _ModelClient(
+        {"summary": "Created the dashboard.", "definition": empty.model_dump(mode="json", by_alias=True)}
+    )
+    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
+
+    draft = await agent.draft(
+        prompt="Create an executive dashboard for revenue, margins and customers",
+        context=_orders_context(),
+        base_definition=None,
+    )
+
+    assert draft.definition is not None
+    assert len(client.requests) == 1
+    assert len(draft.definition.filters.dimensions) == 1
+    rule = draft.definition.filters.dimensions[0]
+    assert rule.target.tableName == "orders"
+    assert rule.target.fieldId == "orders.month"
+    assert rule.operator == "inThePast"
+    assert rule.values == [30]
+    assert rule.settings is not None
+    assert rule.settings.unitOfTime == "days"
+    assert rule.tileTargets is not None
+    assert set(rule.tileTargets) == {tile.uuid for tile in draft.definition.tiles}
+    assert all(target is not False for target in rule.tileTargets.values())
+    validate_dashboard_semantics(draft.definition, _orders_context())
+    validate_time_series_default_windows(draft.definition, _orders_context())
+
+
+@pytest.mark.asyncio
 async def test_agent_rejects_a_second_filterless_response() -> None:
     empty = _definition()
     client = _ModelClient(

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -702,6 +702,38 @@ async def test_agent_repairs_refusal_shaped_creation_with_mode_specific_feedback
 
 
 @pytest.mark.asyncio
+async def test_agent_canonicalizes_unambiguous_visualization_aliases_before_contract_validation() -> None:
+    payload = _definition_with_filter().model_dump(mode="json", by_alias=True)
+    kpi = next(chart for chart in payload["charts"] if chart["id"] == "chart-kpi")
+    kpi["visualization"]["config"] = {"field": "total_revenue", "format": "percent"}
+    line = next(chart for chart in payload["charts"] if chart["id"] == "chart-line")
+    line["visualization"]["config"]["layout"] = {
+        "xField": "month",
+        "yField": ["revenue"],
+    }
+    context_payload = _orders_context().model_dump(mode="json")
+    context_payload["explores"][0]["metrics"][0]["format"] = "currency:USD"
+    context = DashboardSemanticContext.model_validate(context_payload)
+    client = _ModelClient({"summary": "Created executive dashboard.", "definition": payload})
+    agent = DashboardAuthoringAgent(api_key="test", model_client=client)
+
+    draft = await agent.draft(
+        prompt="Create an executive dashboard for revenue, margins and customers",
+        context=context,
+        base_definition=None,
+    )
+
+    assert draft.definition is not None
+    normalized_kpi = next(chart for chart in draft.definition.charts if chart.id == "chart-kpi")
+    assert normalized_kpi.visualization.config.field == "orders.revenue"
+    assert normalized_kpi.visualization.config.format == "currency:USD"
+    normalized_line = next(chart for chart in draft.definition.charts if chart.id == "chart-line")
+    assert normalized_line.visualization.config.layout.xField == "orders.month"
+    assert normalized_line.visualization.config.layout.yField == ["orders.revenue"]
+    assert len(client.requests) == 1
+
+
+@pytest.mark.asyncio
 async def test_create_authoring_session_canonicalizes_model_filter_targets(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- canonicalize only unambiguous raw visualization aliases before nested dashboard contract validation
- bind singleton KPI fields and Cartesian axes to the actual fields already present in each chart query
- use governed semantic metric formatting instead of model-invented aliases such as `percent`
- deterministically add a governed 30-day date filter when creation omits controls, including explicit per-tile targets and `false` for incompatible tiles
- preserve explicit filter opt-outs and fail closed whenever a field mapping is ambiguous or no governed date field exists
- strengthen authoring guidance to copy exact query field IDs and governed formats

## Regressions
- repairs staging errors for `total_revenue`, `total_customers`, `month`, and `revenue` encoding aliases plus unsupported `percent` formatting
- repairs repeated `Dashboard authoring requires at least one governed filter control` failures without spending another model turn

## Validation
- focused dashboard/model suite: 71 passed
- focused filter regression set: 5 passed
- `ruff check gateway/dashboard/authoring.py tests/test_dashboard_authoring.py`
- `git diff --check`

## Scope
- targets `staging`
- excludes local `docker-compose.dev.yml` and `plugin/` changes