### PR TITLE
Resizable lineage inspector, remove @ mentions, hide notebook menu in chat

### DIFF
--- a/signalpilot/gateway/gateway/auth/mcp_api_key.py
+++ b/signalpilot/gateway/gateway/auth/mcp_api_key.py
@@ -167,6 +167,9 @@ async def validate_api_key(key: str, backend_url: str) -> dict[str, Any] | None:
 
 _warned_no_backend_url: bool = False
 
+# The streamable-http MCP transport serves exactly one route.
+_MCP_PATHS = frozenset({"/mcp", "/mcp/"})
+
 
 class MCPAuthMiddleware:
     """Pure ASGI middleware that authenticates MCP streamable-http requests.
@@ -195,6 +198,15 @@ class MCPAuthMiddleware:
         # Only intercept HTTP connections (not lifespan/websocket)
         if scope["type"] != "http":
             await self._app(scope, receive, send)
+            return
+
+        # This app is mounted at the root, so every path no router claimed
+        # lands here. Answer those with a plain 404 before any credential
+        # check; otherwise a mistyped notebook-proxy URL sent with a Clerk
+        # token is rejected as an "invalid notebook session token", which
+        # misleads the browser and the person reading the toast.
+        if scope.get("path", "") not in _MCP_PATHS:
+            await _send_json(send, 404, "Not Found")
             return
 
         # All modes: validate against gateway's own DB-backed API keys
@@ -472,11 +484,16 @@ def _extract_api_key_header(scope: dict[str, Any]) -> str | None:
 
 async def _send_401(send: Callable, message: str) -> None:
     """Send a minimal 401 JSON response through the ASGI send callable."""
+    await _send_json(send, 401, message)
+
+
+async def _send_json(send: Callable, status: int, message: str) -> None:
+    """Send a minimal ``{"detail": message}`` JSON response with ``status``."""
     body = json.dumps({"detail": message}).encode()
     await send(
         {
             "type": "http.response.start",
-            "status": 401,
+            "status": status,
             "headers": [
                 (b"content-type", b"application/json"),
                 (b"content-length", str(len(body)).encode()),

--- a/signalpilot/gateway/gateway/mcp/server.py
+++ b/signalpilot/gateway/gateway/mcp/server.py
@@ -41,6 +41,13 @@ mcp = FastMCP(
         "Use list_connections to see available databases."
     ),
     transport_security=_transport_security,
+    # Stateless streamable HTTP: no server-side session table. The chat
+    # agent's MCP client holds its session id for a whole run, and a stateful
+    # transport keeps that table in one process's memory. Every deploy,
+    # restart, or second replica then answers the rest of the run with
+    # "Session not found". Per-request auth already lives in
+    # MCPAuthMiddleware and contextvars, so no tool depends on the session.
+    stateless_http=True,
 )
 
 

--- a/signalpilot/gateway/tests/test_mcp_auth.py
+++ b/signalpilot/gateway/tests/test_mcp_auth.py
@@ -241,6 +241,26 @@ class TestMCPAuthMiddleware:
     """Tests for the pure ASGI MCPAuthMiddleware."""
 
     @pytest.mark.asyncio
+    async def test_unknown_path_returns_404_before_any_credential_check(self):
+        """The MCP app is mounted at the root, so unrouted paths land here.
+
+        A browser that mis-builds a notebook-proxy URL must get a 404, not a
+        401 that blames its (valid) Clerk token as a bad notebook session token.
+        """
+
+        async def downstream_app(scope, receive, send):
+            raise AssertionError("unrouted paths must never reach the MCP app")
+
+        middleware = MCPAuthMiddleware(downstream_app)
+        scope = _make_scope(_bearer_headers("eyJhbGciOiJSUzI1NiJ9.clerk.token"))
+        scope["path"] = "/notebook/6a1927cd"
+
+        result = await _collect_response(middleware, scope)
+
+        assert result["status"] == 404
+        assert result["body"] == {"detail": "Not Found"}
+
+    @pytest.mark.asyncio
     async def test_db_error_returns_503_not_401(self):
         """When the DB is unavailable during local auth, return 503 (not 401).
 

--- a/signalpilot/gateway/tests/test_mcp_transport_stateless.py
+++ b/signalpilot/gateway/tests/test_mcp_transport_stateless.py
@@ -1,0 +1,12 @@
+"""The MCP streamable-HTTP transport must not hold per-process session state."""
+
+from __future__ import annotations
+
+
+def test_mcp_streamable_http_is_stateless():
+    """A stateful transport loses every in-flight chat run on a gateway
+    restart or deploy: the agent keeps sending its old session id and gets
+    "Session not found" for the rest of the run."""
+    from gateway.mcp.server import mcp
+
+    assert mcp.settings.stateless_http is True

