### PR TITLE
Refactor dashboard creation through semantic intents

### DIFF
--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -23,6 +23,7 @@ from gateway.analysis_delivery.model_client import AnthropicMessagesError
 from gateway.config.notebooks import chat_force_oauth_token
 from gateway.dashboard import store as dashboard_store
 from gateway.dashboard.authoring import DashboardAuthoringAgent, materialize_agent_draft
+from gateway.dashboard.authoring_intent import DashboardIntentRepairError
 from gateway.dashboard.cache import dashboard_query_cache_key
 from gateway.dashboard.compiler import (
     DashboardCompileError,
@@ -752,6 +753,7 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
             context=context,
             base_definition=base_definition,
             validator=validate_candidate,
+            timezone=body.timezone,
         )
         definition = materialize_agent_draft(draft, base_definition=base_definition)
         if base_definition is None:
@@ -801,7 +803,8 @@ async def create_dashboard_authoring_session(body: DashboardAuthoringRequest, st
                 ),
             },
         )
-        raise HTTPException(status_code=422, detail=f"Agent draft rejected: {exc}") from exc
+        detail = str(exc) if isinstance(exc, DashboardIntentRepairError) else f"Agent draft rejected: {exc}"
+        raise HTTPException(status_code=422, detail=detail) from exc
     custom_sql = has_custom_sql(definition)
     return await dashboard_store.create_authoring_session(
         store.session,
@@ -914,6 +917,7 @@ async def continue_dashboard_authoring_session(session_id: str, body: DashboardA
             context=context,
             base_definition=current_definition,
             validator=validate_candidate,
+            timezone=current_definition.signalPilot.timezone,
         )
         definition = materialize_agent_draft(draft, base_definition=current_definition)
         verified = await _verified_context(store, definition)

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -10,12 +10,19 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
-from pydantic import Field, model_validator
+from pydantic import Field, ValidationError, model_validator
 
 from gateway.analysis_delivery.model_client import (
     AnthropicMessagesClient,
     ClaudeAgentSDKStructuredClient,
     MessagesModelClient,
+)
+from gateway.dashboard.authoring_intent import (
+    DashboardCreationIntent,
+    DashboardIntentIssue,
+    DashboardIntentRepairError,
+    DashboardIntentValidationError,
+    compile_dashboard_creation_intent,
 )
 from gateway.dashboard.domain import ContractModel, DashboardDefinition, SemanticChartQuery
 from gateway.dashboard.operations import DashboardOperation, apply_dashboard_operations
@@ -200,7 +207,15 @@ class DashboardAuthoringAgent:
         context: DashboardSemanticContext,
         base_definition: DashboardDefinition | None,
         validator: Callable[[DashboardAgentDraft], None] | None = None,
+        timezone: str = "UTC",
     ) -> DashboardAgentDraft:
+        if base_definition is None:
+            return await self._draft_creation_intent(
+                prompt=prompt,
+                context=context,
+                validator=validator,
+                timezone=timezone,
+            )
         mode = "update" if base_definition is not None else "create"
         contract = DashboardAgentDraft.model_json_schema(by_alias=True)
         system = (
@@ -360,6 +375,137 @@ class DashboardAuthoringAgent:
                     **request_body,
                     "messages": [{"role": "user", "content": json.dumps(repair_payload, default=str)}],
                 }
+        assert last_error is not None
+        raise last_error
+
+    async def _draft_creation_intent(
+        self,
+        *,
+        prompt: str,
+        context: DashboardSemanticContext,
+        validator: Callable[[DashboardAgentDraft], None] | None,
+        timezone: str,
+    ) -> DashboardAgentDraft:
+        contract = DashboardCreationIntent.model_json_schema(by_alias=True)
+        system = (
+            "You are SignalPilot's governed dashboard planner. Return only business copy and semantic choices using "
+            "the supplied explores, dimensions, and metrics. Copy exploreName and every field ID exactly from "
+            "semantic_context. Choose among KPI, table, bar, line, and area. KPI requires exactly one metric and no "
+            "dimensions. Bar, line, and area require exactly one dimension and at least one metric. Line and area "
+            "require a supplied date or timestamp dimension. Suggest useful governed filter dimensions, preferring a "
+            "date field plus a small number of business-relevant categorical fields unless the request opts out. The "
+            "server owns queries, encodings, formats, IDs, layout, filter defaults and targets, provenance, and project "
+            "metadata. Never emit SQL, renderer configuration, output bindings, placeholders, or fields absent from "
+            "semantic_context. When a requested concept has no exact approved metric, use the closest faithful "
+            "governed choice, explain the substitution in summary, and omit only the unsupported chart. Do not refuse "
+            "the whole dashboard when at least one faithful chart is possible."
+        )
+        payload = {
+            "mode": "create",
+            "request": prompt,
+            "semantic_context": compact_semantic_projection(context),
+            "filters_enabled": not explicitly_omits_filters(prompt),
+        }
+        request_body = {
+            "model": self.model,
+            "max_tokens": 8_000,
+            "system": system,
+            "messages": [{"role": "user", "content": json.dumps(payload, default=str)}],
+            "tools": [
+                {
+                    "name": "submit_dashboard_draft",
+                    "description": "Return a semantic dashboard creation intent. The server compiles all mechanics.",
+                    "input_schema": contract,
+                }
+            ],
+            "tool_choice": {"type": "tool", "name": "submit_dashboard_draft"},
+        }
+
+        async def request_tool_input(body: dict[str, Any]) -> Any:
+            response = await self.model_client.create_message(body)
+            content = response.get("content")
+            if not isinstance(content, list):
+                raise ValueError("Dashboard authoring model returned no tool result")
+            return next(
+                (
+                    block.get("input")
+                    for block in content
+                    if isinstance(block, dict)
+                    and block.get("type") == "tool_use"
+                    and block.get("name") == "submit_dashboard_draft"
+                ),
+                None,
+            )
+
+        feedback: list[dict[str, Any]] = []
+        rejected_fingerprints: set[str] = set()
+        last_error: ValueError | None = None
+        for attempt in range(MAX_DRAFT_ATTEMPTS):
+            rejected_intent = await request_tool_input(request_body)
+            fingerprint = json.dumps(rejected_intent, default=str, sort_keys=True, separators=(",", ":"))
+            repeated = fingerprint in rejected_fingerprints
+            rejected_fingerprints.add(fingerprint)
+            try:
+                intent = DashboardCreationIntent.model_validate(rejected_intent)
+                definition = compile_dashboard_creation_intent(
+                    intent,
+                    context,
+                    timezone=timezone,
+                    include_filters=not explicitly_omits_filters(prompt),
+                )
+                draft = DashboardAgentDraft(summary=intent.summary, definition=definition)
+                if validator is not None:
+                    validator(draft)
+                return draft
+            except DashboardIntentValidationError as exc:
+                issues = exc.as_payload()
+                last_error = exc
+            except ValidationError as exc:
+                issues = [
+                    DashboardIntentIssue(
+                        code="invalid_intent_contract",
+                        path=".".join(str(part) for part in error["loc"]) or "intent",
+                        message=error["msg"],
+                    ).model_dump(mode="json", by_alias=True, exclude_none=True)
+                    for error in exc.errors(include_url=False, include_input=False)
+                ]
+                last_error = ValueError("Dashboard creation intent did not match its contract")
+            except ValueError as exc:
+                issues = [
+                    DashboardIntentIssue(
+                        code="compiled_definition_invalid",
+                        path="intent",
+                        message=str(exc)[:1000],
+                    ).model_dump(mode="json", by_alias=True, exclude_none=True)
+                ]
+                last_error = exc
+            for issue in issues:
+                if issue not in feedback:
+                    feedback.append(issue)
+            logger.warning(
+                "Dashboard creation intent rejected attempt=%s/%s issue_codes=%s",
+                attempt + 1,
+                MAX_DRAFT_ATTEMPTS,
+                [issue["code"] for issue in issues],
+            )
+            if repeated:
+                raise DashboardIntentRepairError() from last_error
+            if attempt + 1 >= MAX_DRAFT_ATTEMPTS:
+                assert last_error is not None
+                raise DashboardIntentRepairError() from last_error
+            repair_payload = {
+                **payload,
+                "validation_feedback": feedback,
+                "repair_instruction": (
+                    "Correct every issue using only allowedValues and exact identifiers from semantic_context. "
+                    "Preserve all valid charts and previous corrections, then resubmit the complete semantic intent."
+                ),
+                "rejected_intent": rejected_intent,
+            }
+            request_body = {
+                **request_body,
+                "messages": [{"role": "user", "content": json.dumps(repair_payload, default=str)}],
+            }
         assert last_error is not None
         raise last_error
 

