### PR TITLE
fix(security): annotate scratch-root default for bandit B108

### DIFF
--- a/signalpilot/gateway/gateway/standalone_chat/worker_files.py
+++ b/signalpilot/gateway/gateway/standalone_chat/worker_files.py
@@ -44,8 +44,10 @@ def reset_debounce(run_id: str) -> None:
 
 
 def _scratch_root() -> str:
-    root = os.getenv("SP_CHAT_SCRATCH_ROOT", "/tmp/signalpilot-chat-runs").strip()
-    return (root or "/tmp/signalpilot-chat-runs").rstrip("/")
+    # nosec B108 - container-local scratch root, same default the sandbox uses
+    default = "/tmp/signalpilot-chat-runs"  # nosec B108
+    root = os.getenv("SP_CHAT_SCRATCH_ROOT", default).strip()
+    return (root or default).rstrip("/")
 
 
 def _relative_scratch_path(file_path: Any) -> str | None:


### PR DESCRIPTION
Unblocks the security gate on main: bandit flags the hardcoded /tmp scratch-root default in the chat file mirror. The sandbox side of the same constant already carries the nosec B108 annotation; this applies the same treatment. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)