--- a/signalpilot/web/components/chat/chat-composer-panel.test.tsx
+++ b/signalpilot/web/components/chat/chat-composer-panel.test.tsx
@@ -84,7 +84,6 @@ describe("ChatComposerPanel plan dock", () => {
             runIsStreaming={currentRun?.status === "running"}
             currentRun={currentRun}
             onStop={vi.fn(async () => undefined)}
-            mentionOptions={[]}
             conversationId={currentRun ? "conv-1" : undefined}
             bootstrap={bootstrap}
             selectedProjectId={null}

--- a/signalpilot/web/components/chat/chat-composer-panel.tsx
+++ b/signalpilot/web/components/chat/chat-composer-panel.tsx
@@ -34,7 +34,6 @@ export function ChatComposerPanel({
   runIsStreaming,
   currentRun,
   onStop,
-  mentionOptions,
   conversationId,
   bootstrap,
   selectedProjectId,
@@ -50,7 +49,6 @@ export function ChatComposerPanel({
   runIsStreaming: boolean;
   currentRun: StandaloneChatRun | null;
   onStop: (runId: string) => Promise<void>;
-  mentionOptions: string[];
   conversationId?: string;
   bootstrap: StandaloneChatBootstrap;
   selectedProjectId: string | null;
@@ -85,7 +83,6 @@ export function ChatComposerPanel({
       disabledReason={disabledReason}
       running={runIsStreaming}
       onStop={currentRun ? () => void onStop(currentRun.id) : undefined}
-      mentionOptions={mentionOptions}
       placeholder={
         currentRun?.status === "waiting_for_user"
           ? "Answer the clarification…"

--- a/signalpilot/web/components/chat/chat-settings-panel.tsx
+++ b/signalpilot/web/components/chat/chat-settings-panel.tsx
@@ -25,6 +25,11 @@ import {
 } from "~/components/connectors/connectors-context";
 import { useConnectorActions } from "~/components/connectors/use-connector-actions";
 import { Chip, Eyebrow, FOCUS_RING } from "~/components/connectors/ui";
+import {
+  CHAT_TELEMETRY_AVAILABLE,
+  setChatTelemetryEnabled,
+  useChatTelemetrySetting,
+} from "~/components/chat/use-chat-telemetry-setting";
 
 export type ChatBudgetSettings = {
   perQueryBudgetUsd: number;
@@ -306,6 +311,35 @@ function ModelSection({ model }: { model: ChatModelSettings }) {
   );
 }
 
+function TelemetrySection() {
+  const enabled = useChatTelemetrySetting();
+  if (!CHAT_TELEMETRY_AVAILABLE) return null;
+
+  return (
+    <section aria-labelledby="chat-settings-telemetry" className="space-y-3">
+      <Eyebrow>
+        <span id="chat-settings-telemetry">Diagnostics</span>
+      </Eyebrow>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-[12.5px] font-medium text-[var(--color-text)]">
+            Chat telemetry
+          </p>
+          <p className="mt-0.5 text-[11.5px] leading-5 text-[var(--color-text-dim)]">
+            Show live timing and token diagnostics. Saved only in this browser.
+          </p>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={setChatTelemetryEnabled}
+          aria-label="Enable chat telemetry"
+          data-testid="chat-settings-telemetry-toggle"
+        />
+      </div>
+    </section>
+  );
+}
+
 /**
  * Right-side "Chat settings" panel — the same slot family as the artifacts
  * panel. Connectors first (a one-line "what your next chat gets" summary,
@@ -392,6 +426,7 @@ export function ChatSettingsPanel({
           </section>
         )}
         {budgets && <BudgetsSection budgets={budgets} />}
+        <TelemetrySection />
       </div>
     </aside>
     </>

--- a/signalpilot/web/components/chat/chat-telemetry-panel.tsx
+++ b/signalpilot/web/components/chat/chat-telemetry-panel.tsx
@@ -15,9 +15,10 @@ import {
   type ChatEventArrival,
 } from "~/lib/chat-telemetry";
 import { ChatTelemetryContext } from "~/components/chat/chat-telemetry-context";
-
-const CHAT_TELEMETRY_ENABLED =
-  process.env.NEXT_PUBLIC_CHAT_TELEMETRY_ENABLED === "true";
+import {
+  CHAT_TELEMETRY_AVAILABLE,
+  useChatTelemetrySetting,
+} from "~/components/chat/use-chat-telemetry-setting";
 
 function Metric({ label, value, detail }: { label: string; value: string; detail?: string }) {
   return (
@@ -160,23 +161,26 @@ export function ChatTelemetryBoundary({
   arrivals: ChatEventArrival[];
   running: boolean;
 }) {
+  const telemetryEnabled = useChatTelemetrySetting();
   const [nowMs, setNowMs] = useState(() => Date.now());
   useEffect(() => {
-    if (!CHAT_TELEMETRY_ENABLED || !running) return;
+    if (!CHAT_TELEMETRY_AVAILABLE || !telemetryEnabled || !running) return;
     const timer = window.setInterval(() => setNowMs(Date.now()), 500);
     return () => window.clearInterval(timer);
-  }, [running]);
-  if (!CHAT_TELEMETRY_ENABLED) return children;
+  }, [running, telemetryEnabled]);
+  if (!CHAT_TELEMETRY_AVAILABLE) return children;
   return (
-    <ChatTelemetryContext.Provider value={{ enabled: true, nowMs }}>
+    <ChatTelemetryContext.Provider value={{ enabled: telemetryEnabled, nowMs }}>
       {children}
-      <ChatTelemetryPanel
-        messages={messages}
-        events={events}
-        currentRun={currentRun}
-        arrivals={arrivals}
-        nowMs={nowMs}
-      />
+      {telemetryEnabled && (
+        <ChatTelemetryPanel
+          messages={messages}
+          events={events}
+          currentRun={currentRun}
+          arrivals={arrivals}
+          nowMs={nowMs}
+        />
+      )}
     </ChatTelemetryContext.Provider>
   );
 }

--- a/signalpilot/web/components/chat/standalone-chat-composer.test.tsx
+++ b/signalpilot/web/components/chat/standalone-chat-composer.test.tsx
@@ -9,8 +9,6 @@ import type { RunPlan } from "~/lib/chat-run-steps";
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-const MENTION_OPTIONS = ["revenue_by_region", "revenue_monthly", "orders"];
-
 /** Stateful wrapper mirroring real usage: the page owns the draft state. */
 function ComposerHarness({ onValue }: { onValue: (value: string) => void }) {
   const [value, setValue] = useState("");
@@ -24,13 +22,12 @@ function ComposerHarness({ onValue }: { onValue: (value: string) => void }) {
       onSubmit={vi.fn()}
       submitDisabled={false}
       placeholder="Ask"
-      mentionOptions={MENTION_OPTIONS}
     />
   );
 }
 
 /** Types into the textarea the way a user would: native value setter +
- * input event, so React's onChange (and the mention scanner) run. */
+ * input event, so React's onChange runs. */
 function typeIntoComposer(container: HTMLElement, text: string) {
   const textarea = container.querySelector("textarea");
   if (!textarea) throw new Error("composer textarea not found");
@@ -43,7 +40,7 @@ function typeIntoComposer(container: HTMLElement, text: string) {
   textarea.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
-describe("Standalone Data Chat composer mentions", () => {
+describe("Standalone Data Chat composer typing", () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -59,45 +56,21 @@ describe("Standalone Data Chat composer mentions", () => {
     vi.clearAllMocks();
   });
 
-  it("suggests matching models while typing an @-mention and inserts the pick", async () => {
+  it("inserts a literal @ with no autocomplete popover", async () => {
     const onValue = vi.fn();
     await act(async () => {
       root.render(<ComposerHarness onValue={onValue} />);
     });
     await act(async () => typeIntoComposer(container, "Compare @rev"));
 
-    const options = [...container.querySelectorAll("button")].filter((button) =>
-      button.textContent?.startsWith("revenue"),
+    expect(onValue).toHaveBeenLastCalledWith("Compare @rev");
+    expect(container.querySelector("textarea")?.value).toBe("Compare @rev");
+    // The only buttons are the composer controls, never a suggestion list.
+    const buttons = [...container.querySelectorAll("button")];
+    expect(buttons.every((button) => button.hasAttribute("aria-label"))).toBe(
+      true,
     );
-    expect(options.map((button) => button.textContent)).toEqual([
-      "revenue_by_region",
-      "revenue_monthly",
-    ]);
-
-    await act(async () =>
-      options[0].dispatchEvent(
-        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
-      ),
-    );
-    expect(onValue).toHaveBeenLastCalledWith("Compare @revenue_by_region ");
-  });
-
-  it("does not open the mention popover for plain text", async () => {
-    await act(async () => {
-      root.render(<ComposerHarness onValue={vi.fn()} />);
-    });
-    await act(async () =>
-      typeIntoComposer(
-        container,
-        "Compare this with the quarterly revenue numbers",
-      ),
-    );
-
-    expect(
-      [...container.querySelectorAll("button")].some((button) =>
-        button.textContent?.includes("revenue_by_region"),
-      ),
-    ).toBe(false);
+    expect(container.textContent).not.toContain("models & metrics");
   });
 });
 

--- a/signalpilot/web/components/chat/standalone-chat-composer.tsx
+++ b/signalpilot/web/components/chat/standalone-chat-composer.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { AtSign, Send, Settings2, Square } from "lucide-react";
+import { Send, Settings2, Square } from "lucide-react";
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type KeyboardEvent,
@@ -30,7 +29,6 @@ function runningHint(liveState: RunLiveState, liveLabel?: string): string {
       return "Enter to queue for the next turn · Shift+Enter for a new line";
   }
 }
-const MENTION_RE = /(?:^|\s)@([\w./-]*)$/;
 
 export function StandaloneChatComposer({
   value,
@@ -42,7 +40,6 @@ export function StandaloneChatComposer({
   onStop,
   placeholder,
   projectPicker,
-  mentionOptions,
   onOpenSettings,
   settingsOpen = false,
   liveState = "idle",
@@ -61,8 +58,6 @@ export function StandaloneChatComposer({
   onStop?: () => void;
   placeholder: string;
   projectPicker?: ReactNode;
-  /** Model/metric/table names for @-mention autocomplete. */
-  mentionOptions?: string[];
   /** Shows the gear; it toggles the right-side Chat settings panel. */
   onOpenSettings?: () => void;
   /** Whether that panel is open (drives aria-expanded on the gear). */
@@ -79,8 +74,6 @@ export function StandaloneChatComposer({
   const canSubmit = Boolean(value.trim()) && !submitDisabled;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [blockedFlash, setBlockedFlash] = useState(false);
-  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
-  const [mentionIndex, setMentionIndex] = useState(0);
 
   // Autosize: grow with content up to a cap, then scroll.
   useEffect(() => {
@@ -89,45 +82,6 @@ export function StandaloneChatComposer({
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, MAX_TEXTAREA_PX)}px`;
   }, [value]);
-
-  const mentionMatches = useMemo(() => {
-    if (mentionQuery === null || !mentionOptions?.length) return [];
-    const q = mentionQuery.toLowerCase();
-    return mentionOptions
-      .filter((m) => m.toLowerCase().includes(q))
-      .slice(0, 8);
-  }, [mentionQuery, mentionOptions]);
-
-  const refreshMention = useCallback(
-    (nextValue: string) => {
-      const el = textareaRef.current;
-      const caret = el ? el.selectionStart : nextValue.length;
-      const before = nextValue.slice(0, caret ?? nextValue.length);
-      const match = MENTION_RE.exec(before);
-      setMentionQuery(match ? match[1] : null);
-      setMentionIndex(0);
-    },
-    [],
-  );
-
-  const insertMention = useCallback(
-    (name: string) => {
-      const el = textareaRef.current;
-      const caret = el ? el.selectionStart : value.length;
-      const before = value.slice(0, caret ?? value.length);
-      const after = value.slice(caret ?? value.length);
-      const replaced = before.replace(MENTION_RE, (full) =>
-        full.startsWith("@") ? `@${name} ` : `${full[0]}@${name} `,
-      );
-      onValueChange(replaced + after);
-      setMentionQuery(null);
-      requestAnimationFrame(() => {
-        el?.focus();
-        el?.setSelectionRange(replaced.length, replaced.length);
-      });
-    },
-    [onValueChange, value],
-  );
 
   const submit = useCallback(() => {
     const text = value.trim();
@@ -139,32 +93,10 @@ export function StandaloneChatComposer({
       return;
     }
     onValueChange("");
-    setMentionQuery(null);
     onSubmit(text);
   }, [onSubmit, onValueChange, submitDisabled, value]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (mentionMatches.length > 0) {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setMentionIndex((i) => (i + 1) % mentionMatches.length);
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setMentionIndex((i) => (i - 1 + mentionMatches.length) % mentionMatches.length);
-        return;
-      }
-      if (event.key === "Tab" || event.key === "Enter") {
-        event.preventDefault();
-        insertMention(mentionMatches[mentionIndex]);
-        return;
-      }
-      if (event.key === "Escape") {
-        setMentionQuery(null);
-        return;
-      }
-    }
     if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
       event.preventDefault();
       submit();
@@ -191,42 +123,13 @@ export function StandaloneChatComposer({
           plan ? "rounded-b-2xl rounded-t-none" : "rounded-2xl"
         }`}
       >
-        {/* @-mention popover */}
-        {mentionMatches.length > 0 && (
-          <div className="absolute bottom-full left-4 z-30 mb-2 w-80 overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-card)] shadow-xl">
-            <div className="flex items-center gap-1.5 border-b border-[var(--color-border)] px-3 py-1.5 text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-dim)]">
-              <AtSign className="h-3 w-3" /> models &amp; metrics
-            </div>
-            {mentionMatches.map((name, i) => (
-              <button
-                key={name}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  insertMention(name);
-                }}
-                className={`block w-full truncate px-3 py-1.5 text-left font-mono text-xs ${
-                  i === mentionIndex
-                    ? "bg-[var(--color-bg-hover)] text-[var(--color-text)]"
-                    : "text-[var(--color-text-muted)]"
-                }`}
-              >
-                {name}
-              </button>
-            ))}
-          </div>
-        )}
-
         <textarea
           ref={textareaRef}
           data-chat-composer
           rows={1}
           autoFocus
           value={value}
-          onChange={(event) => {
-            onValueChange(event.target.value);
-            refreshMention(event.target.value);
-          }}
+          onChange={(event) => onValueChange(event.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           // The global stylesheet paints two rings on a focused textarea: a
@@ -306,7 +209,7 @@ export function StandaloneChatComposer({
         <p className="mt-2.5 text-center text-xs text-[var(--color-text-muted)]">
           {running
             ? runningHint(liveState, liveLabel)
-            : "Enter to send · Shift+Enter for a new line · @ to mention a model"}
+            : "Enter to send · Shift+Enter for a new line"}
         </p>
       )}
     </div>

--- a/signalpilot/web/components/chat/standalone-data-chat.tsx
+++ b/signalpilot/web/components/chat/standalone-data-chat.tsx
@@ -46,7 +46,6 @@ import { ChatComposerPanel } from "~/components/chat/chat-composer-panel";
 import {
   useChatAutoScroll,
   useChatDraft,
-  useMentionOptions,
   useNotebookPanelState,
   useSelectedChatProject,
   useStandaloneQueryApproval,
@@ -308,8 +307,6 @@ export function StandaloneDataChat({
     currentRun,
   );
 
-  const mentionOptions = useMentionOptions(selectedProjectId);
-
   const conversations = historyData?.conversations ?? [];
   const starters =
     readiness?.starter_questions ??
@@ -347,7 +344,6 @@ export function StandaloneDataChat({
       runIsStreaming={runIsStreaming}
       currentRun={currentRun}
       onStop={onStop}
-      mentionOptions={mentionOptions}
       conversationId={conversationId}
       bootstrap={bootstrap}
       selectedProjectId={selectedProjectId}

--- a/signalpilot/web/components/chat/use-chat-telemetry-setting.test.tsx
+++ b/signalpilot/web/components/chat/use-chat-telemetry-setting.test.tsx
@@ -1,0 +1,55 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CHAT_TELEMETRY_STORAGE_KEY,
+  setChatTelemetryEnabled,
+  useChatTelemetrySetting,
+} from "~/components/chat/use-chat-telemetry-setting";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Probe() {
+  const enabled = useChatTelemetrySetting();
+  return (
+    <button type="button" aria-pressed={enabled} onClick={() => setChatTelemetryEnabled(!enabled)}>
+      Toggle
+    </button>
+  );
+}
+
+describe("chat telemetry local setting", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    window.localStorage.removeItem(CHAT_TELEMETRY_STORAGE_KEY);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    window.localStorage.removeItem(CHAT_TELEMETRY_STORAGE_KEY);
+    container.remove();
+  });
+
+  it("defaults off and persists an opt-in only in local storage", async () => {
+    await act(async () => root.render(<Probe />));
+    const toggle = container.querySelector("button")!;
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    expect(window.localStorage.getItem(CHAT_TELEMETRY_STORAGE_KEY)).toBeNull();
+
+    await act(async () => toggle.click());
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    expect(window.localStorage.getItem(CHAT_TELEMETRY_STORAGE_KEY)).toBe("true");
+
+    await act(async () => toggle.click());
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    expect(window.localStorage.getItem(CHAT_TELEMETRY_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/signalpilot/web/components/chat/use-chat-telemetry-setting.ts
+++ b/signalpilot/web/components/chat/use-chat-telemetry-setting.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export const CHAT_TELEMETRY_AVAILABLE =
+  process.env.NEXT_PUBLIC_CHAT_TELEMETRY_ENABLED === "true";
+
+export const CHAT_TELEMETRY_STORAGE_KEY = "sp:chat-telemetry-enabled";
+
+const CHANGE_EVENT = "sp:chat-telemetry-setting-change";
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CHAT_TELEMETRY_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === CHAT_TELEMETRY_STORAGE_KEY) onStoreChange();
+  };
+  window.addEventListener("storage", onStorage);
+  window.addEventListener(CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    window.removeEventListener(CHANGE_EVENT, onStoreChange);
+  };
+}
+
+export function setChatTelemetryEnabled(enabled: boolean): void {
+  try {
+    if (enabled) {
+      window.localStorage.setItem(CHAT_TELEMETRY_STORAGE_KEY, "true");
+    } else {
+      window.localStorage.removeItem(CHAT_TELEMETRY_STORAGE_KEY);
+    }
+  } catch {
+    // Keep the control usable when browser storage is unavailable.
+  }
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+/** Browser-only opt-in. Missing or unavailable storage always means disabled. */
+export function useChatTelemetrySetting(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/signalpilot/web/components/chat/use-standalone-chat-run.ts
+++ b/signalpilot/web/components/chat/use-standalone-chat-run.ts
@@ -15,7 +15,6 @@ import {
 import type { KeyedMutator } from "swr";
 import {
   decideStandaloneQueryProposal,
-  getDbtMap,
   streamStandaloneRunEvents,
   type StandaloneChatEvent,
   type StandaloneChatBootstrap,
@@ -399,39 +398,6 @@ export function useStandaloneQueryApproval({
     [approvalEvent, detail, mutateDetail, mutateHistory, toast],
   );
   return { approvalEvent, onQueryDecision };
-}
-
-/**
- * @-mention names: reuse the compiled dbt map's node names for the selected
- * project (the same graph the Lineage page serves). Best-effort.
- */
-export function useMentionOptions(selectedProjectId: string | null) {
-  const [mentionOptions, setMentionOptions] = useState<string[]>([]);
-  useEffect(() => {
-    let active = true;
-    if (!selectedProjectId) {
-      setMentionOptions([]);
-      return;
-    }
-    void getDbtMap(selectedProjectId, undefined, true)
-      .then((res) => {
-        if (!active) return;
-        const graph = res.graph as { nodes?: Record<string, { name?: string }> } | null;
-        const names = graph?.nodes
-          ? Object.values(graph.nodes)
-              .map((n) => n.name)
-              .filter((n): n is string => Boolean(n))
-          : [];
-        setMentionOptions([...new Set(names)].sort());
-      })
-      .catch(() => {
-        if (active) setMentionOptions([]);
-      });
-    return () => {
-      active = false;
-    };
-  }, [selectedProjectId]);
-  return mentionOptions;
 }
 
 /** Draft persistence: keep per-conversation (or "new") drafts across reloads. */

--- a/signalpilot/web/components/lineage/dbt-map-page.tsx
+++ b/signalpilot/web/components/lineage/dbt-map-page.tsx
@@ -34,6 +34,9 @@ import { MapHeader } from "./map-header";
 import { SchemaWindow } from "./schema-window";
 import { FocusPanel } from "./focus-panel";
 import { Inspector, type InspectorTab } from "./inspector";
+import { leftPanelCollapses, widthFittingPanel } from "./inspector-resize";
+import { useInspectorWidth } from "./use-inspector-width";
+import { PanelRail } from "./panel-rail";
 import { LayerLegend } from "./layer-legend";
 import { NotFoundCard, UnmappedCard } from "./not-found-card";
 import { useDbtMap, useModelColumns, useModelSql, type MapStatus } from "./use-dbt-map";
@@ -91,6 +94,7 @@ export function DbtMapPage({
   const [highlightSource, setHighlightSource] = useState<string | null>(null);
   const [inspectorTab, setInspectorTab] = useState<InspectorTab>("details");
   const searchRef = useRef<HTMLInputElement>(null);
+  const rowRef = useRef<HTMLDivElement>(null);
 
   // Resolve the focus target against the loaded graph.
   const resolution = useMemo(
@@ -99,6 +103,11 @@ export function DbtMapPage({
   );
   const focusId = resolution?.kind === "found" ? resolution.id : null;
   const focusModel = focusId && parsed ? parsed.models.get(focusId) ?? null : null;
+
+  // Inspector width: owned here so the left panel can yield to the rail.
+  // Full left panel widths: focus panel w-72, schema window w-60.
+  const leftPanelWidth = focusId ? 288 : 240;
+  const inspectorSize = useInspectorWidth(rowRef, embedded ? "modal" : "page", leftPanelWidth);
 
   // Canonical share path for the current view (drives the URL + copy-link).
   const focusPath = useMemo(() => {
@@ -241,6 +250,14 @@ export function DbtMapPage({
     parsed && !map.partial && focusTarget && resolution && resolution.kind !== "found",
   );
 
+  // When the open inspector leaves less than the canvas reserve, the panel
+  // collapses to a rail and the rail button hands the width back.
+  const leftCollapsed =
+    Boolean(selected && parsed) &&
+    leftPanelCollapses(inspectorSize.containerWidth, inspectorSize.width, leftPanelWidth);
+  const restoreLeftPanel = () =>
+    inspectorSize.commit(widthFittingPanel(inspectorSize.containerWidth, leftPanelWidth));
+
   return (
     <div
       className={`flex flex-col overflow-hidden ${embedded ? "h-full" : "h-screen"}`}
@@ -268,8 +285,10 @@ export function DbtMapPage({
         />
       )}
 
-      <div className="flex min-h-0 flex-1">
-        {parsed &&
+      <div ref={rowRef} className="flex min-h-0 flex-1" data-testid="lineage-row">
+        {parsed && leftCollapsed ? (
+          <PanelRail label={focusId ? "lineage" : "schemas"} onExpand={restoreLeftPanel} />
+        ) : parsed &&
           (focusId ? (
             <FocusPanel
               parsed={parsed}
@@ -289,7 +308,7 @@ export function DbtMapPage({
             />
           ))}
 
-        <div className="relative min-w-0 flex-1 bg-[var(--color-bg)]">
+        <div className="relative min-w-0 flex-1 bg-[var(--color-bg)]" data-testid="lineage-canvas">
           {parsed ? (
             <>
               <ReactFlowProvider>
@@ -383,6 +402,7 @@ export function DbtMapPage({
             onClose={() => setSelectedId(null)}
             onNavigate={(id) => setSelectedId(id)}
             onFocus={focusOn}
+            size={inspectorSize}
           />
         )}
       </div>

--- a/signalpilot/web/components/lineage/inspector-resize-handle.tsx
+++ b/signalpilot/web/components/lineage/inspector-resize-handle.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * The inspector's left-edge grab strip. Pointer capture keeps the drag on
+ * the handle (the ReactFlow pane next to it never sees the moves), width
+ * updates are rAF-throttled, text selection is off while dragging, and a
+ * double-click resets. As a keyboard separator: arrows resize by a step
+ * (Shift for a big one), Home and End snap to the bounds.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import { keyboardResize, type WidthBounds } from "./inspector-resize";
+
+export function InspectorResizeHandle({
+  width,
+  bounds,
+  onPreview,
+  onCommit,
+  onReset,
+}: {
+  width: number;
+  bounds: WidthBounds;
+  onPreview: (px: number) => void;
+  onCommit: (px: number) => void;
+  onReset: () => void;
+}) {
+  const [dragging, setDragging] = useState(false);
+  const drag = useRef<{ startX: number; startWidth: number; latest: number; raf: number | null } | null>(null);
+
+  const clamp = useCallback(
+    (px: number) => Math.min(bounds.max, Math.max(bounds.min, Math.round(px))),
+    [bounds],
+  );
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0 && e.pointerType === "mouse") return;
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = { startX: e.clientX, startWidth: width, latest: width, raf: null };
+    setDragging(true);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    if (!d) return;
+    // The handle sits on the left edge: moving left widens.
+    d.latest = clamp(d.startWidth + (d.startX - e.clientX));
+    if (d.raf !== null) return;
+    d.raf = requestAnimationFrame(() => {
+      d.raf = null;
+      onPreview(d.latest);
+    });
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    if (!d) return;
+    drag.current = null;
+    if (d.raf !== null) cancelAnimationFrame(d.raf);
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
+    setDragging(false);
+    onCommit(d.latest);
+  };
+
+  // No text selection under the pointer while the width follows it.
+  useEffect(() => {
+    if (!dragging) return;
+    const body = document.body;
+    const prevSelect = body.style.userSelect;
+    const prevCursor = body.style.cursor;
+    body.style.userSelect = "none";
+    body.style.cursor = "col-resize";
+    return () => {
+      body.style.userSelect = prevSelect;
+      body.style.cursor = prevCursor;
+    };
+  }, [dragging]);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const next = keyboardResize(e.key, e.shiftKey, width, bounds);
+    if (next === null) return;
+    e.preventDefault();
+    if (next !== width) onCommit(next);
+  };
+
+  const max = Number.isFinite(bounds.max) ? bounds.max : undefined;
+  return (
+    <div
+      role="separator"
+      tabIndex={0}
+      aria-orientation="vertical"
+      aria-label="Resize inspector"
+      aria-valuenow={width}
+      aria-valuemin={bounds.min}
+      aria-valuemax={max}
+      data-testid="inspector-resize-handle"
+      data-dragging={dragging ? "1" : "0"}
+      title="Drag to resize. Double-click to reset."
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onDoubleClick={onReset}
+      onKeyDown={onKeyDown}
+      className="group absolute inset-y-0 left-[-4px] z-20 w-2 cursor-col-resize touch-none select-none outline-none"
+    >
+      {/* The visible affordance: a thin bar that lights on hover, drag, focus. */}
+      <div
+        aria-hidden="true"
+        className={`mx-auto h-full w-[3px] rounded-full transition-colors ${
+          dragging
+            ? "bg-[var(--color-accent)]"
+            : "bg-transparent group-hover:bg-[var(--color-border-hover)] group-focus-visible:bg-[var(--color-accent)]"
+        }`}
+      />
+    </div>
+  );
+}

--- a/signalpilot/web/components/lineage/inspector-resize.test.ts
+++ b/signalpilot/web/components/lineage/inspector-resize.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CANVAS_RESERVE,
+  INSPECTOR_MIN_WIDTH,
+  INSPECTOR_WIDTH_KEY,
+  KEY_STEP,
+  KEY_STEP_LARGE,
+  LEFT_RAIL_WIDTH,
+  PAGE_DEFAULT_WIDTH,
+  clampWidth,
+  defaultInspectorWidth,
+  isWide,
+  keyboardResize,
+  leftPanelCollapses,
+  parseStoredWidth,
+  readStoredWidth,
+  wideInspectorWidth,
+  widthBounds,
+  widthFittingPanel,
+  writeStoredWidth,
+} from "./inspector-resize";
+
+class MemoryStorage {
+  map = new Map<string, string>();
+  getItem(k: string) {
+    return this.map.get(k) ?? null;
+  }
+  setItem(k: string, v: string) {
+    this.map.set(k, v);
+  }
+  removeItem(k: string) {
+    this.map.delete(k);
+  }
+}
+
+describe("widthBounds and clampWidth", () => {
+  it("leaves the canvas reserve plus the rail at the maximum", () => {
+    const b = widthBounds(1600);
+    expect(b.min).toBe(INSPECTOR_MIN_WIDTH);
+    expect(b.max).toBe(1600 - CANVAS_RESERVE - LEFT_RAIL_WIDTH);
+  });
+
+  it("never drops the maximum under the minimum on tiny viewports", () => {
+    expect(widthBounds(400).max).toBe(INSPECTOR_MIN_WIDTH);
+  });
+
+  it("is unbounded before the container is measured", () => {
+    const b = widthBounds(0);
+    expect(b.max).toBe(Number.POSITIVE_INFINITY);
+    expect(clampWidth(2000, b)).toBe(2000);
+  });
+
+  it("clamps, rounds, and rejects non-finite widths", () => {
+    const b = widthBounds(1600);
+    expect(clampWidth(100, b)).toBe(b.min);
+    expect(clampWidth(5000, b)).toBe(b.max);
+    expect(clampWidth(600.4, b)).toBe(600);
+    expect(clampWidth(Number.NaN, b)).toBe(b.min);
+  });
+});
+
+describe("defaults and presets", () => {
+  it("uses a fixed page default and a share of the modal", () => {
+    expect(defaultInspectorWidth("page", 1600)).toBe(PAGE_DEFAULT_WIDTH);
+    expect(defaultInspectorWidth("page", 0)).toBe(PAGE_DEFAULT_WIDTH);
+    expect(defaultInspectorWidth("modal", 1000)).toBe(450);
+    expect(defaultInspectorWidth("modal", 0)).toBe(PAGE_DEFAULT_WIDTH);
+  });
+
+  it("the default never collapses the full left panel", () => {
+    // 1056 wide row with the 288 focus panel: 560 would squeeze the canvas.
+    expect(defaultInspectorWidth("page", 1056, 288)).toBe(1056 - 288 - CANVAS_RESERVE);
+    expect(defaultInspectorWidth("page", 1600, 288)).toBe(PAGE_DEFAULT_WIDTH);
+    expect(leftPanelCollapses(1056, defaultInspectorWidth("page", 1056, 288), 288)).toBe(false);
+    // Tiny rows bottom out at the minimum.
+    expect(defaultInspectorWidth("page", 700, 288)).toBe(INSPECTOR_MIN_WIDTH);
+  });
+
+  it("the wide preset is 70 percent, clamped to the bounds", () => {
+    expect(wideInspectorWidth(1600)).toBe(1120);
+    expect(wideInspectorWidth(500)).toBe(INSPECTOR_MIN_WIDTH);
+    expect(isWide(1120, 1600)).toBe(true);
+    expect(isWide(1000, 1600)).toBe(false);
+    expect(isWide(1000, 0)).toBe(false);
+  });
+
+  it("the left panel collapses once the canvas would go under the reserve", () => {
+    expect(leftPanelCollapses(1600, 560, 288)).toBe(false);
+    expect(leftPanelCollapses(1600, 1100, 288)).toBe(true);
+    expect(leftPanelCollapses(0, 1100, 288)).toBe(false);
+    const fit = widthFittingPanel(1600, 288);
+    expect(fit).toBe(1600 - 288 - CANVAS_RESERVE);
+    expect(leftPanelCollapses(1600, fit, 288)).toBe(false);
+  });
+});
+
+describe("persistence", () => {
+  it("parses stored values and ignores junk", () => {
+    expect(parseStoredWidth("640")).toBe(640);
+    expect(parseStoredWidth("640.6")).toBe(641);
+    expect(parseStoredWidth("abc")).toBeNull();
+    expect(parseStoredWidth("12")).toBeNull();
+    expect(parseStoredWidth(null)).toBeNull();
+  });
+
+  it("round-trips through storage under the shared key and clears on null", () => {
+    const s = new MemoryStorage();
+    writeStoredWidth(s, 720.4);
+    expect(s.getItem(INSPECTOR_WIDTH_KEY)).toBe("720");
+    expect(readStoredWidth(s)).toBe(720);
+    writeStoredWidth(s, null);
+    expect(readStoredWidth(s)).toBeNull();
+  });
+
+  it("swallows storage failures", () => {
+    const broken = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(readStoredWidth(broken)).toBeNull();
+    expect(() => writeStoredWidth(broken, 500)).not.toThrow();
+    expect(readStoredWidth(null)).toBeNull();
+  });
+});
+
+describe("keyboardResize", () => {
+  const b = widthBounds(1600);
+
+  it("left widens and right narrows by the step, shift by the big step", () => {
+    expect(keyboardResize("ArrowLeft", false, 560, b)).toBe(560 + KEY_STEP);
+    expect(keyboardResize("ArrowRight", false, 560, b)).toBe(560 - KEY_STEP);
+    expect(keyboardResize("ArrowLeft", true, 560, b)).toBe(560 + KEY_STEP_LARGE);
+    expect(keyboardResize("ArrowRight", true, 560, b)).toBe(560 - KEY_STEP_LARGE);
+  });
+
+  it("clamps at the bounds and snaps with Home and End", () => {
+    expect(keyboardResize("ArrowRight", true, INSPECTOR_MIN_WIDTH + 10, b)).toBe(INSPECTOR_MIN_WIDTH);
+    expect(keyboardResize("ArrowLeft", true, b.max - 10, b)).toBe(b.max);
+    expect(keyboardResize("Home", false, 900, b)).toBe(b.min);
+    expect(keyboardResize("End", false, 900, b)).toBe(b.max);
+    expect(keyboardResize("End", false, 900, widthBounds(0))).toBe(900);
+  });
+
+  it("ignores other keys", () => {
+    expect(keyboardResize("ArrowUp", false, 560, b)).toBeNull();
+    expect(keyboardResize("Enter", false, 560, b)).toBeNull();
+  });
+});

--- a/signalpilot/web/components/lineage/inspector-resize.ts
+++ b/signalpilot/web/components/lineage/inspector-resize.ts
@@ -1,0 +1,143 @@
+/**
+ * Width rules for the resizable lineage inspector. Pure: the hook
+ * (use-inspector-width.ts) and the handle (inspector-resize-handle.tsx)
+ * own DOM and React state, this file owns the numbers so they can be unit
+ * tested. The page and the chat modal share one stored preference.
+ */
+
+/** localStorage key, shared by the /lineage page and the chat modal. */
+export const INSPECTOR_WIDTH_KEY = "sp:lineage-inspector-width";
+
+/** Narrowest useful inspector. */
+export const INSPECTOR_MIN_WIDTH = 320;
+/** Canvas that must stay visible left of the inspector. */
+export const CANVAS_RESERVE = 240;
+/** Width of the left panel once it has collapsed to a rail. */
+export const LEFT_RAIL_WIDTH = 36;
+/** Default on the page: comfortable for SQL. */
+export const PAGE_DEFAULT_WIDTH = 560;
+/** Default in the modal: a share of the modal width. */
+export const MODAL_DEFAULT_FRACTION = 0.45;
+/** The "expand" preset as a share of the container. */
+export const WIDE_FRACTION = 0.7;
+/** Keyboard steps (px). */
+export const KEY_STEP = 32;
+export const KEY_STEP_LARGE = 128;
+
+export type InspectorSurface = "page" | "modal";
+
+export interface WidthBounds {
+  min: number;
+  max: number;
+}
+
+/**
+ * Bounds for a container this wide. The maximum leaves the canvas reserve
+ * plus the collapsed left rail; an unmeasured container (0) is unbounded so
+ * the first paint does not snap to the minimum.
+ */
+export function widthBounds(containerWidth: number): WidthBounds {
+  if (!(containerWidth > 0)) return { min: INSPECTOR_MIN_WIDTH, max: Number.POSITIVE_INFINITY };
+  const max = Math.max(INSPECTOR_MIN_WIDTH, Math.floor(containerWidth - CANVAS_RESERVE - LEFT_RAIL_WIDTH));
+  return { min: INSPECTOR_MIN_WIDTH, max };
+}
+
+export function clampWidth(width: number, bounds: WidthBounds): number {
+  if (!Number.isFinite(width)) return bounds.min;
+  return Math.min(bounds.max, Math.max(bounds.min, Math.round(width)));
+}
+
+/**
+ * Default width: 560 on the page, 45 percent in the modal, and never so wide
+ * that the full left panel would collapse. Only a stored user width may
+ * push the panel to its rail.
+ */
+export function defaultInspectorWidth(
+  surface: InspectorSurface,
+  containerWidth: number,
+  leftPanelWidth = 0,
+): number {
+  const base =
+    surface === "modal" && containerWidth > 0
+      ? Math.round(containerWidth * MODAL_DEFAULT_FRACTION)
+      : PAGE_DEFAULT_WIDTH;
+  if (!(containerWidth > 0)) return base;
+  return clampWidth(Math.min(base, containerWidth - leftPanelWidth - CANVAS_RESERVE), widthBounds(containerWidth));
+}
+
+export function wideInspectorWidth(containerWidth: number): number {
+  return clampWidth(containerWidth * WIDE_FRACTION, widthBounds(containerWidth));
+}
+
+/** True when the width already sits at (or past) the wide preset. */
+export function isWide(width: number, containerWidth: number): boolean {
+  return containerWidth > 0 && width >= wideInspectorWidth(containerWidth) - 4;
+}
+
+/**
+ * True when the full left panel plus this inspector would squeeze the
+ * canvas under the reserve: the panel then collapses to the rail.
+ */
+export function leftPanelCollapses(containerWidth: number, inspectorWidth: number, panelWidth: number): boolean {
+  if (!(containerWidth > 0)) return false;
+  return containerWidth - inspectorWidth - panelWidth < CANVAS_RESERVE;
+}
+
+/** Widest inspector that still fits the full left panel. */
+export function widthFittingPanel(containerWidth: number, panelWidth: number): number {
+  return clampWidth(containerWidth - panelWidth - CANVAS_RESERVE, widthBounds(containerWidth));
+}
+
+/** Parse a stored preference; null for anything that is not a sane number. */
+export function parseStoredWidth(raw: string | null | undefined): number | null {
+  if (raw == null) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < INSPECTOR_MIN_WIDTH) return null;
+  return Math.round(n);
+}
+
+export function readStoredWidth(storage: Pick<Storage, "getItem"> | null | undefined): number | null {
+  try {
+    return parseStoredWidth(storage?.getItem(INSPECTOR_WIDTH_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredWidth(
+  storage: Pick<Storage, "setItem" | "removeItem"> | null | undefined,
+  width: number | null,
+): void {
+  try {
+    if (width === null) storage?.removeItem(INSPECTOR_WIDTH_KEY);
+    else storage?.setItem(INSPECTOR_WIDTH_KEY, String(Math.round(width)));
+  } catch {
+    // Private mode or a full store: the width just does not persist.
+  }
+}
+
+/**
+ * Keyboard resize on the separator. Returns the next width, or null when
+ * the key is not a resize key. Left widens (the handle is on the left edge,
+ * so left moves it left), right narrows.
+ */
+export function keyboardResize(
+  key: string,
+  shift: boolean,
+  width: number,
+  bounds: WidthBounds,
+): number | null {
+  const step = shift ? KEY_STEP_LARGE : KEY_STEP;
+  switch (key) {
+    case "ArrowLeft":
+      return clampWidth(width + step, bounds);
+    case "ArrowRight":
+      return clampWidth(width - step, bounds);
+    case "Home":
+      return bounds.min;
+    case "End":
+      return Number.isFinite(bounds.max) ? bounds.max : clampWidth(width, bounds);
+    default:
+      return null;
+  }
+}

--- a/signalpilot/web/components/lineage/inspector-sql.tsx
+++ b/signalpilot/web/components/lineage/inspector-sql.tsx
@@ -71,8 +71,10 @@ export function InspectorSql({ state, modelName }: { state: ModelSqlState; model
   const language = sql.language === "python" ? "python" : "sql";
 
   return (
-    <div className="flex min-h-0 flex-col p-3" data-testid="inspector-sql" data-variant={active}>
-      <div className="mb-2 flex items-center gap-1">
+    <div className="flex min-h-0 flex-1 flex-col p-3" data-testid="inspector-sql" data-variant={active}>
+      {/* One header row: variant toggle, file path, copy. The path gives
+          way first and wraps under the controls when the panel is narrow. */}
+      <div className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1">
         {hasCompiled && (
           <div role="group" aria-label="SQL variant" className="flex items-center gap-0.5 rounded-[7px] border border-[var(--color-border)] p-0.5">
             {(["raw", "compiled"] as Variant[]).map((v) => (
@@ -92,18 +94,27 @@ export function InspectorSql({ state, modelName }: { state: ModelSqlState; model
             ))}
           </div>
         )}
-        <span className="ml-auto">
+        {path && (
+          <div
+            className="min-w-[10rem] flex-1 truncate font-mono text-[9px] text-[var(--color-text-dim)]"
+            title={path}
+            data-testid="inspector-sql-path"
+          >
+            {path}
+            {sql.truncated && <span className="ml-1 text-[var(--color-warning)]">(truncated)</span>}
+          </div>
+        )}
+        <span className="ml-auto shrink-0">
           <CopyButton text={body} label="Copy" />
         </span>
       </div>
-      {path && (
-        <div className="mb-1.5 truncate font-mono text-[9px] text-[var(--color-text-dim)]" title={path} data-testid="inspector-sql-path">
-          {path}
-          {sql.truncated && <span className="ml-1 text-[var(--color-warning)]">(truncated)</span>}
-        </div>
-      )}
-      <div className="min-h-0 overflow-hidden rounded-[8px] border border-[var(--color-border)] bg-[var(--color-bg-input)]">
-        <ChatCode code={fold.shown} language={language} maxHeightClass="max-h-[60vh]" />
+      {/* Fills the inspector width; grows with the panel height and scrolls
+          inside (both axes) only when the body is bigger than the box. */}
+      <div
+        className="flex min-h-0 w-full shrink flex-col overflow-hidden rounded-[8px] border border-[var(--color-border)] bg-[var(--color-bg-input)] [&>pre]:min-h-0 [&>pre]:max-h-none"
+        data-testid="inspector-sql-code"
+      >
+        <ChatCode code={fold.shown} language={language} maxHeightClass="" />
       </div>
       {(fold.hidden > 0 || (expanded && foldable(body))) && (
         <button

--- a/signalpilot/web/components/lineage/inspector.tsx
+++ b/signalpilot/web/components/lineage/inspector.tsx
@@ -7,7 +7,7 @@
  * exploration) and Copy link (the model's shareable /lineage URL).
  */
 
-import { Crosshair, Link2, X } from "lucide-react";
+import { Crosshair, Link2, Maximize2, Minimize2, X } from "lucide-react";
 import React from "react";
 
 import { Skeleton } from "~/components/ui/skeleton";
@@ -16,6 +16,8 @@ import { LAYER_COLOR, LAYER_LABEL, matGlyph } from "./palette";
 import type { MapColumn, MapModel, ParsedMap } from "./parse-map";
 import { canonicalRef, lineagePath } from "./lineage-nav";
 import { InspectorSql } from "./inspector-sql";
+import { InspectorResizeHandle } from "./inspector-resize-handle";
+import type { InspectorWidthState } from "./use-inspector-width";
 import type { ModelSqlState } from "./use-dbt-map";
 
 export type InspectorTab = "details" | "sql";
@@ -32,6 +34,7 @@ export function Inspector({
   onClose,
   onNavigate,
   onFocus,
+  size,
 }: {
   parsed: ParsedMap;
   model: MapModel;
@@ -44,6 +47,8 @@ export function Inspector({
   onClose: () => void;
   onNavigate: (id: string) => void;
   onFocus: (id: string) => void;
+  /** Width state from use-inspector-width; the host owns it. */
+  size: InspectorWidthState;
 }) {
   const { toast } = useToast();
   const color = LAYER_COLOR[model.layer];
@@ -90,9 +95,21 @@ export function Inspector({
     );
 
   return (
-    <div className="flex h-full w-72 shrink-0 flex-col border-l border-[var(--color-border)] bg-[var(--color-bg-card)]/80 backdrop-blur">
+    <div
+      data-testid="lineage-inspector"
+      data-wide={size.wide ? "1" : "0"}
+      style={{ width: size.width }}
+      className="relative flex h-full shrink-0 flex-col border-l border-[var(--color-border)] bg-[var(--color-bg-card)]/80 backdrop-blur"
+    >
+      <InspectorResizeHandle
+        width={size.width}
+        bounds={size.bounds}
+        onPreview={size.preview}
+        onCommit={size.commit}
+        onReset={size.reset}
+      />
       <div className="flex items-start justify-between gap-2 border-b border-[var(--color-border)] p-3">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px]" style={{ color, background: `${color}1f` }} aria-hidden="true">
               {matGlyph(model.materialized, model.layer)}
@@ -109,9 +126,22 @@ export function Inspector({
             ))}
           </div>
         </div>
-        <button type="button" onClick={onClose} className="text-[var(--color-text-dim)] hover:text-[var(--color-text)]" aria-label="Close inspector">
-          <X className="h-3.5 w-3.5" />
-        </button>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={size.toggleWide}
+            aria-pressed={size.wide}
+            aria-label={size.wide ? "Restore inspector width" : "Expand inspector"}
+            title={size.wide ? "Restore width" : "Expand for SQL"}
+            data-testid="inspector-expand"
+            className="text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+          >
+            {size.wide ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+          </button>
+          <button type="button" onClick={onClose} className="text-[var(--color-text-dim)] hover:text-[var(--color-text)]" aria-label="Close inspector">
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
 
       {/* Actions */}
@@ -172,7 +202,7 @@ export function Inspector({
           role="tabpanel"
           id="inspector-panel-sql"
           aria-labelledby="inspector-tab-sql"
-          className="min-h-0 flex-1 overflow-y-auto"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
         >
           <InspectorSql state={sql} modelName={model.name} />
         </div>
@@ -197,7 +227,7 @@ export function Inspector({
             {/* Name / dimmed type (when the distilled graph carries one —
                 data follow-up for the gateway payload), description visible
                 on its own clamped line instead of tooltip-only. */}
-            <div className="max-h-48 overflow-y-auto rounded-[8px] border border-[var(--color-border)] bg-[var(--color-bg-input)]">
+            <div className="max-h-[40vh] overflow-y-auto rounded-[8px] border border-[var(--color-border)] bg-[var(--color-bg-input)]">
               {columns === null && (
                 <div className="space-y-1.5 px-2 py-1.5" aria-busy="true">
                   {Array.from({ length: Math.min(model.columnCount, 4) }, (_, i) => (

--- a/signalpilot/web/components/lineage/map-canvas.tsx
+++ b/signalpilot/web/components/lineage/map-canvas.tsx
@@ -324,12 +324,38 @@ export function MapCanvas({
     () => `${focusId ?? ""}|${[...visible].sort().join(",")}`,
     [focusId, visible],
   );
+  // The canvas box changes size when the inspector is resized (or the
+  // window is): once the change settles, reframe the same set so the
+  // story stays in view instead of sliding under the panel.
+  const [resizeTick, setResizeTick] = useState(0);
+  const framedResizeRef = useRef(0);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    let first = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const ro = new ResizeObserver(() => {
+      if (first) {
+        first = false;
+        return;
+      }
+      clearTimeout(timer);
+      timer = setTimeout(() => setResizeTick((t) => t + 1), 180);
+    });
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      clearTimeout(timer);
+    };
+  }, []);
   useEffect(() => {
     if (initTick === 0) return;
-    if (frameKeyRef.current === frameKey) return;
+    const resized = framedResizeRef.current !== resizeTick;
+    if (frameKeyRef.current === frameKey && !resized) return;
     const firstFrame = frameKeyRef.current === null;
     frameKeyRef.current = frameKey;
-    const duration = reducedMotion || firstFrame ? 0 : 400;
+    framedResizeRef.current = resizeTick;
+    const duration = reducedMotion || firstFrame ? 0 : resized ? 250 : 400;
     const vw = wrapRef.current?.clientWidth ?? 1200;
     const vh = wrapRef.current?.clientHeight ?? 800;
     const boundsOf = (ids: string[]) => {
@@ -402,7 +428,7 @@ export function MapCanvas({
       }
     }
     frame(all, 0.05, 1);
-  }, [api, parsed, positions, visible, focusId, frameKey, initTick, reducedMotion]);
+  }, [api, parsed, positions, visible, focusId, frameKey, initTick, resizeTick, reducedMotion]);
 
   // External selection (schema panel / inspector nav) -> center the node.
   useEffect(() => {

--- a/signalpilot/web/components/lineage/panel-rail.tsx
+++ b/signalpilot/web/components/lineage/panel-rail.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * The left panel collapsed to a slim rail. Shown when a wide inspector
+ * would squeeze the canvas under its reserve; the button hands the width
+ * back so the full panel fits again.
+ */
+
+import { PanelLeftOpen } from "lucide-react";
+import React from "react";
+
+import { LEFT_RAIL_WIDTH } from "./inspector-resize";
+
+export function PanelRail({ label, onExpand }: { label: string; onExpand: () => void }) {
+  return (
+    <div
+      data-testid="lineage-panel-rail"
+      style={{ width: LEFT_RAIL_WIDTH }}
+      className="flex h-full shrink-0 flex-col items-center gap-2 border-r border-[var(--color-border)] bg-[var(--color-bg-card)]/60 py-2"
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={`Show ${label} panel`}
+        title={`Show ${label} panel`}
+        className="flex h-7 w-7 items-center justify-center rounded-[7px] text-[var(--color-text-dim)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text)]"
+      >
+        <PanelLeftOpen className="h-3.5 w-3.5" />
+      </button>
+      <span
+        aria-hidden="true"
+        style={{ writingMode: "vertical-rl" }}
+        className="mt-1 text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-dim)]"
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/signalpilot/web/components/lineage/use-inspector-width.ts
+++ b/signalpilot/web/components/lineage/use-inspector-width.ts
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * Owns the inspector width for one lineage surface. The preference (a raw
+ * px value, or null for "use the default") lives in state and, on commit,
+ * in localStorage under one key shared by the page and the modal. The
+ * rendered width is that preference clamped to the measured container, so
+ * a stored wide value on a small viewport still leaves the canvas visible.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react";
+
+import {
+  clampWidth,
+  defaultInspectorWidth,
+  isWide,
+  readStoredWidth,
+  wideInspectorWidth,
+  widthBounds,
+  writeStoredWidth,
+  type InspectorSurface,
+  type WidthBounds,
+} from "./inspector-resize";
+
+export interface InspectorWidthState {
+  /** Rendered width (clamped). */
+  width: number;
+  bounds: WidthBounds;
+  containerWidth: number;
+  wide: boolean;
+  /** Live update during a drag: state only. */
+  preview: (px: number) => void;
+  /** Update and persist. */
+  commit: (px: number) => void;
+  /** Back to the surface default; clears the stored preference. */
+  reset: () => void;
+  /** Toggle between the wide preset and the width before it. */
+  toggleWide: () => void;
+}
+
+const useIsoLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+export function useInspectorWidth(
+  containerRef: RefObject<HTMLElement | null>,
+  surface: InspectorSurface,
+  /** Full width of the left panel, so the default keeps it open. */
+  leftPanelWidth = 0,
+): InspectorWidthState {
+  const [preferred, setPreferred] = useState<number | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const beforeWideRef = useRef<number | null>(null);
+
+  // Hydrate the preference after mount: SSR has no storage.
+  useEffect(() => {
+    setPreferred(readStoredWidth(typeof window === "undefined" ? null : window.localStorage));
+  }, []);
+
+  // Track the container so the bounds follow the viewport.
+  useIsoLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => setContainerWidth(el.clientWidth);
+    measure();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [containerRef]);
+
+  const bounds = useMemo(() => widthBounds(containerWidth), [containerWidth]);
+  const fallback = defaultInspectorWidth(surface, containerWidth, leftPanelWidth);
+  const width = clampWidth(preferred ?? fallback, bounds);
+
+  const preview = useCallback((px: number) => setPreferred(px), []);
+  const commit = useCallback((px: number) => {
+    const next = Math.round(px);
+    setPreferred(next);
+    writeStoredWidth(window.localStorage, next);
+  }, []);
+  const reset = useCallback(() => {
+    beforeWideRef.current = null;
+    setPreferred(null);
+    writeStoredWidth(window.localStorage, null);
+  }, []);
+  const toggleWide = useCallback(() => {
+    if (isWide(width, containerWidth)) {
+      commit(beforeWideRef.current ?? fallback);
+      beforeWideRef.current = null;
+      return;
+    }
+    beforeWideRef.current = width;
+    commit(wideInspectorWidth(containerWidth));
+  }, [width, containerWidth, fallback, commit]);
+
+  return {
+    width,
+    bounds,
+    containerWidth,
+    wide: isWide(width, containerWidth),
+    preview,
+    commit,
+    reset,
+    toggleWide,
+  };
+}

--- a/signalpilot/web/e2e/chat-lineage-modal.spec.ts
+++ b/signalpilot/web/e2e/chat-lineage-modal.spec.ts
@@ -141,6 +141,7 @@ test.describe("chat lineage modal", () => {
     const mock = await mockLineageRoutes(context, { skeletonDelayMs: 1500, projectsDelayMs: 1500 });
     try {
       await openProse(page);
+      await page.evaluate(() => localStorage.removeItem("sp:lineage-inspector-width"));
       await page.getByTestId("showcase-rendered").locator(`a[href="${LINK_HREF}"]`).click();
       const modal = page.getByTestId("lineage-modal");
       await expect(modal).toBeVisible();
@@ -193,6 +194,34 @@ test.describe("chat lineage modal", () => {
       await sql.getByRole("button", { name: "compiled" }).click();
       await expect(sql.locator("pre")).toContainText("demo.analytics.stg_refunds");
       expect(mock.count(/dbt-map\/model\/[^/]+\/sql/)).toBe(1);
+
+      // The inspector resizes inside the modal too: the default is a share
+      // of the modal, a drag on the left-edge handle widens it and the
+      // canvas gives the width up, and the code block follows.
+      const inspector = embed.getByTestId("lineage-inspector");
+      const canvas = embed.getByTestId("lineage-canvas");
+      const handle = embed.getByTestId("inspector-resize-handle");
+      const width = async (l: typeof inspector) => (await l.boundingBox())!.width;
+      const embedWidth = await width(embed);
+      const inspectorBefore = await width(inspector);
+      const canvasBefore = await width(canvas);
+      expect(inspectorBefore).toBe(Math.round(embedWidth * 0.45));
+      const box = (await handle.boundingBox())!;
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + box.width / 2 - 200, box.y + box.height / 2, { steps: 6 });
+      await page.mouse.up();
+      await expect.poll(() => width(inspector)).toBe(inspectorBefore + 200);
+      // The canvas gave the width up, unless that would take it under its
+      // reserve: then the left panel collapsed to a rail instead.
+      const canvasAfter = await width(canvas);
+      if (canvasBefore - 200 >= 240) expect(canvasAfter).toBe(canvasBefore - 200);
+      else await expect(embed.getByTestId("lineage-panel-rail")).toBeVisible();
+      expect(canvasAfter).toBeGreaterThanOrEqual(240);
+      expect(await width(embed.getByTestId("inspector-sql-code"))).toBe(inspectorBefore + 200 - 25);
+      await expect(modal).toBeVisible();
+      await handle.dblclick();
+      await expect.poll(() => width(inspector)).toBe(inspectorBefore);
 
       // The stg_refunds node already has its columns from the cone: no request.
       const columnCalls = mock.count(/dbt-map\/columns/);

--- a/signalpilot/web/e2e/chats-composer.spec.ts
+++ b/signalpilot/web/e2e/chats-composer.spec.ts
@@ -71,7 +71,7 @@ test("composer autosizes, gives disabled feedback, and the project picker search
   const after = await textarea.evaluate((el) => el.clientHeight);
   expect(after).toBeGreaterThan(before);
 
-  // Helper hint documents Enter / Shift+Enter / @.
+  // Helper hint documents Enter / Shift+Enter.
   await textarea.fill("");
   await expect(page.getByText(/Enter to send/)).toBeVisible();
 

--- a/signalpilot/web/e2e/lineage-inspector.spec.ts
+++ b/signalpilot/web/e2e/lineage-inspector.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { PROJECT_ID, mockLineageRoutes } from "./lineage-fixtures";
+
+/**
+ * The resizable lineage inspector on /lineage/<model> against the fixture
+ * gateway (local mode): drag the left-edge handle, persistence across a
+ * reload, double-click reset, keyboard steps, the expand toggle, the SQL
+ * tab filling the width, and the left panel yielding to a rail.
+ */
+
+const BASE = process.env.SP_WEB_BASE_URL ?? "http://localhost:3200";
+const DEEP_LINK = `${BASE}/lineage/stg_refunds?project=${PROJECT_ID}`;
+const WIDTH_KEY = "sp:lineage-inspector-width";
+
+const widthOf = async (loc: Locator) => (await loc.boundingBox())!.width;
+
+async function openInspector(page: Page) {
+  await page.goto(DEEP_LINK);
+  const root = page.getByTestId("lineage-page");
+  await expect(root).toHaveAttribute("data-graph", "full");
+  await root.locator(".react-flow__node").filter({ hasText: "fct_orders" }).first().click();
+  const inspector = root.getByTestId("lineage-inspector");
+  await expect(inspector).toBeVisible();
+  // The row (panel + canvas + inspector) sits beside the app shell, so the
+  // bounds derive from it rather than from the viewport.
+  const row = Math.round(await widthOf(root.getByTestId("lineage-row")));
+  return {
+    root,
+    inspector,
+    row,
+    max: row - 240 - 36,
+    canvas: root.getByTestId("lineage-canvas"),
+    handle: root.getByTestId("inspector-resize-handle"),
+  };
+}
+
+async function dragHandle(page: Page, handle: Locator, dx: number) {
+  const box = (await handle.boundingBox())!;
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  // A few steps so the rAF-throttled preview runs mid-drag too.
+  await page.mouse.move(x + dx / 2, y, { steps: 4 });
+  await page.mouse.move(x + dx, y, { steps: 4 });
+  await page.mouse.up();
+}
+
+test.describe("lineage inspector resize", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await mockLineageRoutes(context);
+    // Clear the preference once (an init script would also wipe it on the
+    // reload the persistence test relies on).
+    await page.goto(`${BASE}/lineage`);
+    await page.evaluate((key) => localStorage.removeItem(key), WIDTH_KEY);
+  });
+
+  test.afterEach(async ({ context }) => {
+    await context.unrouteAll({ behavior: "ignoreErrors" });
+  });
+
+  test("drag widens the inspector, shrinks the canvas, persists, and double-click resets", async ({ page }) => {
+    const { inspector, canvas, handle, max } = await openInspector(page);
+    const startWidth = await widthOf(inspector);
+    const startCanvas = await widthOf(canvas);
+    expect(startWidth).toBe(560);
+    await expect(handle).toHaveAttribute("role", "separator");
+    await expect(handle).toHaveAttribute("aria-orientation", "vertical");
+    await expect(handle).toHaveAttribute("aria-valuenow", "560");
+    await expect(handle).toHaveAttribute("aria-valuemin", "320");
+    await expect(handle).toHaveAttribute("aria-valuemax", String(max));
+
+    await dragHandle(page, handle, -400);
+    await expect.poll(() => widthOf(inspector)).toBe(startWidth + 400);
+    // The canvas gave the width up; the left panel yielded to the rail as
+    // the canvas neared its reserve, so it shrank by less than the drag.
+    const canvasAfter = await widthOf(canvas);
+    expect(canvasAfter).toBeLessThan(startCanvas);
+    expect(canvasAfter).toBeGreaterThanOrEqual(240);
+    await expect(page.getByTestId("lineage-panel-rail")).toBeVisible();
+    await expect(handle).toHaveAttribute("aria-valuenow", String(startWidth + 400));
+    expect(await page.evaluate((k) => localStorage.getItem(k), WIDTH_KEY)).toBe(String(startWidth + 400));
+
+    // Persisted: a reload comes back at the dragged width.
+    await page.reload();
+    const again = await openInspector(page);
+    await expect.poll(() => widthOf(again.inspector)).toBe(startWidth + 400);
+
+    // Double-click resets to the default and clears the preference.
+    await again.handle.dblclick();
+    await expect.poll(() => widthOf(again.inspector)).toBe(560);
+    expect(await page.evaluate((k) => localStorage.getItem(k), WIDTH_KEY)).toBeNull();
+  });
+
+  test("the stored width is clamped to the viewport", async ({ page }) => {
+    await page.addInitScript((key) => localStorage.setItem(key, "5000"), WIDTH_KEY);
+    const { inspector, canvas, row, max } = await openInspector(page);
+    await expect.poll(() => widthOf(inspector)).toBe(max);
+    // The left panel collapsed to the rail; the canvas keeps its reserve.
+    await expect(page.getByTestId("lineage-panel-rail")).toBeVisible();
+    expect(await widthOf(canvas)).toBeGreaterThanOrEqual(240);
+    await page.getByRole("button", { name: "Show lineage panel" }).click();
+    await expect(page.getByTestId("lineage-panel-rail")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "raw tables" })).toBeVisible();
+    await expect.poll(() => widthOf(inspector)).toBe(row - 288 - 240);
+  });
+
+  test("keyboard resizes on the separator", async ({ page }) => {
+    const { inspector, handle, max } = await openInspector(page);
+    await handle.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(() => widthOf(inspector)).toBe(592);
+    await page.keyboard.press("Shift+ArrowLeft");
+    await expect.poll(() => widthOf(inspector)).toBe(720);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => widthOf(inspector)).toBe(688);
+    await page.keyboard.press("Shift+ArrowRight");
+    await expect.poll(() => widthOf(inspector)).toBe(560);
+    await page.keyboard.press("Home");
+    await expect.poll(() => widthOf(inspector)).toBe(320);
+    await page.keyboard.press("End");
+    await expect.poll(() => widthOf(inspector)).toBe(max);
+    expect(await page.evaluate((k) => localStorage.getItem(k), WIDTH_KEY)).toBe(String(max));
+  });
+
+  test("the expand toggle widens to the preset and the SQL block fills the width", async ({ page }) => {
+    const { root, inspector, handle, row } = await openInspector(page);
+    const wide = Math.round(row * 0.7);
+    const expand = root.getByTestId("inspector-expand");
+    await expect(expand).toHaveAttribute("aria-pressed", "false");
+    await expand.click();
+    await expect.poll(() => widthOf(inspector)).toBe(wide);
+    await expect(expand).toHaveAttribute("aria-pressed", "true");
+    await expect(inspector).toHaveAttribute("data-wide", "1");
+
+    // The SQL block tracks the inspector width (padding aside).
+    await root.getByTestId("inspector-tab-sql").click();
+    const sql = root.getByTestId("inspector-sql");
+    await expect(sql.locator("pre")).toContainText("ref('stg_refunds')");
+    // Width minus the 24 px padding and the 1 px left border.
+    const code = root.getByTestId("inspector-sql-code");
+    expect(await widthOf(code)).toBe(wide - 25);
+    await page.screenshot({ path: "test-results/lineage-inspector-sql-wide.png" });
+    // The header keeps toggle, path and copy on one row at this width.
+    const toggle = sql.getByRole("group", { name: "SQL variant" });
+    const path = root.getByTestId("inspector-sql-path");
+    const copy = sql.getByRole("button", { name: "Copy" });
+    const rowY = (await toggle.boundingBox())!.y;
+    expect(Math.abs((await path.boundingBox())!.y - rowY)).toBeLessThan(8);
+    expect(Math.abs((await copy.boundingBox())!.y - rowY)).toBeLessThan(8);
+
+    // Drag narrower: the block follows.
+    await dragHandle(page, handle, 300);
+    await expect.poll(() => widthOf(inspector)).toBe(wide - 300);
+    expect(await widthOf(code)).toBe(wide - 300 - 25);
+
+    // The toggle restores the width from before the preset.
+    await expand.click();
+    await expect.poll(() => widthOf(inspector)).toBe(wide);
+    await expand.click();
+    await expect.poll(() => widthOf(inspector)).toBe(wide - 300);
+  });
+});

--- a/signalpilot/web/notebook/components/editor/dbt-lineage/use-dbt-lineage.ts
+++ b/signalpilot/web/notebook/components/editor/dbt-lineage/use-dbt-lineage.ts
@@ -22,7 +22,7 @@ import { parseManifest } from "./parse-manifest";
 
 function getApiBase(): string {
   const rm = getRuntimeManager();
-  const base = rm.httpURL.toString().replace(/\/$/, "");
+  const base = rm.httpBaseURL.toString().replace(/\/$/, "");
   return `${base}/api/dbt`;
 }
 

--- a/signalpilot/web/notebook/components/editor/renderers/vertical-layout/notebook-actions.test.tsx
+++ b/signalpilot/web/notebook/components/editor/renderers/vertical-layout/notebook-actions.test.tsx
@@ -1,0 +1,64 @@
+import { createStore, Provider } from "jotai";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { viewerOnlyAtom } from "@/core/mode";
+import { requestClientAtom } from "@/core/network/requests";
+import { NotebookActionButtons } from "./notebook-actions";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const DROPDOWN = '[data-testid="notebook-actions-dropdown"]';
+
+describe("NotebookActionButtons", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render(viewerOnly: boolean) {
+    const store = createStore();
+    store.set(viewerOnlyAtom, viewerOnly);
+    // The menu only needs readCode, and only when an item is selected.
+    store.set(requestClientAtom, {
+      readCode: async () => ({ contents: "" }),
+    } as never);
+    await act(async () => {
+      root.render(
+        <Provider store={store}>
+          <NotebookActionButtons
+            canShowCode={true}
+            showCode={false}
+            onToggleShowCode={() => {}}
+          />
+        </Provider>,
+      );
+    });
+  }
+
+  it("renders the three-dots trigger in the full notebook app", async () => {
+    await render(false);
+    const dropdown = container.querySelector(DROPDOWN);
+    expect(dropdown).not.toBeNull();
+    const trigger = dropdown?.querySelector('button[aria-haspopup="menu"]');
+    expect(trigger).not.toBeNull();
+    expect(trigger?.querySelector("svg.lucide-ellipsis")).not.toBeNull();
+  });
+
+  it("renders nothing on viewer-only surfaces (chat notebook panel)", async () => {
+    await render(true);
+    expect(container.querySelector(DROPDOWN)).toBeNull();
+    expect(container.querySelector('button[aria-haspopup="menu"]')).toBeNull();
+  });
+});

--- a/signalpilot/web/notebook/components/editor/renderers/vertical-layout/notebook-actions.tsx
+++ b/signalpilot/web/notebook/components/editor/renderers/vertical-layout/notebook-actions.tsx
@@ -1,0 +1,164 @@
+import { useAtomValue } from "jotai";
+import {
+  Check,
+  Code2Icon,
+  CodeIcon,
+  FolderDownIcon,
+  ImageIcon,
+  MoreHorizontalIcon,
+} from "lucide-react";
+import type React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { viewerOnlyAtom } from "@/core/mode";
+import { useRequestClient } from "@/core/network/requests";
+import { downloadAsHTML } from "@/core/static/download-html";
+import { isStaticNotebook } from "@/core/static/static-state";
+import { cn } from "@/utils/cn";
+import {
+  ADD_PRINTING_CLASS,
+  downloadBlob,
+  downloadHTMLAsImage,
+} from "@/utils/download";
+import { Filenames } from "@/utils/filenames";
+
+/**
+ * Notebook-level actions menu for the read view: show code, download as
+ * HTML, .py, and PNG. Hidden on pure viewer surfaces (the chat live notebook
+ * panel and its pop-out): they own their Code/App toggle, run in a sandbox
+ * with no static export, and the chat page hosts the notebook chrome.
+ */
+export const NotebookActionButtons: React.FC<{
+  canShowCode: boolean;
+  showCode: boolean;
+  onToggleShowCode: () => void;
+}> = ({ canShowCode, showCode, onToggleShowCode }) => {
+  const { readCode } = useRequestClient();
+  const viewerOnly = useAtomValue(viewerOnlyAtom);
+
+  const handleDownloadAsPNG = async () => {
+    const app = document.getElementById("App");
+    if (!app) {
+      return;
+    }
+    await downloadHTMLAsImage({
+      element: app,
+      filename: document.title,
+      // Add body.printing ONLY when converting the whole notebook to a screenshot
+      prepare: ADD_PRINTING_CLASS,
+    });
+  };
+
+  const handleDownloadAsHTML = async () => {
+    const app = document.getElementById("App");
+    if (!app) {
+      return;
+    }
+    await downloadAsHTML({ filename: document.title, includeCode: true });
+  };
+
+  const handleDownloadAsPython = async () => {
+    const code = await readCode();
+    downloadBlob(
+      new Blob([code.contents], { type: "text/plain" }),
+      Filenames.toPY(document.title),
+    );
+  };
+
+  const isStatic = isStaticNotebook();
+  const actions: React.ReactNode[] = [];
+
+  if (viewerOnly) {
+    return null;
+  }
+
+  if (canShowCode) {
+    actions.push(
+      <DropdownMenuItem
+        onSelect={onToggleShowCode}
+        data-testid="notebook-action-show-code"
+        key="show-code"
+      >
+        <Code2Icon className="mr-2" size={14} strokeWidth={1.5} />
+        <span className="flex-1">Show code</span>
+        {showCode && <Check className="h-4 w-4" />}
+      </DropdownMenuItem>,
+      <DropdownMenuSeparator key="show-code-separator" />,
+    );
+  }
+
+  if (!isStatic) {
+    actions.push(
+      <DropdownMenuItem
+        onSelect={handleDownloadAsHTML}
+        data-testid="notebook-action-download-html"
+        key="download-html"
+      >
+        <FolderDownIcon className="mr-2" size={14} strokeWidth={1.5} />
+        Download as HTML
+      </DropdownMenuItem>,
+    );
+
+    // Only show download as Python if code is available
+    if (canShowCode) {
+      actions.push(
+        <DropdownMenuItem
+          onSelect={handleDownloadAsPython}
+          data-testid="notebook-action-download-python"
+          key="download-python"
+        >
+          <CodeIcon className="mr-2" size={14} strokeWidth={1.5} />
+          Download as .py
+        </DropdownMenuItem>,
+      );
+    }
+
+    actions.push(
+      <DropdownMenuSeparator key="download-separator" />,
+      <DropdownMenuItem
+        onSelect={handleDownloadAsPNG}
+        data-testid="notebook-action-download-png"
+        key="download-png"
+      >
+        <ImageIcon className="mr-2" size={14} strokeWidth={1.5} />
+        Download as PNG
+      </DropdownMenuItem>,
+    );
+  }
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  // Don't change the id of this element
+  // as this may be used in custom css to hide/show the actions dropdown
+  return (
+    <div
+      data-testid="notebook-actions-dropdown"
+      className={cn(
+        "right-0 top-0 z-50 m-4 print:hidden flex gap-2",
+        // If the notebook is static, we have a banner at the top, so
+        // we can't use fixed positioning. Ideally this is sticky, but the
+        // current dom structure makes that difficult.
+        isStaticNotebook() ? "absolute" : "fixed",
+      )}
+    >
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild={true}>
+          <Button variant="secondary" size="xs">
+            <MoreHorizontalIcon className="w-4 h-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="print:hidden w-[220px]">
+          {actions}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};

--- a/signalpilot/web/notebook/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/signalpilot/web/notebook/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -1,12 +1,6 @@
 import { useAtomValue } from "jotai";
 import {
-  Check,
-  Code2Icon,
-  CodeIcon,
-  FolderDownIcon,
-  ImageIcon,
   Loader2Icon,
-  MoreHorizontalIcon,
 } from "lucide-react";
 import type React from "react";
 import { memo, useEffect, useRef, useState } from "react";
@@ -15,14 +9,6 @@ import { ReadonlyCode } from "@/components/editor/code/readonly-python-code";
 import { OutputArea } from "@/components/editor/Output";
 import { ConsoleOutput } from "@/components/editor/output/console/ConsoleOutput";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import type { CellId } from "@/core/cells/ids";
 import { isOutputEmpty } from "@/core/cells/outputs";
@@ -36,21 +22,14 @@ import { useNotebookCodeAvailable } from "@/core/meta/code-visibility";
 import { showCodeInRunModeAtom } from "@/core/meta/state";
 import { isErrorMime } from "@/core/mime";
 import { type AppMode, kioskModeAtom } from "@/core/mode";
-import { useRequestClient } from "@/core/network/requests";
 import type { CellConfig } from "@/core/network/types";
-import { downloadAsHTML } from "@/core/static/download-html";
 import { isStaticNotebook } from "@/core/static/static-state";
 
 import { cn } from "@/utils/cn";
-import {
-  ADD_PRINTING_CLASS,
-  downloadBlob,
-  downloadHTMLAsImage,
-} from "@/utils/download";
-import { Filenames } from "@/utils/filenames";
 import { FloatingOutline } from "../../chrome/panels/outline/floating-outline";
 import { cellDomProps } from "../../common";
 import type { ICellRendererPlugin, ICellRendererProps } from "../types";
+import { NotebookActionButtons } from "./notebook-actions";
 import { useDelayVisibility } from "./useDelayVisibility";
 import { VerticalLayoutWrapper } from "./vertical-layout-wrapper";
 
@@ -172,7 +151,7 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
         {renderCells()}
       </div>
       {mode === "read" && (
-        <ActionButtons
+        <NotebookActionButtons
           canShowCode={canShowCode}
           showCode={showCode}
           onToggleShowCode={() => setShowCode((v) => !v)}
@@ -180,130 +159,6 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
       )}
       <FloatingOutline />
     </VerticalLayoutWrapper>
-  );
-};
-
-const ActionButtons: React.FC<{
-  canShowCode: boolean;
-  showCode: boolean;
-  onToggleShowCode: () => void;
-}> = ({ canShowCode, showCode, onToggleShowCode }) => {
-  const { readCode } = useRequestClient();
-
-  const handleDownloadAsPNG = async () => {
-    const app = document.getElementById("App");
-    if (!app) {
-      return;
-    }
-    await downloadHTMLAsImage({
-      element: app,
-      filename: document.title,
-      // Add body.printing ONLY when converting the whole notebook to a screenshot
-      prepare: ADD_PRINTING_CLASS,
-    });
-  };
-
-  const handleDownloadAsHTML = async () => {
-    const app = document.getElementById("App");
-    if (!app) {
-      return;
-    }
-    await downloadAsHTML({ filename: document.title, includeCode: true });
-  };
-
-  const handleDownloadAsPython = async () => {
-    const code = await readCode();
-    downloadBlob(
-      new Blob([code.contents], { type: "text/plain" }),
-      Filenames.toPY(document.title),
-    );
-  };
-
-  const isStatic = isStaticNotebook();
-  const actions: React.ReactNode[] = [];
-
-  if (canShowCode) {
-    actions.push(
-      <DropdownMenuItem
-        onSelect={onToggleShowCode}
-        data-testid="notebook-action-show-code"
-        key="show-code"
-      >
-        <Code2Icon className="mr-2" size={14} strokeWidth={1.5} />
-        <span className="flex-1">Show code</span>
-        {showCode && <Check className="h-4 w-4" />}
-      </DropdownMenuItem>,
-      <DropdownMenuSeparator key="show-code-separator" />,
-    );
-  }
-
-  if (!isStatic) {
-    actions.push(
-      <DropdownMenuItem
-        onSelect={handleDownloadAsHTML}
-        data-testid="notebook-action-download-html"
-        key="download-html"
-      >
-        <FolderDownIcon className="mr-2" size={14} strokeWidth={1.5} />
-        Download as HTML
-      </DropdownMenuItem>,
-    );
-
-    // Only show download as Python if code is available
-    if (canShowCode) {
-      actions.push(
-        <DropdownMenuItem
-          onSelect={handleDownloadAsPython}
-          data-testid="notebook-action-download-python"
-          key="download-python"
-        >
-          <CodeIcon className="mr-2" size={14} strokeWidth={1.5} />
-          Download as .py
-        </DropdownMenuItem>,
-      );
-    }
-
-    actions.push(
-      <DropdownMenuSeparator key="download-separator" />,
-      <DropdownMenuItem
-        onSelect={handleDownloadAsPNG}
-        data-testid="notebook-action-download-png"
-        key="download-png"
-      >
-        <ImageIcon className="mr-2" size={14} strokeWidth={1.5} />
-        Download as PNG
-      </DropdownMenuItem>,
-    );
-  }
-
-  if (actions.length === 0) {
-    return null;
-  }
-
-  // Don't change the id of this element
-  // as this may be used in custom css to hide/show the actions dropdown
-  return (
-    <div
-      data-testid="notebook-actions-dropdown"
-      className={cn(
-        "right-0 top-0 z-50 m-4 print:hidden flex gap-2",
-        // If the notebook is static, we have a banner at the top, so
-        // we can't use fixed positioning. Ideally this is sticky, but the
-        // current dom structure makes that difficult.
-        isStaticNotebook() ? "absolute" : "fixed",
-      )}
-    >
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild={true}>
-          <Button variant="secondary" size="xs">
-            <MoreHorizontalIcon className="w-4 h-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="print:hidden w-[220px]">
-          {actions}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
   );
 };
 

--- a/signalpilot/web/notebook/core/network/api-call.ts
+++ b/signalpilot/web/notebook/core/network/api-call.ts
@@ -67,9 +67,7 @@ async function getBaseUrlAndHeaders(): Promise<{
   // Fallback: RuntimeManager (standalone mode / after full init)
   const rm = getRuntimeManager();
   await rm.waitForHealthy();
-  const url = rm.httpURL;
-  url.search = "";
-  url.hash = "";
+  const url = rm.httpBaseURL;
   const baseUrl = Strings.withTrailingSlash(url.toString());
   const hdrs: Record<string, string> = {
     "Content-Type": "application/json",

--- a/signalpilot/web/notebook/core/network/api.ts
+++ b/signalpilot/web/notebook/core/network/api.ts
@@ -211,7 +211,7 @@ export const API = {
 
 export function createClientWithRuntimeManager(runtimeManager: RuntimeManager) {
   const spClient = createSpClient({
-    baseUrl: runtimeManager.httpURL.toString(),
+    baseUrl: runtimeManager.httpBaseURL.toString(),
   });
 
   spClient.use({

--- a/signalpilot/web/notebook/core/network/requests-network.ts
+++ b/signalpilot/web/notebook/core/network/requests-network.ts
@@ -40,7 +40,7 @@ export function createNetworkRequests(): EditRequests & RunRequests {
   } | null = null;
   const getClient = () => {
     const runtimeManager = getRuntimeManager();
-    const base = runtimeManager.httpURL.toString();
+    const base = runtimeManager.httpBaseURL.toString();
     if (!cachedClient || cachedClient.base !== base) {
       cachedClient = {
         base,

--- a/signalpilot/web/notebook/core/runtime/config.ts
+++ b/signalpilot/web/notebook/core/runtime/config.ts
@@ -68,7 +68,7 @@ export function asRemoteURL(path: string): URL {
   if (path.startsWith("http")) {
     return new URL(path);
   }
-  let base = getRuntimeManager().httpURL.toString();
+  let base = getRuntimeManager().httpBaseURL.toString();
   if (base.startsWith("blob:")) {
     // Remove leading blob:
     base = base.replace("blob:", "");

--- a/signalpilot/web/notebook/core/runtime/runtime-url.test.ts
+++ b/signalpilot/web/notebook/core/runtime/runtime-url.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { RuntimeManager } from "./runtime";
+
+describe("RuntimeManager URL bases", () => {
+  it("keeps a query string on the configured URL intact", () => {
+    const rm = new RuntimeManager({
+      url: "http://gateway.test/notebook/sid-1?kiosk=true",
+      lazy: false,
+    });
+    expect(rm.httpURL.toString()).toBe(
+      "http://gateway.test/notebook/sid-1/?kiosk=true",
+    );
+  });
+
+  it("drops the query string from the REST base so paths join cleanly", () => {
+    const rm = new RuntimeManager({
+      url: "http://gateway.test/notebook/sid-1?kiosk=true",
+      lazy: false,
+    });
+    expect(rm.httpBaseURL.toString()).toBe(
+      "http://gateway.test/notebook/sid-1/",
+    );
+  });
+
+  it("leaves a plain URL unchanged apart from the trailing slash", () => {
+    const rm = new RuntimeManager({
+      url: "http://gateway.test/notebook/sid-1",
+      lazy: false,
+    });
+    expect(rm.httpBaseURL.toString()).toBe(
+      "http://gateway.test/notebook/sid-1/",
+    );
+  });
+});

--- a/signalpilot/web/notebook/core/runtime/runtime.ts
+++ b/signalpilot/web/notebook/core/runtime/runtime.ts
@@ -45,10 +45,27 @@ export class RuntimeManager {
     // resolve against the last path SEGMENT's parent, so a session base of
     // ".../notebook/{sid}" (no slash) would silently drop the session id
     // and 404 every virtual file.
-    const url = this.config.url.endsWith("/")
-      ? this.config.url
-      : `${this.config.url}/`;
-    return new URL(url);
+    // Parse before normalizing: appending "/" to a raw string that carries
+    // a query string (".../notebook/{sid}?kiosk=true") corrupts the query
+    // and leaves the path without its trailing slash.
+    const url = new URL(this.config.url);
+    if (!url.pathname.endsWith("/")) {
+      url.pathname = `${url.pathname}/`;
+    }
+    return url;
+  }
+
+  /**
+   * Base for REST calls against the runtime: origin and path only. Query
+   * params on the configured URL (such as the kiosk flag) belong to the
+   * websocket; joined onto an HTTP path they produce a URL no router
+   * matches.
+   */
+  get httpBaseURL(): URL {
+    const url = this.httpURL;
+    url.search = "";
+    url.hash = "";
+    return url;
   }
 
   get isSameOrigin(): boolean {


### PR DESCRIPTION
## What is in this PR

Three frontend fixes. Stacks on #333 (this branch was cut from `feat/artifact-cards-and-lineage-nav`); once #333 merges, only the last commit is the delta.

### Resizable lineage inspector
- Drag handle on the inspector's left edge, on the lineage page and inside the chat lineage modal. Minimum 320 px; maximum leaves 240 px of canvas, so the panel can take nearly the whole viewport.
- One-click expand toggle to a 70 percent preset, double-click the handle to reset, keyboard resizing on the handle (`role="separator"`, arrow keys, Home/End).
- Width persists in `localStorage` (`sp:lineage-inspector-width`), clamped to the current viewport on read, shared by page and modal.
- The SQL tab fills the panel width and available height; the left focus panel collapses to a slim rail when the canvas would go under 240 px; ReactFlow reframes after resizes.
- Verified on the real staging page with a signed-in browser: drag to 1100 px, End to max, reset to 560 px, expand to 963 px, width persisted.

### Chat composer
- Removed the `@` model-mention autocomplete (popover, matching, `useMentionOptions` that fetched the full dbt map, hint text). Typing `@` inserts the character. Nothing gateway-side carried mentions.

### Chat notebook view
- The notebook read-view actions menu (show code, download as HTML/PNG/.py) is hidden inside the chat's embedded notebook, gated on the existing viewer-only mode that only the chat embed sets. Its downloads targeted the chat page's chrome. The full notebook app keeps the menu; a unit test asserts both.

### Verification
- Type check clean. Vitest: 553 passed (2 pre-existing unrelated failures in `project-connection-settings`). Playwright: 41 passed across lineage-inspector, lineage-cache, chat-lineage-modal, chat-ux-test-page, chats-composer, chat-live-notebook, and chat-artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
