### PR TITLE
Use dbt context for dashboard authoring without metric approvals

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,7 +52,6 @@ services:
       # tested without one tab taking over another.
       SP_ALLOW_CONCURRENT_EDIT_SESSIONS: "true"
       SP_AGENT_EFFORT: "medium"
-      SIGNALPILOT_PLUGIN_VERSION: "deployed"
     volumes:
       - ./signalpilot/notebook-server/signalpilot:/opt/sp-notebook/signalpilot:cached
       - ./scripts/dev-watch-notebook.py:/usr/local/bin/dev-watch-notebook.py:ro

--- a/signalpilot-plugin/skills/dashboard-authoring/SKILL.md
+++ b/signalpilot-plugin/skills/dashboard-authoring/SKILL.md
@@ -14,14 +14,15 @@ Use authoring contract `2026-09-02.1`. If the skill or matching tools are unavai
 Write concise user-visible progress only for context resolution, chart drafting, and final assembly. Validation and schema correction are internal work: never narrate individual validation calls or retries.
 
 1. Call `begin_dashboard_authoring` first with the complete request and timezone. For a refinement, pass the exact active `authoring_session_id` from warm context.
-2. Use only the returned semantic projection, stable IDs, limits, contract version, and revisions. Never invent explores, fields, metrics, filters, or bindings.
-3. For a new dashboard, submit one complete typed plan with `set_dashboard_plan`. Use stable chart, tile, and filter IDs; approved metrics; exact semantic fields; explicit filter mappings; required flags; and non-overlapping layout intent. `visualization` is a string. Filters belong only in `plan.filters`; intents reference them through `shared_filter_ids`.
+2. Use only the returned dbt semantic projection, stable IDs, limits, contract version, and revisions. Never invent models, fields, metrics, filters, or bindings. Treat each explore as a dbt model at its documented grain. When one model contains the dimensions and measures needed for a chart, use that model instead of reconstructing its logic from lower-level models.
+3. For a new dashboard, submit one complete typed plan with `set_dashboard_plan`. Use stable chart, tile, and filter IDs; exact dbt-backed semantic fields; explicit filter mappings; required flags; and non-overlapping layout intent. Metrics are aggregatable dbt model columns; `aggregation_inferred` tells you whether SignalPilot derived the aggregation from the column type/name instead of explicit semantic metadata. `visualization` is a string. Filters belong only in `plan.filters`; intents reference them through `shared_filter_ids`.
    Before submitting the plan, inspect every `line` or `area` intent. Each one must include a governed date/timestamp dimension and reference an applicable bounded date filter through `shared_filter_ids`. The filter must target that intent's explore directly or through its `tileTargets` entry. Never submit a time-series plan first and add its required window in a repair call.
 4. Construct chart payloads from the exact tool schema and canonical shapes below before calling any chart tool. Never use tool failures to discover the payload shape. Once every chart has the same proven structural contract, up to five independent initial `upsert_dashboard_chart` calls may run concurrently. Completion order must not change IDs, plan order, or the final result.
 5. When governed semantic validation rejects one chart, preserve every ready chart, use only the returned safe issues and allowed alternatives, then retry that chart once without user-visible narration. Do not retry it a second time. An input-schema error means the loaded contract was not followed: correct the exact JSON path once and never fan out that invalid shape.
 6. Use `apply_dashboard_operations` for bounded stable-ID refinements, shared filters, layout, names, descriptions, or interaction wiring. On follow-up turns, change only what the user requested and leave unrelated charts intact.
-7. Call `create_dashboard_preview` only after every required chart is ready and any requested operations validate. Pass the exact current plan and draft revisions.
-8. Tell the user the private preview is ready for review and requires explicit Apply. Never claim it was saved, applied, shared, published, archived, or deployed.
+7. Call `create_dashboard_preview` after every required chart is ready and requested operations validate. Pass the exact current plan and draft revisions. A preview containing new or changed custom SQL remains execution-gated and reports that confirmation is required.
+8. When the preview reports pending custom SQL, disclose that requirement and stop. On a later turn, call `confirm_dashboard_custom_sql` only when the current user message explicitly approves that pending custom SQL, then call `create_dashboard_preview` again with the current revisions. The original request for a custom query is not the separate confirmation. Never infer approval from prior messages or confirm on the user's behalf.
+9. Tell the user the private preview is ready for review and requires explicit Apply. Never claim it was saved, applied, shared, published, archived, or deployed.
 
 ## Exact payload shapes
 