--- a/signalpilot/gateway/gateway/dashboard/authoring_intent.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring_intent.py
@@ -1,0 +1,548 @@
+"""Small model-authored dashboard intent and deterministic definition compiler."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Literal
+
+from pydantic import Field
+
+from gateway.dashboard.domain import (
+    AndFilterGroup,
+    CartesianChartConfig,
+    CartesianConfig,
+    CartesianLayout,
+    ChartDefinition,
+    ChartSignalPilot,
+    ContractModel,
+    DashboardDefinition,
+    DashboardFieldTarget,
+    DashboardFilterRule,
+    DashboardFilters,
+    DashboardSignalPilot,
+    DashboardTileDefinition,
+    DashboardTileProperties,
+    FilterRule,
+    FilterSettings,
+    KpiChartConfig,
+    KpiConfig,
+    QueryFilters,
+    SemanticChartQuery,
+    SortField,
+    TableChartConfig,
+    TableConfig,
+)
+from gateway.models.dashboards import DashboardSemanticContext, DashboardSemanticExplore
+
+VisualizationIntent = Literal["kpi", "table", "bar", "line", "area"]
+
+
+class DashboardChartIntent(ContractModel):
+    """Business and semantic choices the model is allowed to make for one chart."""
+
+    ref: str = Field(min_length=1, max_length=80)
+    visualization: VisualizationIntent
+    exploreName: str = Field(min_length=1)
+    dimensions: list[str] = Field(default_factory=list, max_length=4)
+    metrics: list[str] = Field(default_factory=list, max_length=4)
+    title: str = Field(min_length=1, max_length=100)
+    question: str = Field(min_length=1, max_length=120)
+    description: str = Field(min_length=1, max_length=1000)
+    drillDimensions: list[str] = Field(default_factory=list, max_length=4)
+
+
+class DashboardFilterIntent(ContractModel):
+    """A governed dimension the model considers useful as a dashboard control."""
+
+    exploreName: str = Field(min_length=1)
+    fieldId: str = Field(min_length=1)
+    label: str | None = Field(default=None, min_length=1, max_length=100)
+
+
+class DashboardCreationIntent(ContractModel):
+    """Creation-only model contract; renderer and persistence mechanics are excluded."""
+
+    summary: str = Field(min_length=1, max_length=1000)
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=1000)
+    charts: list[DashboardChartIntent] = Field(min_length=1, max_length=12)
+    filters: list[DashboardFilterIntent] = Field(default_factory=list, max_length=4)
+
+
+class DashboardIntentIssue(ContractModel):
+    code: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    rejectedValue: str | None = None
+    allowedValues: list[str] = Field(default_factory=list)
+
+
+class DashboardIntentValidationError(ValueError):
+    """Structured semantic feedback suitable for a bounded model repair turn."""
+
+    def __init__(self, issues: list[DashboardIntentIssue]) -> None:
+        self.issues = issues
+        super().__init__("; ".join(issue.message for issue in issues))
+
+    def as_payload(self) -> list[dict[str, Any]]:
+        return [issue.model_dump(mode="json", by_alias=True, exclude_none=True) for issue in self.issues]
+
+
+class DashboardIntentRepairError(ValueError):
+    """Safe terminal failure after bounded automatic semantic repair."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Dashboard authoring could not map the request to the project's governed fields after automatic repair. "
+            "Try naming an available metric or dimension more explicitly."
+        )
+
+
+def _slug(value: str, *, fallback: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+    return (slug or fallback)[:64]
+
+
+def _question(value: str) -> str:
+    normalized = value.rstrip()
+    return normalized if normalized.endswith("?") else f"{normalized}?"
+
+
+def _governed_format(value: str | None) -> str | None:
+    if value is None:
+        return None
+    aliases = {"number": "decimal", "percent": "percentage"}
+    normalized = aliases.get(value, value)
+    if normalized in {"integer", "decimal", "compact", "percentage"}:
+        return normalized
+    if normalized.startswith("currency:") and len(normalized) == 12 and normalized[9:].isupper():
+        return normalized
+    return None
+
+
+def _intent_issues(
+    intent: DashboardCreationIntent,
+    context: DashboardSemanticContext,
+) -> list[DashboardIntentIssue]:
+    issues: list[DashboardIntentIssue] = []
+    explores = {explore.name: explore for explore in context.explores}
+    explore_names = list(explores)
+    duplicate_refs = [ref for ref, count in Counter(chart.ref for chart in intent.charts).items() if count > 1]
+    for ref in duplicate_refs:
+        issues.append(
+            DashboardIntentIssue(
+                code="duplicate_chart_ref",
+                path="charts",
+                message=f"Chart ref must be unique: {ref}",
+                rejectedValue=ref,
+            )
+        )
+    for index, chart in enumerate(intent.charts):
+        path = f"charts[{index}]"
+        explore = explores.get(chart.exploreName)
+        if explore is None:
+            issues.append(
+                DashboardIntentIssue(
+                    code="unknown_explore",
+                    path=f"{path}.exploreName",
+                    message=f"Unknown explore: {chart.exploreName}",
+                    rejectedValue=chart.exploreName,
+                    allowedValues=explore_names,
+                )
+            )
+            continue
+        dimensions = {field.field_id: field for field in explore.dimensions}
+        metrics = {metric.field_id: metric for metric in explore.metrics}
+        for field_index, field_id in enumerate(chart.dimensions):
+            if field_id not in dimensions:
+                issues.append(
+                    DashboardIntentIssue(
+                        code="unknown_dimension",
+                        path=f"{path}.dimensions[{field_index}]",
+                        message=f"Unknown dimension for {chart.exploreName}: {field_id}",
+                        rejectedValue=field_id,
+                        allowedValues=list(dimensions),
+                    )
+                )
+        for field_index, field_id in enumerate(chart.metrics):
+            if field_id not in metrics:
+                issues.append(
+                    DashboardIntentIssue(
+                        code="unknown_metric",
+                        path=f"{path}.metrics[{field_index}]",
+                        message=f"Unknown metric for {chart.exploreName}: {field_id}",
+                        rejectedValue=field_id,
+                        allowedValues=list(metrics),
+                    )
+                )
+        for field_index, field_id in enumerate(chart.drillDimensions):
+            if field_id not in dimensions:
+                issues.append(
+                    DashboardIntentIssue(
+                        code="unknown_drill_dimension",
+                        path=f"{path}.drillDimensions[{field_index}]",
+                        message=f"Unknown drill dimension for {chart.exploreName}: {field_id}",
+                        rejectedValue=field_id,
+                        allowedValues=list(dimensions),
+                    )
+                )
+        if not chart.metrics:
+            issues.append(
+                DashboardIntentIssue(
+                    code="missing_metric",
+                    path=f"{path}.metrics",
+                    message=f"{chart.visualization} chart requires at least one governed metric",
+                    allowedValues=list(metrics),
+                )
+            )
+        if chart.visualization == "kpi" and (len(chart.metrics) != 1 or chart.dimensions):
+            issues.append(
+                DashboardIntentIssue(
+                    code="incompatible_visualization",
+                    path=path,
+                    message="KPI charts require exactly one metric and no dimensions",
+                )
+            )
+        if chart.visualization in {"bar", "line", "area"} and len(chart.dimensions) != 1:
+            issues.append(
+                DashboardIntentIssue(
+                    code="missing_dimension",
+                    path=f"{path}.dimensions",
+                    message=f"{chart.visualization} chart requires exactly one governed dimension",
+                    allowedValues=list(dimensions),
+                )
+            )
+        if chart.visualization in {"line", "area"} and len(chart.dimensions) == 1:
+            dimension = dimensions.get(chart.dimensions[0])
+            if dimension is not None and dimension.logical_type not in {"date", "timestamp"}:
+                date_dimensions = [
+                    field.field_id for field in explore.dimensions if field.logical_type in {"date", "timestamp"}
+                ]
+                issues.append(
+                    DashboardIntentIssue(
+                        code="incompatible_visualization",
+                        path=f"{path}.dimensions[0]",
+                        message=f"{chart.visualization} chart requires a governed date or timestamp dimension",
+                        rejectedValue=chart.dimensions[0],
+                        allowedValues=date_dimensions,
+                    )
+                )
+        repeated = set(chart.dimensions) & set(chart.drillDimensions)
+        if repeated or len(chart.drillDimensions) != len(set(chart.drillDimensions)):
+            issues.append(
+                DashboardIntentIssue(
+                    code="invalid_drill_hierarchy",
+                    path=f"{path}.drillDimensions",
+                    message="Drill dimensions must be distinct and cannot repeat a query dimension",
+                )
+            )
+    for index, filter_intent in enumerate(intent.filters):
+        path = f"filters[{index}]"
+        explore = explores.get(filter_intent.exploreName)
+        if explore is None:
+            issues.append(
+                DashboardIntentIssue(
+                    code="unknown_explore",
+                    path=f"{path}.exploreName",
+                    message=f"Unknown filter explore: {filter_intent.exploreName}",
+                    rejectedValue=filter_intent.exploreName,
+                    allowedValues=explore_names,
+                )
+            )
+            continue
+        dimensions = [field.field_id for field in explore.dimensions]
+        if filter_intent.fieldId not in dimensions:
+            issues.append(
+                DashboardIntentIssue(
+                    code="unsupported_filter",
+                    path=f"{path}.fieldId",
+                    message=f"Filter must reference a governed dimension: {filter_intent.fieldId}",
+                    rejectedValue=filter_intent.fieldId,
+                    allowedValues=dimensions,
+                )
+            )
+    return issues
+
+
+def _tile_layout(intent: DashboardCreationIntent) -> dict[int, tuple[int, int, int, int]]:
+    layout: dict[int, tuple[int, int, int, int]] = {}
+    kpi_indexes = [index for index, chart in enumerate(intent.charts) if chart.visualization == "kpi"]
+    y = 0
+    for start in range(0, len(kpi_indexes), 3):
+        row = kpi_indexes[start : start + 3]
+        width = 36 // len(row)
+        for position, chart_index in enumerate(row):
+            layout[chart_index] = (position * width, y, width, 5)
+        y += 5
+    for index, chart in enumerate(intent.charts):
+        if chart.visualization != "kpi":
+            layout[index] = (0, y, 36, 10)
+            y += 10
+    return layout
+
+
+def _date_field(explore: DashboardSemanticExplore, preferred: list[str]) -> str | None:
+    available = {
+        field.field_id for field in explore.dimensions if field.logical_type in {"date", "timestamp"}
+    }
+    return next((field_id for field_id in preferred if field_id in available), None) or next(
+        (field.field_id for field in explore.dimensions if field.field_id in available),
+        None,
+    )
+
+
+def _compiled_filters(
+    *,
+    intent: DashboardCreationIntent,
+    context: DashboardSemanticContext,
+    charts: list[ChartDefinition],
+    tiles: list[DashboardTileDefinition],
+    include_filters: bool,
+) -> list[DashboardFilterRule]:
+    if not include_filters:
+        return []
+    explores = {explore.name: explore for explore in context.explores}
+    chart_counts = Counter(chart.query.exploreName for chart in charts)
+    selected: list[DashboardFilterIntent] = []
+    seen: set[tuple[str, str]] = set()
+
+    def select(candidate: DashboardFilterIntent) -> None:
+        key = (candidate.exploreName, candidate.fieldId)
+        if key not in seen:
+            seen.add(key)
+            selected.append(candidate)
+
+    requested_dates = [
+        candidate
+        for candidate in intent.filters
+        if next(
+            (
+                field.logical_type
+                for field in explores[candidate.exploreName].dimensions
+                if field.field_id == candidate.fieldId
+            ),
+            None,
+        )
+        in {"date", "timestamp"}
+    ]
+    time_series_explores = {
+        chart.query.exploreName
+        for chart in charts
+        if chart.visualization.type == "cartesian" and chart.visualization.config.seriesType in {"line", "area"}
+    }
+    for explore_name in sorted(time_series_explores, key=lambda value: -chart_counts[value]):
+        explore = explores[explore_name]
+        preferred = [
+            candidate.fieldId for candidate in requested_dates if candidate.exploreName == explore_name
+        ] + [
+            chart.query.dimensions[0]
+            for chart in charts
+            if chart.query.exploreName == explore_name
+            and chart.visualization.type == "cartesian"
+            and chart.visualization.config.seriesType in {"line", "area"}
+        ]
+        field_id = _date_field(explore, preferred)
+        if field_id:
+            select(DashboardFilterIntent(exploreName=explore_name, fieldId=field_id))
+    if not selected:
+        for candidate in requested_dates:
+            select(candidate)
+            break
+    if not selected:
+        for explore_name, _count in chart_counts.most_common():
+            field_id = _date_field(explores[explore_name], [])
+            if field_id:
+                select(DashboardFilterIntent(exploreName=explore_name, fieldId=field_id))
+                break
+    for candidate in intent.filters:
+        explore = explores[candidate.exploreName]
+        logical_type = next(field.logical_type for field in explore.dimensions if field.field_id == candidate.fieldId)
+        if logical_type not in {"date", "timestamp"}:
+            select(candidate)
+        if len(selected) >= 3:
+            break
+    if not selected:
+        raise DashboardIntentValidationError(
+            [
+                DashboardIntentIssue(
+                    code="governed_filter_unavailable",
+                    path="filters",
+                    message="Dashboard creation requires a governed filter dimension, but none is available",
+                )
+            ]
+        )
+
+    rules: list[DashboardFilterRule] = []
+    tile_by_chart = {tile.chartId: tile for tile in tiles}
+    for index, candidate in enumerate(selected):
+        explore = explores[candidate.exploreName]
+        field = next(field for field in explore.dimensions if field.field_id == candidate.fieldId)
+        target = DashboardFieldTarget(tableName=explore.name, fieldId=field.field_id)
+        tile_targets: dict[str, DashboardFieldTarget | Literal[False]] = {}
+        for chart in charts:
+            tile = tile_by_chart[chart.id]
+            tile_targets[tile.uuid] = target if chart.query.exploreName == explore.name else False
+        is_date = field.logical_type in {"date", "timestamp"}
+        rules.append(
+            DashboardFilterRule(
+                id=f"filter-{index + 1}-{_slug(field.field_id, fallback='field')}",
+                operator="inThePast" if is_date else "equals",
+                values=[30] if is_date else [],
+                target=target,
+                tileTargets=tile_targets,
+                label=candidate.label or field.label or field.column.replace("_", " ").title(),
+                settings=FilterSettings(unitOfTime="days") if is_date else None,
+            )
+        )
+    return rules
+
+
+def compile_dashboard_creation_intent(
+    intent: DashboardCreationIntent,
+    context: DashboardSemanticContext,
+    *,
+    timezone: str,
+    include_filters: bool = True,
+) -> DashboardDefinition:
+    """Compile model-authored semantic choices into a complete governed definition."""
+
+    issues = _intent_issues(intent, context)
+    if issues:
+        raise DashboardIntentValidationError(issues)
+    explores = {explore.name: explore for explore in context.explores}
+    layout = _tile_layout(intent)
+    charts: list[ChartDefinition] = []
+    tiles: list[DashboardTileDefinition] = []
+    for index, chart_intent in enumerate(intent.charts):
+        explore = explores[chart_intent.exploreName]
+        metrics = {metric.field_id: metric for metric in explore.metrics}
+        chart_slug = f"{index + 1}-{_slug(chart_intent.ref or chart_intent.title, fallback='chart')}"
+        chart_id = f"chart-{chart_slug}"
+        tile_id = f"tile-{chart_slug}"
+        if chart_intent.visualization == "kpi":
+            visualization = KpiChartConfig(
+                type="big_number",
+                config=KpiConfig(
+                    field=chart_intent.metrics[0],
+                    format=_governed_format(metrics[chart_intent.metrics[0]].format),
+                ),
+            )
+            limit = 1
+            sorts: list[SortField] = []
+        elif chart_intent.visualization == "table":
+            visualization = TableChartConfig(
+                type="table",
+                config=TableConfig(
+                    columns=[*chart_intent.dimensions, *chart_intent.metrics],
+                    groups=chart_intent.dimensions or None,
+                ),
+            )
+            limit = 100
+            sorts = [SortField(fieldId=chart_intent.metrics[0], descending=True)]
+        else:
+            visualization = CartesianChartConfig(
+                type="cartesian",
+                config=CartesianConfig(
+                    seriesType=chart_intent.visualization,
+                    layout=CartesianLayout(
+                        xField=chart_intent.dimensions[0],
+                        yField=chart_intent.metrics,
+                    ),
+                ),
+            )
+            limit = 100
+            sorts = [
+                SortField(
+                    fieldId=(
+                        chart_intent.dimensions[0]
+                        if chart_intent.visualization in {"line", "area"}
+                        else chart_intent.metrics[0]
+                    ),
+                    descending=chart_intent.visualization == "bar",
+                )
+            ]
+        query_filters = QueryFilters()
+        if not include_filters and chart_intent.visualization in {"line", "area"}:
+            field_id = chart_intent.dimensions[0]
+            query_filters = QueryFilters(
+                dimensions=AndFilterGroup(
+                    id=f"window-{chart_slug}",
+                    **{
+                        "and": [
+                            FilterRule(
+                                id=f"window-rule-{chart_slug}",
+                                operator="inThePast",
+                                values=[30],
+                                target={"fieldId": field_id},
+                                settings=FilterSettings(unitOfTime="days"),
+                            )
+                        ]
+                    },
+                )
+            )
+        query = SemanticChartQuery(
+            kind="semantic",
+            exploreName=explore.name,
+            dimensions=chart_intent.dimensions,
+            metrics=chart_intent.metrics,
+            filters=query_filters,
+            sorts=sorts,
+            limit=limit,
+            timezone=timezone,
+            projectId=context.project_id,
+            commitSha=context.commit_sha,
+        )
+        charts.append(
+            ChartDefinition(
+                id=chart_id,
+                title=chart_intent.title,
+                question=_question(chart_intent.question),
+                description=chart_intent.description,
+                query=query,
+                visualization=visualization,
+                signalPilot=ChartSignalPilot(
+                    crossFilter=chart_intent.visualization != "kpi",
+                    drillDimensions=chart_intent.drillDimensions or None,
+                    tableGroups=chart_intent.dimensions or None if chart_intent.visualization == "table" else None,
+                    provenanceRef=f"agent-intent:{chart_slug}",
+                ),
+            )
+        )
+        x, y, width, height = layout[index]
+        tiles.append(
+            DashboardTileDefinition(
+                uuid=tile_id,
+                tileSlug=chart_slug,
+                type="saved_chart",
+                x=x,
+                y=y,
+                w=width,
+                h=height,
+                properties=DashboardTileProperties(title=chart_intent.title, chartSlug=chart_slug),
+                chartId=chart_id,
+            )
+        )
+    filters = _compiled_filters(
+        intent=intent,
+        context=context,
+        charts=charts,
+        tiles=tiles,
+        include_filters=include_filters,
+    )
+    return DashboardDefinition(
+        schemaVersion=1,
+        name=intent.name,
+        description=intent.description,
+        filters=DashboardFilters(dimensions=filters, metrics=[]),
+        tiles=tiles,
+        charts=charts,
+        signalPilot=DashboardSignalPilot(
+            dashboardId="draft-intent",
+            projectId=context.project_id,
+            connectionName=context.connection_name,
+            commitSha=context.commit_sha,
+            semanticFingerprint=context.semantic_fingerprint,
+            timezone=timezone,
+        ),
+    )

--- a/signalpilot/gateway/gateway/dashboard/operations.py
+++ b/signalpilot/gateway/gateway/dashboard/operations.py
@@ -362,6 +362,19 @@ def _has_bounded_default(rule: DashboardFilterRule) -> bool:
     )
 
 
+def _query_filter_rules(group) -> list:
+    if group is None:
+        return []
+    children = group.and_ if hasattr(group, "and_") else group.or_
+    rules = []
+    for child in children:
+        if hasattr(child, "target"):
+            rules.append(child)
+        else:
+            rules.extend(_query_filter_rules(child))
+    return rules
+
+
 def canonicalize_dashboard_time_series_defaults(
     definition: DashboardDefinition,
     context: DashboardSemanticContext,
@@ -414,6 +427,15 @@ def validate_time_series_default_windows(
         ):
             continue
         valid_window = False
+        if isinstance(chart.query, SemanticChartQuery):
+            query_field_types = explores.get(chart.query.exploreName, {})
+            valid_window = any(
+                query_field_types.get(rule.target.fieldId) in {"date", "timestamp"}
+                and _has_bounded_default(rule)
+                for rule in _query_filter_rules(chart.query.filters.dimensions)
+            )
+        if valid_window:
+            continue
         for tile in tiles_by_chart[chart.id]:
             for rule in definition.filters.dimensions:
                 explicit_target = (rule.tileTargets or {}).get(tile.uuid)

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -18,6 +18,7 @@ from gateway.analysis_delivery.model_client import AnthropicMessagesError, Claud
 from gateway.api import dashboards as dashboard_api
 from gateway.dashboard import store as dashboard_store
 from gateway.dashboard.authoring import DashboardAgentDraft, DashboardAuthoringAgent, materialize_agent_draft
+from gateway.dashboard.authoring_intent import DashboardIntentRepairError
 from gateway.dashboard.cache import dashboard_query_cache_key
 from gateway.dashboard.domain import DashboardDefinition
 from gateway.dashboard.operations import (
@@ -394,6 +395,35 @@ class _ModelClient:
         }
 
 
+def _creation_intent_payload(
+    *,
+    summary: str = "Created the dashboard.",
+    explore_name: str = "orders",
+    metric: str = "orders.revenue",
+    visualization: str = "bar",
+) -> dict:
+    dimensions = [] if visualization == "kpi" else ["orders.month" if visualization in {"line", "area"} else "orders.region"]
+    return {
+        "summary": summary,
+        "name": "Executive revenue",
+        "description": "A governed executive revenue overview.",
+        "charts": [
+            {
+                "ref": "revenue",
+                "visualization": visualization,
+                "exploreName": explore_name,
+                "dimensions": dimensions,
+                "metrics": [metric],
+                "title": "Revenue",
+                "question": "How is revenue performing?",
+                "description": "Governed revenue performance.",
+                "drillDimensions": [],
+            }
+        ],
+        "filters": [],
+    }
+
+
 class _ProviderFailingAgent:
     model = "claude-provider-test"
 
@@ -452,38 +482,27 @@ def test_dashboard_authoring_uses_agent_sdk_for_oauth() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_repairs_filterless_creation_before_returning_the_draft() -> None:
-    empty = _definition()
-    repaired = _definition_with_filter()
-    client = _ModelClient(
-        [
-            {"summary": "Created the dashboard.", "definition": empty.model_dump(mode="json", by_alias=True)},
-            {
-                "summary": "Created the dashboard with filters.",
-                "definition": repaired.model_dump(mode="json", by_alias=True),
-            },
-        ]
-    )
+async def test_agent_creation_uses_narrow_intent_schema_and_compiles_filters() -> None:
+    client = _ModelClient(_creation_intent_payload())
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
     draft = await agent.draft(
         prompt="Create an executive revenue dashboard",
-        context=_context(),
+        context=_orders_context(),
         base_definition=None,
     )
     assert draft.definition is not None
-    assert [rule.id for rule in draft.definition.filters.dimensions] == ["date-filter"]
-    assert len(client.requests) == 2
-    repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
-    assert "validation_feedback" in repair_payload
-    assert "rejected_draft" in repair_payload
+    assert len(draft.definition.filters.dimensions) == 1
+    assert draft.definition.filters.dimensions[0].target.fieldId == "orders.month"
+    assert len(client.requests) == 1
+    schema = json.dumps(client.requests[0]["tools"][0]["input_schema"])
+    assert "DashboardDefinition" not in schema
+    assert "sqlTemplate" not in schema
+    assert "tileTargets" not in schema
 
 
 @pytest.mark.asyncio
 async def test_agent_allows_omitted_drills_without_a_declared_hierarchy() -> None:
-    missing = _single_bar_definition(drill_dimensions=None)
-    client = _ModelClient(
-        {"summary": "Created the dashboard.", "definition": missing.model_dump(mode="json", by_alias=True)}
-    )
+    client = _ModelClient(_creation_intent_payload())
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
     draft = await agent.draft(
@@ -532,30 +551,25 @@ async def test_agent_repairs_filterless_follow_up_with_typed_filter_operation() 
 
 @pytest.mark.asyncio
 async def test_explicit_filter_opt_out_allows_a_filterless_draft() -> None:
-    empty = _definition()
     client = _ModelClient(
-        {
-            "summary": "Created the dashboard without filters.",
-            "definition": empty.model_dump(mode="json", by_alias=True),
-        }
+        _creation_intent_payload(summary="Created the dashboard without filters.", visualization="line")
     )
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
     draft = await agent.draft(
         prompt="Create an executive revenue dashboard without filters",
-        context=_context(),
+        context=_orders_context(),
         base_definition=None,
     )
     assert draft.definition is not None
     assert draft.definition.filters.dimensions == []
+    assert draft.definition.charts[0].query.filters.dimensions is not None
+    validate_time_series_default_windows(draft.definition, _orders_context())
     assert len(client.requests) == 1
 
 
 @pytest.mark.asyncio
 async def test_agent_adds_a_governed_bounded_date_filter_without_an_extra_model_turn() -> None:
-    empty = _definition()
-    client = _ModelClient(
-        {"summary": "Created the dashboard.", "definition": empty.model_dump(mode="json", by_alias=True)}
-    )
+    client = _ModelClient(_creation_intent_payload(visualization="line"))
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
     draft = await agent.draft(
@@ -583,38 +597,27 @@ async def test_agent_adds_a_governed_bounded_date_filter_without_an_extra_model_
 
 @pytest.mark.asyncio
 async def test_agent_rejects_a_second_filterless_response() -> None:
-    empty = _definition()
-    client = _ModelClient(
-        {"summary": "Created the dashboard.", "definition": empty.model_dump(mode="json", by_alias=True)}
-    )
+    invalid = _creation_intent_payload(metric="orders.missing")
+    client = _ModelClient(invalid)
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
-    with pytest.raises(ValueError, match="requires at least one governed filter control"):
+    with pytest.raises(ValueError, match="after automatic repair"):
         await agent.draft(
             prompt="Create an executive revenue dashboard",
-            context=_context(),
+            context=_orders_context(),
             base_definition=None,
         )
-    assert len(client.requests) == 3
+    assert len(client.requests) == 2
+    repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
+    assert repair_payload["validation_feedback"][0]["code"] == "unknown_metric"
+    assert repair_payload["validation_feedback"][0]["allowedValues"] == ["orders.revenue"]
 
 
 @pytest.mark.asyncio
 async def test_agent_repairs_semantic_validation_failures_before_returning_the_draft() -> None:
-    invalid_payload = _single_bar_definition(drill_dimensions=["orders.customer"]).model_dump(
-        mode="json", by_alias=True
-    )
-    invalid_payload["charts"][0]["query"]["exploreName"] = "sales"
-    repaired = _single_bar_definition(drill_dimensions=["orders.customer"])
+    invalid_payload = _creation_intent_payload(explore_name="sales")
+    repaired = _creation_intent_payload(summary="Created the dashboard with governed identifiers.")
     client = _ModelClient(
-        [
-            {
-                "summary": "Created the dashboard.",
-                "definition": invalid_payload,
-            },
-            {
-                "summary": "Created the dashboard with governed identifiers.",
-                "definition": repaired.model_dump(mode="json", by_alias=True),
-            },
-        ]
+        [invalid_payload, repaired]
     )
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
@@ -633,20 +636,19 @@ async def test_agent_repairs_semantic_validation_failures_before_returning_the_d
     assert draft.definition.charts[0].query.exploreName == "orders"
     assert len(client.requests) == 2
     repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
-    assert "Unknown explore: sales" in repair_payload["validation_feedback"]
-    assert "Valid exploreName values: orders" in repair_payload["validation_feedback"]
-    assert "Never use <UNKNOWN>" in repair_payload["validation_feedback"]
-    assert repair_payload["rejected_draft"]["definition"]["charts"][0]["query"]["exploreName"] == "sales"
+    assert repair_payload["validation_feedback"][0]["code"] == "unknown_explore"
+    assert repair_payload["validation_feedback"][0]["allowedValues"] == ["orders"]
+    assert repair_payload["rejected_intent"]["charts"][0]["exploreName"] == "sales"
 
 
 @pytest.mark.asyncio
 async def test_agent_preserves_all_validation_failures_across_repair_attempts() -> None:
-    definition = _single_bar_definition(drill_dimensions=["orders.customer"])
-    response = {
-        "summary": "Created the dashboard.",
-        "definition": definition.model_dump(mode="json", by_alias=True),
-    }
-    client = _ModelClient([response, response, response])
+    responses = [
+        _creation_intent_payload(summary="Created attempt one."),
+        _creation_intent_payload(summary="Created attempt two."),
+        _creation_intent_payload(summary="Created attempt three."),
+    ]
+    client = _ModelClient(responses)
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
     validation_attempt = 0
 
@@ -666,86 +668,73 @@ async def test_agent_preserves_all_validation_failures_across_repair_attempts() 
     )
 
     final_repair_payload = json.loads(client.requests[2]["messages"][0]["content"])
-    assert "first governed validation failure" in final_repair_payload["validation_feedback"]
-    assert "second governed validation failure" in final_repair_payload["validation_feedback"]
+    messages = [issue["message"] for issue in final_repair_payload["validation_feedback"]]
+    assert "first governed validation failure" in messages
+    assert "second governed validation failure" in messages
 
 
 @pytest.mark.asyncio
 async def test_agent_repairs_invalid_tool_contract_before_returning_the_draft() -> None:
-    repaired = _definition_with_filter()
+    repaired = _creation_intent_payload(summary="Created one governed dashboard intent.")
     client = _ModelClient(
         [
             {
-                "summary": "Returned both payload types.",
-                "definition": repaired.model_dump(mode="json", by_alias=True),
-                "operations": [{"operation": "rename_dashboard", "name": "Wrong mode"}],
+                "summary": "Returned an incomplete intent.",
+                "name": "Executive revenue",
+                "charts": [],
             },
-            {
-                "summary": "Created one complete dashboard definition.",
-                "definition": repaired.model_dump(mode="json", by_alias=True),
-            },
+            repaired,
         ]
     )
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
     draft = await agent.draft(
         prompt="Create an executive revenue dashboard",
-        context=_context(),
+        context=_orders_context(),
         base_definition=None,
     )
 
     assert draft.definition is not None
     assert len(client.requests) == 2
     repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
-    assert "either a complete definition or typed operations" in repair_payload["validation_feedback"]
+    assert repair_payload["validation_feedback"][0]["code"] == "invalid_intent_contract"
+    assert repair_payload["validation_feedback"][0]["path"] == "charts"
 
 
 @pytest.mark.asyncio
 async def test_agent_repairs_refusal_shaped_creation_with_mode_specific_feedback() -> None:
-    repaired = _definition_with_filter()
+    repaired = _creation_intent_payload(
+        summary="Used governed revenue as the closest supported executive measure."
+    )
     client = _ModelClient(
         [
             {
                 "summary": "Cannot create customers because no exact customer metric is available.",
-                "definition": None,
-                "operations": [],
             },
-            {
-                "summary": "Used governed account dimensions as the closest customer representation.",
-                "definition": repaired.model_dump(mode="json", by_alias=True),
-            },
+            repaired,
         ]
     )
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
     draft = await agent.draft(
         prompt="Create an executive dashboard for revenue, margins and customers",
-        context=_context(),
+        context=_orders_context(),
         base_definition=None,
     )
 
     assert draft.definition is not None
     assert len(client.requests) == 2
     repair_payload = json.loads(client.requests[1]["messages"][0]["content"])
-    assert "refusal or empty payload" in repair_payload["validation_feedback"]
-    assert "closest faithful dashboard" in repair_payload["validation_feedback"]
-    assert "omit only that unsupported element" in repair_payload["validation_feedback"]
+    assert {issue["path"] for issue in repair_payload["validation_feedback"]} >= {"name", "charts"}
+    assert "faithful" in client.requests[0]["system"]
 
 
 @pytest.mark.asyncio
-async def test_agent_canonicalizes_unambiguous_visualization_aliases_before_contract_validation() -> None:
-    payload = _definition_with_filter().model_dump(mode="json", by_alias=True)
-    kpi = next(chart for chart in payload["charts"] if chart["id"] == "chart-kpi")
-    kpi["visualization"]["config"] = {"field": "total_revenue", "format": "percent"}
-    line = next(chart for chart in payload["charts"] if chart["id"] == "chart-line")
-    line["visualization"]["config"]["layout"] = {
-        "xField": "month",
-        "yField": ["revenue"],
-    }
+async def test_agent_compiler_owns_visualization_encodings_and_metric_formats() -> None:
     context_payload = _orders_context().model_dump(mode="json")
     context_payload["explores"][0]["metrics"][0]["format"] = "currency:USD"
     context = DashboardSemanticContext.model_validate(context_payload)
-    client = _ModelClient({"summary": "Created executive dashboard.", "definition": payload})
+    client = _ModelClient(_creation_intent_payload(visualization="line"))
     agent = DashboardAuthoringAgent(api_key="test", model_client=client)
 
     draft = await agent.draft(
@@ -755,12 +744,10 @@ async def test_agent_canonicalizes_unambiguous_visualization_aliases_before_cont
     )
 
     assert draft.definition is not None
-    normalized_kpi = next(chart for chart in draft.definition.charts if chart.id == "chart-kpi")
-    assert normalized_kpi.visualization.config.field == "orders.revenue"
-    assert normalized_kpi.visualization.config.format == "currency:USD"
-    normalized_line = next(chart for chart in draft.definition.charts if chart.id == "chart-line")
-    assert normalized_line.visualization.config.layout.xField == "orders.month"
-    assert normalized_line.visualization.config.layout.yField == ["orders.revenue"]
+    line = draft.definition.charts[0]
+    assert line.visualization.config.layout.xField == "orders.month"
+    assert line.visualization.config.layout.yField == ["orders.revenue"]
+    assert "format" not in json.dumps(client.requests[0]["tools"][0]["input_schema"])
     assert len(client.requests) == 1
 
 
@@ -914,6 +901,50 @@ async def test_create_authoring_session_returns_safe_provider_failure(
     assert exc_info.value.status_code == 502
     assert exc_info.value.detail == dashboard_api._AUTHORING_PROVIDER_REJECTED
     assert "Input is too long" not in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_authoring_session_returns_safe_exhausted_intent_failure(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExhaustedIntentAgent:
+        model = "test-model"
+
+        def __init__(self, *, api_key: str) -> None:
+            assert api_key == "test-key"
+
+        async def draft(self, **_kwargs) -> DashboardAgentDraft:
+            raise DashboardIntentRepairError()
+
+    async def resolve_context(*_args, **_kwargs) -> DashboardSemanticContext:
+        return _orders_context()
+
+    async def resolve_key(*_args, **_kwargs) -> str:
+        return "test-key"
+
+    monkeypatch.setattr(dashboard_api.resolver, "resolve", resolve_context)
+    monkeypatch.setattr(dashboard_api, "DashboardAuthoringAgent", ExhaustedIntentAgent)
+    monkeypatch.setattr(dashboard_api.org_secrets_store, "resolve_anthropic_key", resolve_key)
+    store = SimpleNamespace(
+        session=db_session,
+        user_id="owner-a",
+        _require_org_id=lambda: "org-a",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dashboard_api.create_dashboard_authoring_session(
+            DashboardAuthoringRequest(
+                prompt="Create an executive dashboard",
+                project_id="project-1",
+                commit_sha="a" * 40,
+            ),
+            store,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "after automatic repair" in str(exc_info.value.detail)
+    assert "Agent draft rejected" not in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio

--- a/signalpilot/gateway/tests/test_dashboard_authoring_intent.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring_intent.py
@@ -1,0 +1,244 @@
+"""Creation intent schema and deterministic compiler coverage."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gateway.dashboard.authoring_intent import (
+    DashboardChartIntent,
+    DashboardCreationIntent,
+    DashboardFilterIntent,
+    DashboardIntentValidationError,
+    compile_dashboard_creation_intent,
+)
+from gateway.dashboard.operations import validate_dashboard_semantics, validate_time_series_default_windows
+from gateway.models.dashboards import DashboardSemanticContext
+
+
+def _context() -> DashboardSemanticContext:
+    return DashboardSemanticContext.model_validate(
+        {
+            "project_id": "project-1",
+            "commit_sha": "b91bd2273f38fdc58702c71f538b6b5d5ae462c5",
+            "connection_name": "mssql-pilot",
+            "connection_type": "mssql",
+            "physical_schema_fingerprint": "physical",
+            "semantic_fingerprint": "semantic",
+            "explores": [
+                {
+                    "name": "orders",
+                    "label": "Orders",
+                    "relation": "dbo.orders",
+                    "dimensions": [
+                        {
+                            "field_id": "orders.month",
+                            "column": "month",
+                            "logical_type": "date",
+                            "label": "Month",
+                        },
+                        {
+                            "field_id": "orders.region",
+                            "column": "region",
+                            "logical_type": "string",
+                            "label": "Region",
+                        },
+                    ],
+                    "metrics": [
+                        {
+                            "field_id": "orders.revenue",
+                            "column": "revenue",
+                            "logical_type": "number",
+                            "label": "Revenue",
+                            "aggregation": "sum",
+                            "format": "currency:USD",
+                            "approval_source": "test",
+                            "human_verified": True,
+                        },
+                        {
+                            "field_id": "orders.margin",
+                            "column": "margin",
+                            "logical_type": "number",
+                            "label": "Margin",
+                            "aggregation": "average",
+                            "format": "percent",
+                            "approval_source": "test",
+                            "human_verified": True,
+                        },
+                    ],
+                },
+                {
+                    "name": "customers",
+                    "label": "Customers",
+                    "relation": "dbo.customers",
+                    "dimensions": [
+                        {
+                            "field_id": "customers.created_month",
+                            "column": "created_month",
+                            "logical_type": "date",
+                        },
+                        {
+                            "field_id": "customers.segment",
+                            "column": "segment",
+                            "logical_type": "string",
+                        },
+                    ],
+                    "metrics": [
+                        {
+                            "field_id": "customers.count",
+                            "column": "customer_id",
+                            "logical_type": "number",
+                            "label": "Customers",
+                            "aggregation": "count_distinct",
+                            "format": "number",
+                            "approval_source": "test",
+                            "human_verified": True,
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def _intent() -> DashboardCreationIntent:
+    return DashboardCreationIntent(
+        summary="Created an executive overview.",
+        name="Executive Overview",
+        description="Revenue, margin, and customer health.",
+        charts=[
+            DashboardChartIntent(
+                ref="revenue",
+                visualization="kpi",
+                exploreName="orders",
+                metrics=["orders.revenue"],
+                title="Total Revenue",
+                question="What is total revenue",
+                description="Current governed revenue.",
+            ),
+            DashboardChartIntent(
+                ref="margin",
+                visualization="kpi",
+                exploreName="orders",
+                metrics=["orders.margin"],
+                title="Gross Margin",
+                question="What is gross margin?",
+                description="Current governed margin.",
+            ),
+            DashboardChartIntent(
+                ref="customers",
+                visualization="kpi",
+                exploreName="customers",
+                metrics=["customers.count"],
+                title="Customers",
+                question="How many customers are there?",
+                description="Current governed customer count.",
+            ),
+            DashboardChartIntent(
+                ref="revenue-trend",
+                visualization="line",
+                exploreName="orders",
+                dimensions=["orders.month"],
+                metrics=["orders.revenue"],
+                title="Revenue Trend",
+                question="How is revenue changing?",
+                description="Line chart showing revenue over time.",
+            ),
+        ],
+        filters=[DashboardFilterIntent(exploreName="orders", fieldId="orders.region")],
+    )
+
+
+def test_creation_intent_schema_excludes_dashboard_mechanics_and_sql() -> None:
+    schema = json.dumps(DashboardCreationIntent.model_json_schema(by_alias=True))
+
+    for forbidden in (
+        "sqlTemplate",
+        "outputBindings",
+        "xField",
+        "yField",
+        "tileTargets",
+        "signalPilot",
+        "commitSha",
+        "format",
+    ):
+        assert forbidden not in schema
+
+
+def test_compiler_generates_valid_definition_with_formats_layout_and_filters() -> None:
+    definition = compile_dashboard_creation_intent(_intent(), _context(), timezone="America/New_York")
+
+    assert [tile.w for tile in definition.tiles[:3]] == [12, 12, 12]
+    assert [tile.x for tile in definition.tiles[:3]] == [0, 12, 24]
+    assert definition.tiles[3].w == 36
+    assert definition.tiles[3].y == 5
+    revenue, margin, customers, trend = definition.charts
+    assert revenue.visualization.config.field == "orders.revenue"
+    assert revenue.visualization.config.format == "currency:USD"
+    assert margin.visualization.config.format == "percentage"
+    assert customers.visualization.config.format == "decimal"
+    assert trend.visualization.config.layout.xField == "orders.month"
+    assert trend.visualization.config.layout.yField == ["orders.revenue"]
+    assert revenue.question == "What is total revenue?"
+    assert definition.signalPilot.timezone == "America/New_York"
+    date_filter, region_filter = definition.filters.dimensions
+    assert date_filter.target.fieldId == "orders.month"
+    assert date_filter.operator == "inThePast"
+    assert date_filter.values == [30]
+    assert date_filter.tileTargets is not None
+    assert date_filter.tileTargets[definition.tiles[2].uuid] is False
+    assert region_filter.target.fieldId == "orders.region"
+    validate_dashboard_semantics(definition, _context())
+    validate_time_series_default_windows(definition, _context())
+
+
+def test_compiler_is_deterministic_for_the_same_intent() -> None:
+    first = compile_dashboard_creation_intent(_intent(), _context(), timezone="UTC")
+    second = compile_dashboard_creation_intent(_intent(), _context(), timezone="UTC")
+
+    assert first == second
+
+
+def test_compiler_returns_structured_unknown_metric_feedback() -> None:
+    intent = _intent().model_copy(deep=True)
+    intent.charts[0].metrics = ["orders.total_revenue"]
+
+    with pytest.raises(DashboardIntentValidationError) as error:
+        compile_dashboard_creation_intent(intent, _context(), timezone="UTC")
+
+    issue = error.value.as_payload()[0]
+    assert issue == {
+        "code": "unknown_metric",
+        "path": "charts[0].metrics[0]",
+        "message": "Unknown metric for orders: orders.total_revenue",
+        "rejectedValue": "orders.total_revenue",
+        "allowedValues": ["orders.revenue", "orders.margin"],
+    }
+
+
+def test_compiler_rejects_duplicate_chart_refs_before_generating_ids() -> None:
+    intent = _intent().model_copy(deep=True)
+    intent.charts[1].ref = intent.charts[0].ref
+
+    with pytest.raises(DashboardIntentValidationError) as error:
+        compile_dashboard_creation_intent(intent, _context(), timezone="UTC")
+
+    assert error.value.as_payload()[0]["code"] == "duplicate_chart_ref"
+
+
+def test_filter_opt_out_uses_private_bounded_query_window_for_time_series() -> None:
+    definition = compile_dashboard_creation_intent(
+        _intent(),
+        _context(),
+        timezone="UTC",
+        include_filters=False,
+    )
+
+    assert definition.filters.dimensions == []
+    trend = definition.charts[3]
+    assert trend.query.filters.dimensions is not None
+    rule = trend.query.filters.dimensions.and_[0]
+    assert rule.operator == "inThePast"
+    assert rule.values == [30]
+    validate_time_series_default_windows(definition, _context())


### PR DESCRIPTION
## Summary

- replace full DashboardDefinition generation for new dashboards with a narrow semantic creation intent
- compile queries, encodings, formats, IDs, layout, filters, tile targets, provenance, and project bindings deterministically on the server
- return structured governed-field repair feedback with bounded retries and no-progress detection
- preserve the existing typed-operation path for dashboard follow-ups
- keep time-series previews bounded even when dashboard filter controls are explicitly omitted

## Why

The previous creation schema exposed SQL queries and renderer/persistence mechanics even though the prompt prohibited them. Model retries therefore produced changing validation failures involving SQL output aliases, visualization encodings, formats, filters, and tile targets.

The new model-facing schema contains only business copy and governed semantic choices. It is 2,244 characters versus 18,528 for the previous draft schema, an 87.9% reduction. The server remains the final compiler and validation authority.

## Validation

- Ruff passed for all changed Python files
- focused dashboard and model-client suite: 106 passed
- git diff --check passed
- exact local forced-OAuth request against Dumpsters returned HTTP 201 in 65.9 seconds
- generated seven semantic-only charts and three governed filters with explicit incompatible-tile mappings
- live revenue-trend preview query returned HTTP 200 with a complete result

## Full-suite boundary

The broad local gateway run completed with 4,155 passing and 357 skipped tests, but it is not a clean repository gate in this environment: unrelated credential, auth, scope, and service-fixture suites produced 194 failures and 193 setup errors. The focused changed-area suite was rerun afterward and remained green.

## Product boundaries

- no database migration
- no frontend response-shape change
- no feature flag
- no custom SQL from AI creation
- private preview and explicit Apply behavior remain unchanged