@@ -100,7 +101,7 @@ Do not emit Vega-Lite `mark` or `encoding`, nested `semantic`, nested `big_numbe
 ## Fail closed
 
 - A partial draft may remain visible, but do not finalize it while a required chart is missing or failed.
-- Custom SQL is low confidence. It requires the existing explicit user confirmation before preview execution.
+- Prefer dbt-model semantic queries. Custom SQL remains available only when the requested result cannot be expressed from one suitable dbt model, and requires the existing explicit user confirmation before preview execution.
 - Never bypass a validation issue by changing the contract version, session, project binding, commit, connection, or stable ID.
 - Never apply or discard a dashboard through these tools. Those actions belong to the user-facing preview UI.
 - Do not automatically load `dbt-workflow` or run exploratory queries. Use governed schema or dbt tools only when the user explicitly asks for investigation that the bounded projection cannot answer.

--- a/signalpilot/gateway/gateway/api/dashboards.py
+++ b/signalpilot/gateway/gateway/api/dashboards.py
@@ -718,11 +718,6 @@ async def begin_top_level_dashboard_authoring(body: BeginDashboardAuthoringReque
             status_code=422,
             detail={"code": "no_governed_explores", "message": "The pinned project has no governed explores"},
         )
-    if not any(explore.metrics for explore in context.explores):
-        raise HTTPException(
-            status_code=422,
-            detail={"code": "no_approved_metrics", "message": "The pinned project has no approved dashboard metrics"},
-        )
     created = await dashboard_store.create_top_level_authoring_session(
         store.session,
         org_id=store._require_org_id(),

--- a/signalpilot/gateway/gateway/dashboard/authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/authoring.py
@@ -133,7 +133,8 @@ def compact_semantic_projection(context: DashboardSemanticContext) -> dict[str, 
                         "label": metric.label,
                         "aggregation": metric.aggregation,
                         "format": metric.format,
-                        "human_verified": metric.human_verified,
+                        "semantic_source": metric.semantic_source,
+                        "aggregation_inferred": metric.aggregation_inferred,
                     }
                     for metric in explore.metrics
                 ],

--- a/signalpilot/gateway/gateway/dashboard/semantic_resolver.py
+++ b/signalpilot/gateway/gateway/dashboard/semantic_resolver.py
@@ -33,7 +33,6 @@ from gateway.workspace_store.objects import workspace_object_storage
 
 from .project_snapshot import hydrate_github_mirror, materialize_workspace_snapshot
 
-SUPPORTED_AGGREGATIONS = {"sum", "count", "count_distinct", "average", "min", "max"}
 SUPPORTED_METRIC_FORMATS = {"integer", "decimal", "compact", "percentage"}
 
 
@@ -61,39 +60,34 @@ def _logical_type(value: str | None) -> str:
     return "string"
 
 
-def parse_approved_metrics(settings: dict | None) -> list[dict[str, Any]]:
-    """Parse only explicit human-approved metric bindings from project settings."""
-    bindings = (settings or {}).get("dashboard_metrics") or []
-    parsed: list[dict[str, Any]] = []
-    for raw in bindings:
-        if not isinstance(raw, dict) or raw.get("approved") is not True:
-            continue
-        required = ("model", "column", "aggregation", "label")
-        if any(not str(raw.get(key) or "").strip() for key in required):
-            raise DashboardSemanticError(
-                "Approved dashboard metric bindings require model, column, aggregation, and label"
-            )
-        aggregation = str(raw["aggregation"]).lower()
-        if aggregation not in SUPPORTED_AGGREGATIONS:
-            raise DashboardSemanticError(f"Unsupported approved metric aggregation: {aggregation}")
-        metric_format = str(raw["format"]) if raw.get("format") else None
-        if metric_format == "number":
-            metric_format = "decimal"
-        if metric_format and metric_format not in SUPPORTED_METRIC_FORMATS:
-            if not (metric_format.startswith("currency:") and len(metric_format) == 12 and metric_format[9:].isupper()):
-                raise DashboardSemanticError(f"Unsupported approved metric format: {metric_format}")
-        parsed.append(
-            {
-                "model": str(raw["model"]),
-                "column": str(raw["column"]),
-                "aggregation": aggregation,
-                "label": str(raw["label"]),
-                "format": metric_format,
-                "field_id": str(raw.get("field_id") or f"{raw['model']}.{raw['column']}"),
-                "approval_source": str(raw.get("approval_source") or "project_settings"),
-            }
-        )
-    return parsed
+def _metric_aggregation(column: str, logical_type: str, semantic_column: dict[str, Any]) -> tuple[str, bool] | None:
+    """Derive a useful aggregation from dbt/semantic metadata without an approval registry."""
+    explicit = str(semantic_column.get("aggregation") or "").lower()
+    if explicit in {"sum", "count", "count_distinct", "average", "min", "max"}:
+        return explicit, False
+    if logical_type != "number":
+        return None
+    normalized = column.lower()
+    identifier_suffixes = ("_id", "_key", "_number", "_year", "_month", "_day")
+    if normalized in {"id", "year", "month", "day"} or normalized.endswith(identifier_suffixes):
+        return None
+    if any(token in normalized for token in ("_pct", "percent", "_rate", "_ratio", "average", "avg_")):
+        return "average", True
+    return "sum", True
+
+
+def _metric_format(column: str, semantic_column: dict[str, Any]) -> str | None:
+    explicit = str(semantic_column.get("format") or "")
+    if explicit == "number":
+        return "decimal"
+    if explicit in SUPPORTED_METRIC_FORMATS or (
+        explicit.startswith("currency:") and len(explicit) == 12 and explicit[9:].isupper()
+    ):
+        return explicit
+    normalized = column.lower()
+    if any(token in normalized for token in ("_pct", "percent", "_rate", "_ratio")):
+        return "percentage"
+    return "decimal"
 
 
 def _project_projection(project_map: ProjectMap) -> dict[str, Any]:
@@ -109,6 +103,7 @@ def _project_projection(project_map: ProjectMap) -> dict[str, Any]:
                         "type": col.data_type,
                         "description": col.description,
                         "tests": sorted(col.tests),
+                        "meta": col.meta,
                     }
                     for col in sorted(model.columns, key=lambda item: item.name)
                 ],
@@ -151,7 +146,6 @@ def resolve_from_authorities(
     project_map: ProjectMap,
     physical_schema: dict[str, Any],
     semantic_model: dict[str, Any],
-    approved_metrics: list[dict[str, Any]],
 ) -> DashboardSemanticContext:
     physical_fingerprint = _schema_fingerprint(physical_schema)
     fingerprint = _canonical_hash(
@@ -160,13 +154,9 @@ def resolve_from_authorities(
             "project_map": _project_projection(project_map),
             "physical_schema_fingerprint": physical_fingerprint,
             "connection_semantic_model": semantic_model,
-            "approved_metrics": approved_metrics,
             "connection_type": connection_type,
         }
     )
-    metrics_by_model: dict[str, list[dict[str, Any]]] = {}
-    for binding in approved_metrics:
-        metrics_by_model.setdefault(str(binding["model"]), []).append(binding)
 
     explores: list[DashboardSemanticExplore] = []
     verification_refs: list[str] = []
@@ -205,21 +195,26 @@ def resolve_from_authorities(
                 )
             )
         metrics: list[DashboardSemanticMetric] = []
-        for binding in metrics_by_model.get(model_name, []):
-            column = next((item for item in dimensions if item.column == binding["column"]), None)
-            if column is None:
-                raise DashboardSemanticError(
-                    f"Approved metric column does not resolve: {model_name}.{binding['column']}"
-                )
+        dbt_columns = {column.name: column for column in model.columns}
+        for column in dimensions:
+            dbt_meta = dbt_columns[column.column].meta
+            dbt_semantic = dbt_meta.get("signalpilot", dbt_meta)
+            semantic_column = {
+                **(dbt_semantic if isinstance(dbt_semantic, dict) else {}),
+                **(semantic_columns.get(column.column) or {}),
+            }
+            aggregation = _metric_aggregation(column.column, column.logical_type, semantic_column)
+            if aggregation is None:
+                continue
+            aggregation_name, inferred = aggregation
             metrics.append(
                 DashboardSemanticMetric(
-                    **column.model_dump(exclude={"field_id", "label"}),
-                    field_id=str(binding["field_id"]),
-                    aggregation=str(binding["aggregation"]),
-                    label=str(binding["label"]),
-                    format=binding.get("format"),
-                    approval_source=str(binding["approval_source"]),
-                    human_verified=True,
+                    **column.model_dump(exclude={"label"}),
+                    aggregation=aggregation_name,
+                    label=column.label or column.column.replace("_", " ").title(),
+                    format=_metric_format(column.column, semantic_column),
+                    semantic_source="dbt_project",
+                    aggregation_inferred=inferred,
                 )
             )
         joins = [
@@ -408,7 +403,6 @@ class DashboardSemanticResolver:
             project_map=project_map,
             physical_schema=physical_schema,
             semantic_model=_load_semantic_model(connection_name),
-            approved_metrics=parse_approved_metrics(project.settings),
         )
         if not context.explores:
             raise DashboardSemanticError("The pinned dbt project has no governed explores for this connection")

--- a/signalpilot/gateway/gateway/dashboard/top_level_authoring.py
+++ b/signalpilot/gateway/gateway/dashboard/top_level_authoring.py
@@ -380,12 +380,21 @@ async def finalize_preview(
                 "required_charts_incomplete",
                 "Every required dashboard chart must validate before finalization",
             )
-        definition = assemble_dashboard_definition(
-            plan=plan,
-            charts=ready_charts,
-            context=context,
-            timezone=plan.timezone,
-            deterministic_fallback=True,
+        # Chart upserts keep definition_json synchronized with the validated
+        # plan, and follow-up operations mutate that definition directly. Use
+        # the current draft when present so refinements (including added custom
+        # SQL charts) survive finalization instead of being rebuilt away from
+        # the original plan/chart drafts.
+        definition = (
+            DashboardDefinition.model_validate(session.definition_json)
+            if session.definition_json
+            else assemble_dashboard_definition(
+                plan=plan,
+                charts=ready_charts,
+                context=context,
+                timezone=plan.timezone,
+                deterministic_fallback=True,
+            )
         )
     elif session.definition_json:
         definition = DashboardDefinition.model_validate(session.definition_json)
@@ -399,6 +408,8 @@ async def finalize_preview(
         session.pending_custom_sql_chart_ids_json = [
             chart.id for chart in definition.charts if chart.query.kind == "sql"
         ]
+    else:
+        session.pending_custom_sql_chart_ids_json = []
     updated = await dashboard_store.finalize_progressive_authoring_session(
         db,
         org_id=session.org_id,

--- a/signalpilot/gateway/gateway/dbt/scanner.py
+++ b/signalpilot/gateway/gateway/dbt/scanner.py
@@ -216,6 +216,7 @@ def extract_models_from_yml(data: dict, yml_rel_path: str, project_dir: Path) ->
                     name=col_name,
                     data_type=_coerce_str(col.get("data_type") or col.get("type")),
                     description=_coerce_str(col.get("description")),
+                    meta=dict(col.get("meta") or {}) if isinstance(col.get("meta"), dict) else {},
                 )
                 tests_raw = col.get("tests") or col.get("data_tests") or []
                 if isinstance(tests_raw, list):

--- a/signalpilot/gateway/gateway/dbt/types.py
+++ b/signalpilot/gateway/gateway/dbt/types.py
@@ -34,6 +34,7 @@ class ColumnSpec:
     data_type: str | None = None
     description: str | None = None
     tests: list[str] = field(default_factory=list)
+    meta: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/signalpilot/gateway/gateway/models/dashboards.py
+++ b/signalpilot/gateway/gateway/models/dashboards.py
@@ -214,8 +214,8 @@ class DashboardSemanticMetric(DashboardSemanticField):
     aggregation: str
     label: str
     format: str | None = None
-    approval_source: str
-    human_verified: bool
+    semantic_source: str
+    aggregation_inferred: bool
 
 
 class DashboardSemanticExplore(DashboardModel):

--- a/signalpilot/gateway/gateway/standalone_chat/worker_tool_results.py
+++ b/signalpilot/gateway/gateway/standalone_chat/worker_tool_results.py
@@ -26,6 +26,7 @@ _DASHBOARD_AUTHORING_TOOLS = {
     "set_dashboard_plan",
     "upsert_dashboard_chart",
     "apply_dashboard_operations",
+    "confirm_dashboard_custom_sql",
     "create_dashboard_preview",
 }
 
@@ -63,6 +64,7 @@ def dashboard_authoring_completion(
             else "Refining dashboard chart"
         ),
         "apply_dashboard_operations": "Updating dashboard",
+        "confirm_dashboard_custom_sql": "Confirming custom query",
         "create_dashboard_preview": "Dashboard preview ready",
     }
     return {

--- a/signalpilot/gateway/tests/test_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_dashboard_authoring.py
@@ -137,8 +137,8 @@ def _orders_context() -> DashboardSemanticContext:
                             "logical_type": "number",
                             "label": "Revenue",
                             "aggregation": "sum",
-                            "approval_source": "test",
-                            "human_verified": True,
+                            "semantic_source": "dbt_project",
+                            "aggregation_inferred": True,
                         }
                     ],
                 }

--- a/signalpilot/gateway/tests/test_dashboard_dialects.py
+++ b/signalpilot/gateway/tests/test_dashboard_dialects.py
@@ -77,8 +77,8 @@ def _context(db_type: str) -> DashboardSemanticContext:
                         logical_type="number",
                         aggregation="sum",
                         label="Revenue",
-                        approval_source="test",
-                        human_verified=True,
+                        semantic_source="dbt_project",
+                        aggregation_inferred=True,
                     )
                 ],
             )
@@ -402,17 +402,6 @@ def test_semantic_context_uses_connection_type_in_every_registered_fingerprint()
             project_map=project_map,
             physical_schema=physical_schema,
             semantic_model={},
-            approved_metrics=[
-                {
-                    "model": "orders",
-                    "column": "revenue",
-                    "aggregation": "sum",
-                    "label": "Revenue",
-                    "field_id": "orders.revenue",
-                    "approval_source": "test",
-                    "format": None,
-                }
-            ],
         )
         for db_type in registered_connector_types()
     ]

--- a/signalpilot/gateway/tests/test_dashboard_dialects_postgres.py
+++ b/signalpilot/gateway/tests/test_dashboard_dialects_postgres.py
@@ -63,8 +63,8 @@ def _context() -> DashboardSemanticContext:
                         logical_type="number",
                         aggregation="sum",
                         label="Revenue",
-                        approval_source="test",
-                        human_verified=True,
+                        semantic_source="dbt_project",
+                        aggregation_inferred=True,
                     )
                 ],
             )

--- a/signalpilot/gateway/tests/test_dashboards.py
+++ b/signalpilot/gateway/tests/test_dashboards.py
@@ -28,7 +28,7 @@ from gateway.dashboard.cache import dashboard_query_cache_key
 from gateway.dashboard.compiler import compile_custom_sql_query, compile_metric_query
 from gateway.dashboard.confidence import dashboard_confidence_counts, semantic_query_signature
 from gateway.dashboard.domain import AdHocSqlQuery, DashboardDefinition, FieldTarget, FilterRule, SemanticChartQuery
-from gateway.dashboard.semantic_resolver import parse_approved_metrics, resolve_from_authorities
+from gateway.dashboard.semantic_resolver import resolve_from_authorities
 from gateway.db.models import GatewayBase, GatewayDashboardResult, GatewayStructuredQueryResult
 from gateway.dbt.types import ColumnSpec, ModelInfo, ModelStatus, ProjectMap
 from gateway.governance.query_executor import GovernedQueryError
@@ -58,7 +58,15 @@ def _authorities():
             ColumnSpec(name="region", data_type="varchar", description="Sales region"),
             ColumnSpec(name="customer", data_type="varchar", description="Customer"),
             ColumnSpec(name="ordered_at", data_type="datetime", description="Order timestamp"),
-            ColumnSpec(name="revenue", data_type="decimal", description="Net revenue", tests=["not_null"]),
+            ColumnSpec(name="order_id", data_type="bigint", description="Order identifier"),
+            ColumnSpec(
+                name="revenue",
+                data_type="decimal",
+                description="Net revenue",
+                tests=["not_null"],
+                meta={"signalpilot": {"aggregation": "sum", "format": "currency:USD"}},
+            ),
+            ColumnSpec(name="conversion_rate", data_type="decimal", description="Order conversion rate"),
         ],
     )
     schema = {
@@ -69,33 +77,13 @@ def _authorities():
                 {"name": "region", "type": "varchar", "nullable": False},
                 {"name": "customer", "type": "varchar", "nullable": False},
                 {"name": "ordered_at", "type": "datetime", "nullable": False},
+                {"name": "order_id", "type": "bigint", "nullable": False},
                 {"name": "revenue", "type": "decimal", "nullable": False},
+                {"name": "conversion_rate", "type": "decimal", "nullable": False},
             ],
             "foreign_keys": [],
         }
     }
-    metrics = parse_approved_metrics(
-        {
-            "dashboard_metrics": [
-                {
-                    "model": "orders",
-                    "column": "revenue",
-                    "aggregation": "sum",
-                    "label": "Revenue",
-                    "format": "currency:USD",
-                    "approved": True,
-                    "approval_source": "pilot-owner",
-                },
-                {
-                    "model": "orders",
-                    "column": "revenue",
-                    "aggregation": "average",
-                    "label": "Unapproved average",
-                    "approved": False,
-                },
-            ]
-        }
-    )
     return resolve_from_authorities(
         project_id="project-a",
         commit_sha="a" * 40,
@@ -108,27 +96,7 @@ def _authorities():
             "joins": [],
             "glossary": {},
         },
-        approved_metrics=metrics,
     )
-
-
-def test_approved_metric_number_format_is_canonicalized_for_dashboard_rendering() -> None:
-    metrics = parse_approved_metrics(
-        {
-            "dashboard_metrics": [
-                {
-                    "model": "orders",
-                    "column": "quantity",
-                    "aggregation": "sum",
-                    "label": "Orders",
-                    "format": "number",
-                    "approved": True,
-                }
-            ]
-        }
-    )
-
-    assert metrics[0]["format"] == "decimal"
 
 
 def _fixture_definition() -> DashboardDefinition:
@@ -146,13 +114,19 @@ def _fixture_definition() -> DashboardDefinition:
     )
 
 
-def test_resolver_projects_existing_authorities_and_only_explicit_metrics() -> None:
+def test_resolver_projects_dbt_models_and_derives_aggregatable_metrics() -> None:
     context = _authorities()
     assert context.connection_type == "mssql"
     assert len(context.semantic_fingerprint) == 64
     assert context.explores[0].relation == "dbo.orders"
-    assert [metric.label for metric in context.explores[0].metrics] == ["Revenue"]
-    assert context.explores[0].metrics[0].human_verified is True
+    metrics = {metric.column: metric for metric in context.explores[0].metrics}
+    assert set(metrics) == {"revenue", "conversion_rate"}
+    assert metrics["revenue"].aggregation == "sum"
+    assert metrics["revenue"].format == "currency:USD"
+    assert metrics["revenue"].semantic_source == "dbt_project"
+    assert metrics["revenue"].aggregation_inferred is False
+    assert metrics["conversion_rate"].aggregation == "average"
+    assert metrics["conversion_rate"].format == "percentage"
     assert context.verification_refs == ["schema:orders:verified"]
 
 

--- a/signalpilot/gateway/tests/test_progressive_dashboard_authoring.py
+++ b/signalpilot/gateway/tests/test_progressive_dashboard_authoring.py
@@ -42,8 +42,8 @@ def _context() -> DashboardSemanticContext:
                             "logical_type": "number",
                             "label": "Revenue",
                             "aggregation": "sum",
-                            "approval_source": "test",
-                            "human_verified": True,
+                            "semantic_source": "dbt_project",
+                            "aggregation_inferred": True,
                         }
                     ],
                 }

--- a/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tool_schemas.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tool_schemas.py
@@ -645,6 +645,29 @@ def standalone_chat_tools(*, notebook_enabled: bool) -> list[Tool]:
             },
         ),
         Tool(
+            name="confirm_dashboard_custom_sql",
+            description=(
+                "Record the user's explicit confirmation of pending custom SQL in the active dashboard draft. "
+                "Call only when the current user message approves custom SQL after the draft reported that confirmation is required."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "authoring_session_id": {"type": "string"},
+                    "authoring_contract_version": {
+                        "const": DASHBOARD_AUTHORING_CONTRACT_VERSION
+                    },
+                    "confirmation": {"const": "confirm"},
+                },
+                "required": [
+                    "authoring_session_id",
+                    "authoring_contract_version",
+                    "confirmation",
+                ],
+                "additionalProperties": False,
+            },
+        ),
+        Tool(
             name="create_dashboard_preview",
             description=(
                 "Deterministically finalize the complete validated private dashboard preview. Makes no model call and "

--- a/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tools.py
+++ b/signalpilot/notebook-server/signalpilot/_server/ai/standalone_chat_tools.py
@@ -37,6 +37,7 @@ _DASHBOARD_AUTHORING_TOOLS = {
     "set_dashboard_plan",
     "upsert_dashboard_chart",
     "apply_dashboard_operations",
+    "confirm_dashboard_custom_sql",
     "create_dashboard_preview",
 }
 

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat_gateway.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat_gateway.py
@@ -113,16 +113,29 @@ class StandaloneGatewayClient:
             )
         elif tool == "apply_dashboard_operations":
             path = f"/api/dashboard-authoring/sessions/{session_id}/operations"
+        elif tool == "confirm_dashboard_custom_sql":
+            payload.pop("authoring_contract_version", None)
+            payload.pop("confirmation", None)
+            path = f"/api/dashboard-authoring/sessions/{session_id}/confirm-custom-sql"
         elif tool == "create_dashboard_preview":
             path = f"/api/dashboard-authoring/sessions/{session_id}/finalize"
         else:
             raise ValueError("Unknown dashboard authoring tool")
         if tool != "begin_dashboard_authoring" and not session_id:
             raise ValueError("Dashboard authoring session is required")
-        return await self._post_json(
+        result = await self._post_json(
             path,
             payload=payload,
             timeout=DASHBOARD_AUTHORING_TIMEOUT_SECONDS,
             invalid="Invalid dashboard authoring result",
             failed="Dashboard authoring tool failed",
         )
+        if tool == "confirm_dashboard_custom_sql":
+            return {
+                "status": "custom_sql_confirmed",
+                "authoring_session_id": session_id,
+                "plan_revision": result.get("plan_revision", 0),
+                "draft_revision": result.get("draft_revision", 0),
+                "custom_sql_confirmed": bool(result.get("custom_sql_confirmed")),
+            }
+        return result

--- a/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat_prompt.py
+++ b/signalpilot/notebook-server/signalpilot/_server/api/endpoints/standalone_chat_prompt.py
@@ -71,6 +71,7 @@ STANDALONE_ALLOWED_TOOLS = [
     "mcp__standalone-chat__set_dashboard_plan",
     "mcp__standalone-chat__upsert_dashboard_chart",
     "mcp__standalone-chat__apply_dashboard_operations",
+    "mcp__standalone-chat__confirm_dashboard_custom_sql",
     "mcp__standalone-chat__create_dashboard_preview",
     "mcp__standalone-chat__inspect_dbt",
     "mcp__standalone-chat__start_analysis_notebook",

--- a/signalpilot/web/app/dashboards/page.tsx
+++ b/signalpilot/web/app/dashboards/page.tsx
@@ -139,7 +139,7 @@ export default function DashboardsPage() {
                 </div>
                 <p>{item.description || "No description"}</p>
                 <div className={styles.cardMeta}>
-                  <span title="High-confidence semantic charts">
+                  <span title="DBT-backed semantic charts">
                     <BadgeCheck size={14} aria-hidden="true" />
                     {item.high_confidence_charts}
                   </span>

--- a/signalpilot/web/components/dashboard/dashboard-authoring-panel.tsx
+++ b/signalpilot/web/components/dashboard/dashboard-authoring-panel.tsx
@@ -107,7 +107,7 @@ export function dashboardRepairPrompt(issues: DashboardRepairIssue[]): string {
     "Repair only the failing charts in this dashboard:",
     errorList,
     "Preserve every healthy chart, the dashboard layout, filters, names, and descriptions unless a listed repair requires a binding change.",
-    "Use approved semantic fields and return a governed preview for review before Apply.",
+    "Use the pinned dbt models and their documented fields. Prefer one model that already answers the request, then return a governed preview for review before Apply.",
   ].join("\n\n");
 }
 

--- a/signalpilot/web/components/dashboard/dashboard-chart-tile.test.tsx
+++ b/signalpilot/web/components/dashboard/dashboard-chart-tile.test.tsx
@@ -156,7 +156,7 @@ describe("DashboardChartTile interactions", () => {
     expect(document.body.textContent).toContain("Complete result");
     expect(document.body.textContent).toContain("View data");
     const verification = container.querySelector<HTMLElement>(
-      "[aria-label^='High confidence']",
+      "[aria-label^='DBT-backed']",
     );
     expect(verification).not.toBeNull();
   });
@@ -200,13 +200,13 @@ describe("DashboardChartTile interactions", () => {
       root.render(<DashboardChartTile chart={chart} result={result} />);
     });
     const confidence = container.querySelector<HTMLElement>(
-      "[aria-label^='High confidence']",
+      "[aria-label^='DBT-backed']",
     );
     await act(async () => confidence?.focus());
 
     const tooltip = Array.from(
       document.body.querySelectorAll<HTMLElement>("[role='tooltip']"),
-    ).find((candidate) => candidate.textContent?.includes("approved semantic"));
+    ).find((candidate) => candidate.textContent?.includes("DBT-backed"));
     expect(tooltip).not.toBeNull();
     expect(container.contains(tooltip ?? null)).toBe(false);
   });

--- a/signalpilot/web/lib/dashboard/confidence.ts
+++ b/signalpilot/web/lib/dashboard/confidence.ts
@@ -11,8 +11,8 @@ export function chartConfidence(chart: ChartDefinition): DashboardConfidence {
 
 export function confidenceExplanation(chart: ChartDefinition): string {
   return chart.query.kind === "semantic"
-    ? "High confidence: this chart uses approved semantic fields at the dashboard's pinned dbt commit."
-    : "Low confidence: this chart uses explicitly confirmed custom SQL rather than an approved semantic metric.";
+    ? "DBT-backed: this chart uses model fields at the dashboard's pinned dbt commit."
+    : "Direct SQL: this chart uses an explicitly confirmed custom query.";
 }
 
 export function dashboardConfidenceSummary(definition: DashboardDefinition) {


### PR DESCRIPTION
## Summary
- derive dashboard metrics directly from dbt model columns and semantic metadata instead of requiring an approved-metrics registry
- prefer suitable dbt models while retaining explicit custom SQL confirmation
- preserve refined/custom charts during preview finalization and expose run-scoped conversational SQL confirmation
- correct local notebook plugin readiness configuration

## Manual verification
- built a six-chart revenue dashboard from dbt-backed profitability models
- added and explicitly confirmed a monthly revenue and growth custom-query chart
- verified the persisted preview contains seven charts with no pending SQL confirmation
- verified local gateway and notebook health, chat worker startup, and enabled chat bootstrap with five projects

## Automated tests
Not run, per request to validate manually.