### PR TITLE
feat(onboarding): add Getting Started journeys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@
 # CLAUDE_CODE_OAUTH_TOKEN=
 # CLAUDE_HOST_CONFIG_DIR=${HOME}/.config/signalpilot/claude-code-docker
 
+# Optional first-run Demo Team provisioning. XATA_KEY stays server-side and
+# must be supplied through the deployment secret store.
+# XATA_KEY=
+SP_DEMO_XATA_ORG=0psl2d
+SP_DEMO_CATALOG=[{"slug":"parallax","project":"prj_7r8eolv5c15q12os2k0m3lt408","title":"Parallax","repo_url":"https://github.com/kiwi0401/parallax-demo","parent_branch":"main"}]
+
 # Optional Slack OAuth and Events API integration.
 # Requires a public callback/webhook URL, usually via ngrok or cloudflared.
 # SLACK_OAUTH_CLIENT_ID=

--- a/plans/onboarding/PLAN.md
+++ b/plans/onboarding/PLAN.md
@@ -1,0 +1,392 @@
+# SignalPilot First-Run Onboarding Plan
+
+**Status:** Phase 1 implemented in PR #338; cloud acceptance and rollout remain open
+**Current phase:** Phase 1 — Getting Started foundation and first complete vertical slice
+
+## Goal
+
+Help an authenticated user reach a useful, governed Chat Agent result without
+having to discover setup dependencies across unrelated settings pages.
+
+The onboarding product has three separate, resumable journeys:
+
+1. **Demo** — see SignalPilot work with isolated sample data.
+2. **Production setup** — connect the active Team's dbt project, warehouse, and
+   AI access.
+3. **Product Tour** — learn the working product after Demo or Setup.
+
+The journeys share one persistent **Getting Started** controller, but they do
+not share completion state.
+
+## Locked product decisions
+
+- The user is already authenticated when this flow starts.
+- If the user has an active non-demo Team, production setup uses it rather than
+  creating another Team.
+- Demo runs in a separate, personal Demo Team so demo data and production data
+  cannot be confused.
+- The first demo catalog contains Parallax only because it has an allowlisted
+  Xata project and a matching public dbt repository.
+- The Demo Xata parent branch is protected and shared; each Demo Team receives
+  a private writable child branch.
+- GitHub import creates the SignalPilot project before warehouse linking.
+- **Connect Warehouse** owns the automatic project link. The connection is
+  linked only after a healthy connection test and dbt-adapter compatibility
+  check. There is no separate manual link-project screen.
+- Demo, Setup, and Product Tour are independent journeys.
+- Setup progress belongs to the Team/workspace. Tour progress belongs to the
+  user.
+- Teammate invitation is optional and never blocks the first useful result.
+- Demo limits are enforced by the gateway, not only by disabled UI.
+- Saved replays do not consume a live Demo request.
+- Demo deletion must remove the SignalPilot project, private Xata
+  branch, and connection before the Clerk Team is deleted.
+- `XATA_KEY` is a deployment secret and must never be returned to the browser,
+  stored in the repository, or included in logs.
+
+## User journeys
+
+### Entry
+
+After authentication, show one short question:
+
+> **How would you like to start?**
+
+- **Explore a demo** prepares the private Demo Team.
+- **Connect my data** opens production setup in the active non-demo Team.
+- **Skip for now** enters the product without destroying journey progress.
+
+The choice is reversible. Getting Started remains accessible from the Team
+switcher and can be collapsed, resumed, or restarted.
+
+### Demo journey
+
+1. Create or resume the user's personal Demo Team.
+2. Provision a private Xata branch from the protected Parallax parent.
+3. Register the fixed Xata connection without exposing credentials.
+4. Import the allowlisted Parallax dbt repository.
+5. Wait for successful dbt metadata compilation.
+6. Seed or reuse the versioned saved Chat Agent replay.
+7. Open the replay automatically and show its governed events in order.
+8. Offer suggested live questions.
+9. Enforce the five-live-request allowance atomically at the gateway.
+10. Offer Product Tour and production-setup next actions.
+11. On Demo Team deletion, clean up the project, private branch, and connection
+    before deleting the Team.
+
+### Production setup journey
+
+1. Use the active non-demo Team. When leaving a Demo Team, create or select a
+   production Team first.
+2. Connect GitHub and import a dbt repository, branch, and project directory.
+3. Carry the imported project ID into Connect Warehouse.
+4. Create or select the warehouse connection.
+5. Save and test the connection.
+6. Verify access and dbt-adapter compatibility.
+7. Link the healthy connection to the imported project idempotently.
+8. Add or rotate the Team-scoped Anthropic API key.
+9. Invite one technical teammate or explicitly skip the optional step.
+10. Recompute readiness from current dbt metadata, connection credentials,
+    project link, and AI access.
+11. Set the ready project as the user's default and open Chat Agent.
+
+Failed warehouse tests must not link the project. Saved connections remain
+retryable, and leaving the flow must not erase progress.
+
+### Product Tour journey
+
+The initial tour uses real product routes and targets:
+
+1. Ask a question in Chat Agent.
+2. Follow the governed work and inspect the answer.
+3. Explore a connection or schema.
+4. Open dbt lineage and supporting knowledge.
+5. Review the resulting product surface.
+6. Invite a teammate or learn how to keep working.
+
+The compact controller shows journey, current task, progress, Continue, and
+Expand. The expanded controller shows all steps, locked/unlocked state, current
+form, errors, fallback actions, and the primary action. Session-only dismissal
+must not mark the user or Team complete.
+
+## State and ownership
+
+| State | Owner | Source of truth |
+| --- | --- | --- |
+| Active journey and Product Tour progress | User | Clerk user metadata |
+| Setup Team and imported project identity | Team plus user resume pointer | Gateway project state and Clerk metadata |
+| Warehouse link | Team project | Gateway workspace project `connection_name` |
+| dbt readiness | Team project and revision | Compiled gateway dbt metadata |
+| Anthropic access | Team | Server-side organization secret state |
+| Demo identity | Demo Team | Pinned connection/project policy tags |
+| Demo request usage | Demo Team | Gateway Chat runs excluding saved replay origin |
+| Drawer visibility for the current browser session | Browser session | Session storage |
+
+Client metadata is a resume aid, not authority for readiness, authorization,
+limits, or resource ownership.
+
+## Phase tracker
+
+- [x] Phase 0 — Product contract and clickable prototype.
+- [x] Phase 1 — Getting Started foundation and first complete vertical slice.
+- [ ] Phase 2 — Configured-cloud acceptance and hardening.
+- [ ] Phase 3 — Staged rollout and product completion.
+
+Checked implementation work means the code exists on the Phase 1 branch. It
+does not mean the branch has been merged, deployed, or accepted in production.
+
+## Phase 0 — Product contract and prototype
+
+**Status:** Product contract complete; this canonical plan is added in PR #338.
+
+### Deliverables
+
+- [x] Define Demo, Production Setup, and Product Tour as separate journeys.
+- [x] Establish the first-login choice and reversible navigation.
+- [x] Define Team-owned setup state and user-owned tour state.
+- [x] Define the GitHub import to Connect Warehouse handoff.
+- [x] Require healthy warehouse testing before automatic project linking.
+- [x] Define Demo fallback and Resume Setup behavior.
+- [x] Create the self-contained clickable prototype.
+
+### Exit evidence
+
+- This self-contained `plans/onboarding/PLAN.md`.
+- A local clickable prototype used during product review. The prototype is not
+  included in this implementation PR.
+
+The prototype is product/design evidence only. It is not runtime acceptance.
+
+## Phase 1 — Foundation and first vertical slice
+
+**Status:** Implemented in PR #338. Local automated evidence exists; cloud
+acceptance remains Phase 2.
+
+### Getting Started controller
+
+- [x] Add the global compact and expanded controller.
+- [x] Persist active journey and Product Tour progress.
+- [x] Support collapse, resume, restart, and session-only dismissal.
+- [x] Add a Team-switcher entry point.
+- [x] Add route-level Product Tour targets.
+
+### Demo Team
+
+- [x] Allowlist the Parallax catalog slug, Xata project, parent branch, and dbt
+  repository.
+- [x] Idempotently create or resume the private Demo connection and project.
+- [x] Trigger dbt project preparation and wait for compiled metadata.
+- [x] Seed a versioned, authorized saved replay.
+- [x] Auto-start replay only after the gateway authorizes the conversation/run.
+- [x] Exclude saved replays from live-request usage.
+- [x] Enforce the five-request limit at conversation/run/retry boundaries.
+- [x] Return usage and remaining allowance in Chat bootstrap.
+- [x] Preserve pinned Demo ownership tags during cosmetic edits.
+- [x] Clean up Demo project, private branch, and connection before Team deletion.
+
+### Production setup
+
+- [x] Reuse the GitHub import form and retain the OAuth return path.
+- [x] Tag and persist the setup project for resumable discovery.
+- [x] Reuse the connection editor inside Getting Started.
+- [x] Return saved/tested connection state to the controller.
+- [x] Link the connection to the imported project only after a healthy test.
+- [x] Reuse Team-scoped Anthropic-key management.
+- [x] Reuse the Team invitation form and support Skip.
+- [x] Poll readiness while dbt metadata is being prepared.
+- [x] Set the ready project as Chat Agent's default.
+
+### Entitlements needed for first value
+
+- [x] Make dbt projects and lineage available to Free Teams.
+- [x] Keep user-managed notebook sessions as a paid entitlement.
+- [x] Allow a Free Team owner plus one active or pending teammate.
+- [x] Keep Demo Teams personal and disable Demo invitations.
+
+### Local validation
+
+- [x] Gateway Demo/Getting Started policy tests: 34 passed.
+- [x] Getting Started, Chat replay, and error-copy frontend tests: 20 passed.
+- [x] Web TypeScript typecheck passed.
+- [x] Ruff lint checks passed for changed Python files.
+- [x] Linux/Docker build passed on PR #338.
+- [x] Windows native web build passed on PR #338.
+- [x] macOS arm64 native web build passed on PR #338.
+- [x] Secret scanning, Semgrep, Bandit, and Python dependency checks passed on
+  PR #338.
+
+### Phase 1 exit criteria
+
+- [x] The focused onboarding branch is based on `main`.
+- [x] The complete implementation and roadmap are reviewable in one PR.
+- [ ] Required PR checks pass; the first PR run's Node dependency scan and docs
+  preview failures must be resolved or shown to be unrelated before merge.
+- [ ] PR #338 is reviewed and merged.
+- [ ] Configured-cloud acceptance is complete.
+
+The last two items intentionally remain unchecked. Merge does not replace live
+acceptance, and local/CI builds do not prove the external integrations.
+
+## Phase 2 — Configured-cloud acceptance and hardening
+
+**Status:** Not started as acceptance evidence.
+
+### Environment preparation
+
+- [ ] Configure `SP_DEMO_XATA_ORG` and the allowlisted
+  `SP_DEMO_CATALOG` in the target environment.
+- [ ] Configure `XATA_KEY` only in the deployment secret store.
+- [ ] Confirm Clerk organization creation/switching and user metadata writes.
+- [ ] Provision a test GitHub installation, dbt repository, supported warehouse,
+  and Team-scoped Anthropic key.
+
+### Demo acceptance
+
+- [ ] Create a first Demo Team from a fresh authenticated user.
+- [ ] Prove that the Xata child branch is private, writable, and unique.
+- [ ] Prove that the protected parent cannot be edited or deleted by the flow.
+- [ ] Prove that the paired dbt repository compiles and the Demo becomes ready.
+- [ ] Replay the saved run without consuming the live allowance.
+- [ ] Use five live requests and prove the sixth is rejected by the gateway.
+- [ ] Race concurrent tabs against the final allowance and prove no overrun.
+- [ ] Reload and resume provisioning without duplicate resources.
+- [ ] Delete the Demo Team and prove project, branch, and connection cleanup.
+- [ ] Simulate cleanup failure and prove Team deletion stops with a retryable
+  error rather than leaking private data.
+
+### Production setup acceptance
+
+- [ ] Start Setup in an existing non-demo Team without creating a duplicate.
+- [ ] Start Setup from a Demo Team and switch to a separate production Team.
+- [ ] Complete GitHub OAuth and return to the same Getting Started step.
+- [ ] Import a dbt project and carry the exact project ID forward.
+- [ ] Fail a warehouse test and prove the project remains unlinked.
+- [ ] Pass the test and compatibility checks and prove automatic linking.
+- [ ] Reload mid-flow and resume from server state.
+- [ ] Add Team-scoped Anthropic access without exposing the secret.
+- [ ] Skip invitation and reach readiness.
+- [ ] Invite one teammate and reach readiness.
+- [ ] Open Chat Agent with the ready project selected and complete a useful run.
+
+### Product Tour and browser acceptance
+
+- [ ] Complete the tour from both Demo and Production Setup.
+- [ ] Prove each spotlight target exists on its intended route.
+- [ ] Prove locked steps cannot be selected early.
+- [ ] Collapse, expand, dismiss for the session, resume, and restart.
+- [ ] Verify desktop and narrow-screen layouts.
+- [ ] Verify keyboard focus, Escape handling, labels, and screen-reader status
+  announcements.
+
+### Operational hardening
+
+- [ ] Add allowlisted, metadata-only telemetry for journey start, step completion,
+  failure class, abandonment, readiness, and first useful run.
+- [ ] Exclude credentials, SQL, prompts, result rows, and raw exceptions from
+  telemetry.
+- [ ] Add alerts for provisioning failure, stuck dbt compilation, cleanup
+  failure, and request-limit anomalies.
+- [ ] Document retry and manual cleanup procedures.
+
+### Phase 2 exit criteria
+
+- [ ] All Demo, Setup, Tour, and failure-path checks pass in a configured cloud
+  environment.
+- [ ] No secret or cross-Team data crosses the authorization boundary.
+- [ ] Cleanup and retry procedures are exercised, not merely documented.
+- [ ] Browser evidence exists for desktop and narrow-screen flows.
+- [ ] Known failures have owners and explicit release decisions.
+
+## Phase 3 — Staged rollout and product completion
+
+**Status:** Planned.
+
+### Product choices to close
+
+- [ ] Choose Demo Team retention and inactivity cleanup windows.
+- [ ] Choose whether a user may recreate a Demo Team after cleanup.
+- [ ] Confirm the live-request allowance and whether it varies by campaign.
+- [ ] Finalize the Demo feature surface beyond Chat Agent.
+- [ ] Finalize the exact first Product Tour pages and completion event.
+- [ ] Choose the default role and handoff behavior for a technical setup invite.
+- [ ] Define support behavior when GitHub, dbt compilation, the warehouse, Xata,
+  or Anthropic is unavailable.
+
+### Rollout
+
+- [ ] Deploy to the internal environment with production-equivalent secrets and
+  external integrations.
+- [ ] Run internal dogfood with fresh, invited, returning, and multi-Team users.
+- [ ] Review funnel, failure, cleanup, and support telemetry.
+- [ ] Rehearse rollback without orphaning Demo branches or losing setup state.
+- [ ] Release to a small external cohort.
+- [ ] Expand only after acceptance and operational thresholds hold.
+- [ ] Record production evidence and close or re-scope this plan.
+
+### Success measures
+
+- A Demo user reaches the saved replay with one choice and no credentials.
+- A production user reaches a ready Chat Agent project without searching across
+  settings pages.
+- Failed warehouse tests never create a project link.
+- Both Demo and Setup can enter the same Product Tour.
+- A new user completes a useful governed agent run.
+- Demo resources remain isolated and are cleaned up reliably.
+- Funnel and failure telemetry is actionable without collecting sensitive data.
+
+### Phase 3 exit criteria
+
+- [ ] The staged cohort meets the agreed activation and reliability thresholds.
+- [ ] Security, privacy, cleanup, support, and rollback owners approve rollout.
+- [ ] Production evidence distinguishes implemented, tested, staged, and live
+  states.
+
+## Configuration and security contract
+
+Non-secret configuration:
+
+- `SP_DEMO_XATA_ORG`
+- `SP_DEMO_CATALOG`
+
+Deployment secret:
+
+- `XATA_KEY`
+
+The browser receives only catalog-safe identifiers and bootstrap state. It must
+never receive the gateway Xata credential, stored warehouse credentials, or the
+full Team Anthropic key. Demo catalog input is allowlisted server-side rather
+than trusted from request payloads.
+
+## Deferred scope
+
+The following are outside the current Phase 1 deliverable unless explicitly
+promoted by a later product decision:
+
+- Multiple Demo datasets or a user-selectable Demo catalog.
+- Arbitrary Git repositories or Xata parents supplied by the browser.
+- Sharing a personal Demo Team with teammates.
+- Treating a saved replay as proof of live warehouse or model execution.
+- Replacing the existing GitHub, connection, readiness, BYOK, invitation, or
+  Chat Agent authorities with onboarding-specific duplicates.
+- Claiming staging or production readiness from local tests, CI builds, the
+  prototype, or a Vercel preview alone.
+
+## Evidence log
+
+### 2026-09-03 — Product contract and local prototype
+
+- Defined the three-journey onboarding product specification.
+- Built a local shareable clickable prototype for product review.
+- Locked warehouse auto-linking inside Connect Warehouse.
+
+### 2026-09-05 — Phase 1 implementation
+
+- Branch: `feat/onboarding-getting-started-phase-1`
+- Commit: `50369524a14ec98cd926c7960b98c73117a00fd8`
+- Pull request: #338
+- Base at branch creation: `main` at `88f11cf7bc974bfaecca2d86422434027d1d59f2`
+- Local gateway tests: 34 passed.
+- Local targeted frontend tests: 20 passed.
+- Local TypeScript typecheck: passed.
+- Linux/Docker, Windows native web, and macOS arm64 native web builds: passed.
+- Configured-cloud and production acceptance: not yet performed.

--- a/signalpilot/gateway/gateway/api/chat_routes/conversations.py
+++ b/signalpilot/gateway/gateway/api/chat_routes/conversations.py
@@ -62,6 +62,9 @@ async def list_conversations(
 )
 async def create_conversation(body: StandaloneConversationCreate, store: StoreD, role: OrgRole):
     _require_enabled()
+    from gateway.standalone_chat.demo_limits import enforce_demo_request_limit
+
+    await enforce_demo_request_limit(store.session, org_id=store._require_org_id())
     project, readiness = await _readiness_or_error(store, body.project_id)
     if not readiness.ready or not readiness.branch:
         raise HTTPException(

--- a/signalpilot/gateway/gateway/api/chat_routes/projects.py
+++ b/signalpilot/gateway/gateway/api/chat_routes/projects.py
@@ -16,6 +16,7 @@ from gateway.standalone_chat.config import (
     enterprise_chat_feature_flags,
     standalone_chat_enabled,
 )
+from gateway.standalone_chat.demo_limits import demo_request_usage
 from gateway.standalone_chat.projects import (
     authorize_chat_project,
     cached_starter_questions,
@@ -129,6 +130,7 @@ async def bootstrap_chat(store: StoreD, role: OrgRole):
             )
         )
     ).scalar_one_or_none()
+    demo_usage = await demo_request_usage(store.session, org_id=org_id)
     return ChatBootstrapResponse(
         enabled=True,
         projects=[
@@ -162,6 +164,9 @@ async def bootstrap_chat(store: StoreD, role: OrgRole):
         available_efforts=effort_options,
         default_effort=selected_effort,
         enterprise_features=exposed_flags,
+        demo_request_limit=demo_usage[0] if demo_usage else None,
+        demo_requests_used=demo_usage[1] if demo_usage else 0,
+        demo_requests_remaining=max(0, demo_usage[0] - demo_usage[1]) if demo_usage else None,
     )
 
 

--- a/signalpilot/gateway/gateway/api/chat_routes/runs.py
+++ b/signalpilot/gateway/gateway/api/chat_routes/runs.py
@@ -84,6 +84,9 @@ async def create_run(
     role: OrgRole,
 ):
     _require_enabled()
+    from gateway.standalone_chat.demo_limits import enforce_demo_request_limit
+
+    await enforce_demo_request_limit(store.session, org_id=store._require_org_id())
     conversation = (
         await store.session.execute(
             select(GatewayChatConversation).where(
@@ -312,6 +315,9 @@ async def clarify_run(run_id: str, body: StandaloneClarificationCreate, store: S
 )
 async def retry_run(run_id: str, store: StoreD, role: OrgRole):
     _require_enabled()
+    from gateway.standalone_chat.demo_limits import enforce_demo_request_limit
+
+    await enforce_demo_request_limit(store.session, org_id=store._require_org_id())
     failed = (
         await store.session.execute(
             select(GatewayChatRun)

--- a/signalpilot/gateway/gateway/api/connections/crud.py
+++ b/signalpilot/gateway/gateway/api/connections/crud.py
@@ -67,6 +67,12 @@ _XATA_IDENTITY_EXTRAS: tuple[str, ...] = (
 )
 
 
+def _preserve_pinned_system_tags(existing: list[str], proposed: list[str]) -> list[str]:
+    """Let sandbox users add labels without removing policy/ownership markers."""
+    required = [tag for tag in existing if tag == "sp-demo" or tag.startswith("demo:")]
+    return list(dict.fromkeys([*required, *proposed]))
+
+
 @router.get("/connections", dependencies=[RequireScope("read")])
 async def get_connections(store: StoreD):
     return await store.list_connections()
@@ -103,11 +109,24 @@ async def get_connection_detail(name: str, store: StoreD):
 
 @router.delete("/connections/{name}", status_code=204, response_model=None, dependencies=[RequireScope("write")])
 async def remove_connection(name: str, store: StoreD, _role: OrgAdmin, request: Request):
-    # Demo connections own a private Xata branch: capture the cleanup (with the
-    # connection's stored credentials) BEFORE the row is deleted, run it after.
-    from gateway.api.demo import prepare_demo_branch_cleanup
+    # Demo branch cleanup is strict and precedes row deletion so a transient
+    # control-plane failure remains retryable instead of leaking private data.
+    from gateway.api.demo import _delete_demo_branch_strict, prepare_demo_branch_cleanup
 
-    demo_cleanup = await prepare_demo_branch_cleanup(store, name)
+    existing = await store.get_connection(name)
+    if existing and "sp-demo" in (existing.tags or []):
+        try:
+            await _delete_demo_branch_strict(store, name)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="Could not remove private demo data; retry deletion",
+            ) from exc
+        demo_cleanup = None
+    else:
+        demo_cleanup = await prepare_demo_branch_cleanup(store, name)
 
     if not await store.delete_connection(name):
         raise HTTPException(status_code=404, detail=f"Connection '{name}' not found")
@@ -153,6 +172,11 @@ async def edit_connection(name: str, update: ConnectionUpdate, store: StoreD, _r
                     f"{', '.join(moved)} cannot be changed. Remove it and add it again instead."
                 ),
             )
+        if "tags" in update_data:
+            update_data["tags"] = _preserve_pinned_system_tags(
+                existing.tags or [], update_data["tags"]
+            )
+            update = update.model_copy(update={"tags": update_data["tags"]})
 
     if update_data:
         merged_db_type = update_data.get("db_type", existing.db_type)

--- a/signalpilot/gateway/gateway/api/demo.py
+++ b/signalpilot/gateway/gateway/api/demo.py
@@ -22,24 +22,43 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
-from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import func, select
 
 from gateway.api.deps import StoreD
 from gateway.auth import OrgAdmin
 from gateway.common.ip import request_meta
 from gateway.connectors.xata_control import XataControlClient, XataControlConfig, XataControlError
 from gateway.connectors.xata_creds import resolve_xata_extras
+from gateway.db.models import (
+    GatewayChatConversation,
+    GatewayChatMessage,
+    GatewayChatRun,
+    GatewayChatRunEvent,
+    GatewayChatUserPreference,
+    GatewayDbtManifest,
+    GatewayWorkspaceProject,
+)
 from gateway.models import AuditEntry, ConnectionCreate, DBType
 from gateway.security.scope_guard import RequireScope
+from gateway.standalone_chat.demo_policy import DEMO_REQUEST_LIMIT, DEMO_TAG
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
 
-DEMO_TAG = "sp-demo"
 DEMO_CREDENTIAL_REF = "demo"
+DEMO_PROJECT_TAG = "journey:demo-v1"
+DEMO_REPLAY_VERSION = "experiments-v1"
+DEMO_CATALOG_SLUG = "parallax"
+DEMO_REPO = "https://github.com/kiwi0401/parallax-demo"
+DEMO_PARALLAX_PROJECT = "prj_7r8eolv5c15q12os2k0m3lt408"
+# Retained for a later catalog version; it is intentionally not exposed by
+# the v1 bootstrap endpoint because no companion dbt repository is available.
+DEMO_AKASA_PROJECT = "prj_p6e0sj40ld5gj6hppjda7frf20"
 _PROTECTED_BRANCHES = frozenset({"main", "master", "staging", "prod", "production"})
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,30}$")
 
@@ -79,6 +98,25 @@ class DemoConfig:
 
 class DemoConnectorCreate(BaseModel):
     demo: str = Field(..., min_length=1, max_length=32, pattern=r"^[a-z0-9][a-z0-9-]{0,30}$")
+
+
+class DemoBootstrapCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    catalog_slug: str = Field(..., pattern="^parallax$")
+
+
+class DemoBootstrapResponse(BaseModel):
+    status: str
+    phase: str
+    created: bool
+    connection_name: str | None = None
+    project_id: str | None = None
+    conversation_id: str | None = None
+    replay_run_id: str | None = None
+    request_limit: int = DEMO_REQUEST_LIMIT
+    requests_used: int = 0
+    requests_remaining: int = DEMO_REQUEST_LIMIT
 
 
 def _catalog() -> list[Demo]:
@@ -151,6 +189,17 @@ def _control_client(cfg: DemoConfig) -> XataControlClient:
     )
 
 
+def _require_bootstrap_catalog_entry(demo: Demo) -> None:
+    repo_url = (demo.repo_url or "").removesuffix(".git")
+    if (
+        demo.slug != DEMO_CATALOG_SLUG
+        or demo.project != DEMO_PARALLAX_PROJECT
+        or demo.parent_branch != "main"
+        or repo_url != DEMO_REPO
+    ):
+        raise HTTPException(status_code=503, detail="Demo catalog repository is not allowlisted")
+
+
 async def _demo_state(store, cfg: DemoConfig) -> dict[str, dict]:
     """Map demo slug -> {exists, branch, connection_name} for this workspace."""
     by_name = {c.name: c for c in await store.list_connections()}
@@ -191,28 +240,22 @@ async def get_demo_connector(store: StoreD):
     }
 
 
-@router.post("/demo/connector", status_code=201, dependencies=[RequireScope("write")])
-async def create_demo_connector(
-    store: StoreD, _role: OrgAdmin, request: Request, body: DemoConnectorCreate
-):
-    """Fork one demo warehouse into a fresh Xata branch and register it as a
-    connection. Once per warehouse per workspace: 409 if already cloned."""
+async def _ensure_demo_connection(store, request: Request, slug: str):
+    """Create the catalog connection once, returning ``(connection, demo, branch, created)``."""
     cfg = _demo_config()
     if not cfg.enabled:
         raise HTTPException(
             status_code=503,
             detail="Demo connector is not configured (XATA_KEY / SP_DEMO_XATA_ORG / SP_DEMO_CATALOG)",
         )
-    demo = cfg.get(body.demo)
+    demo = cfg.get(slug)
     if demo is None:
-        raise HTTPException(status_code=404, detail=f"Unknown demo warehouse '{body.demo}'")
+        raise HTTPException(status_code=404, detail=f"Unknown demo warehouse '{slug}'")
 
-    if await store.get_connection(demo.connection_name) is not None:
-        raise HTTPException(
-            status_code=409,
-            detail=f"You have already added the '{demo.title}' demo (connection "
-            f"'{demo.connection_name}'). Remove it from the Connections page to start over.",
-        )
+    existing = await store.get_connection(demo.connection_name)
+    if existing is not None:
+        extras = await store.get_credential_extras(existing.name) or {}
+        return existing, demo, str(extras.get("branch") or ""), False
 
     from gateway.governance.plan_limits import check_connection_limit, get_org_limits
 
@@ -281,6 +324,15 @@ async def create_demo_connector(
     except Exception:
         logger.warning("Failed to append audit log for demo_connector_create")
 
+    return info, demo, branch_name, True
+
+
+@router.post("/demo/connector", status_code=201, dependencies=[RequireScope("write")])
+async def create_demo_connector(
+    store: StoreD, _role: OrgAdmin, request: Request, body: DemoConnectorCreate
+):
+    """Idempotently fork one catalog warehouse into a private Xata branch."""
+    info, demo, branch_name, _created = await _ensure_demo_connection(store, request, body.demo)
     return {
         "connection": info,
         "demo": demo.slug,
@@ -288,6 +340,325 @@ async def create_demo_connector(
         "branch": branch_name,
         "repo_url": demo.repo_url or None,
     }
+
+
+async def _demo_project(store, demo: Demo) -> tuple[GatewayWorkspaceProject | None, bool]:
+    _require_bootstrap_catalog_entry(demo)
+    projects = list(
+        (
+            await store.session.execute(
+                select(GatewayWorkspaceProject).where(
+                    GatewayWorkspaceProject.org_id == store._require_org_id(),
+                    GatewayWorkspaceProject.status == "active",
+                )
+            )
+        ).scalars()
+    )
+    existing = next(
+        (p for p in projects if DEMO_PROJECT_TAG in (p.tags or []) and f"demo:{demo.slug}" in (p.tags or [])),
+        None,
+    )
+    if existing:
+        existing.connection_name = demo.connection_name
+        existing.source = "github"
+        existing.git_remote = f"{DEMO_REPO}.git"
+        existing.default_branch = "main"
+        existing.tags = list(
+            dict.fromkeys([*(existing.tags or []), DEMO_TAG, f"demo:{demo.slug}", DEMO_PROJECT_TAG])
+        )
+        await store.session.commit()
+        compiled = await store.session.scalar(
+            select(func.count(GatewayDbtManifest.id)).where(
+                GatewayDbtManifest.org_id == store._require_org_id(),
+                GatewayDbtManifest.project_id == existing.id,
+                GatewayDbtManifest.status == "success",
+            )
+        )
+        if not compiled:
+            await _prepare_demo_project(store, existing)
+        return existing, False
+
+    project = await store.create_workspace_project(
+        name="parallax-demo",
+        display_name="Demo project",
+        description="SignalPilot private demo workspace",
+        source="github",
+        connection_name=demo.connection_name,
+        git_remote=f"{DEMO_REPO}.git",
+        tags=[DEMO_TAG, f"demo:{demo.slug}", DEMO_PROJECT_TAG],
+        settings={"dbt_project_dir": ""},
+    )
+    row = await store.session.get(GatewayWorkspaceProject, project.id)
+    if row is not None:
+        await _prepare_demo_project(store, row)
+    return row, True
+
+
+async def _prepare_demo_project(store, project: GatewayWorkspaceProject) -> None:
+    """Idempotently import the allowlisted repository and request compilation."""
+    try:
+        from gateway.api.github import _import_workspace_revision
+        from gateway.git.repos import clone_from_remote, materialize_local_branches
+
+        clone_from_remote(project.id, f"{DEMO_REPO}.git")
+        materialize_local_branches(project.id, "main")
+        await _import_workspace_revision(
+            store.session,
+            org_id=store._require_org_id(),
+            project_id=project.id,
+            branch="main",
+        )
+        from gateway.dbt_map import schedule_compile
+
+        schedule_compile(store._require_org_id(), project.id, "main", trigger="demo-bootstrap")
+    except Exception:
+        logger.exception("demo bootstrap project preparation failed for %s", project.id)
+
+
+async def _seed_demo_replay(store, project: GatewayWorkspaceProject) -> tuple[str, str]:
+    org_id = store._require_org_id()
+    user_id = store.user_id or "local"
+    existing = list(
+        (
+            await store.session.execute(
+            select(GatewayChatConversation).where(
+                GatewayChatConversation.org_id == org_id,
+                GatewayChatConversation.user_id == user_id,
+                GatewayChatConversation.project_id == project.id,
+                GatewayChatConversation.origin == "demo_replay",
+            ).order_by(GatewayChatConversation.updated_at.desc())
+            )
+        ).scalars()
+    )
+    for conversation_row in existing:
+        run = (
+            await store.session.execute(
+                select(GatewayChatRun)
+                .where(GatewayChatRun.conversation_id == conversation_row.id)
+                .order_by(GatewayChatRun.created_at)
+            )
+        ).scalars().first()
+        if not run:
+            continue
+        marker = await store.session.get(GatewayChatMessage, run.user_message_id)
+        metadata = marker.metadata_json if marker else {}
+        if metadata.get("demo_replay") is True and metadata.get("fixture_version") == DEMO_REPLAY_VERSION:
+            return conversation_row.id, run.id
+
+    now = time.time()
+    conversation = GatewayChatConversation(
+        id=str(uuid.uuid4()), org_id=org_id, user_id=user_id, project_id=project.id,
+        surface="standalone", origin="demo_replay", branch="main", status="active",
+        title="Which experiments drove conversion lift?", message_count=2,
+        total_tokens=0, total_cost_usd=0.0, created_at=now, updated_at=now,
+    )
+    user_message = GatewayChatMessage(
+        id=str(uuid.uuid4()), org_id=org_id, user_id=user_id, project_id=project.id,
+        conversation_id=conversation.id, role="user",
+        content="Identify the experiments with the largest conversion lift and assess whether the results are trustworthy.",
+        metadata_json={"surface": "standalone", "demo_replay": True, "fixture_version": DEMO_REPLAY_VERSION},
+        sequence=1, created_at=now,
+    )
+    run = GatewayChatRun(
+        id=str(uuid.uuid4()), org_id=org_id, user_id=user_id,
+        conversation_id=conversation.id, project_id=project.id,
+        user_message_id=user_message.id, status="completed", runtime_env="demo-replay",
+        started_at=datetime.fromtimestamp(now + 0.2, UTC),
+        terminal_at=datetime.fromtimestamp(now + 8, UTC), last_event_sequence=6,
+    )
+    assistant = GatewayChatMessage(
+        id=str(uuid.uuid4()), org_id=org_id, user_id=user_id, project_id=project.id,
+        conversation_id=conversation.id, role="assistant",
+        content=(
+            "The largest observed lift comes from the checkout and onboarding experiments. "
+            "The checkout result is the most trustworthy because its sample is large and the confidence interval excludes zero; "
+            "the onboarding lift is promising but should be rerun because exposure is uneven across clients."
+        ),
+        metadata_json={"surface": "standalone", "run_id": run.id, "status": "completed"},
+        sequence=2, created_at=now + 8,
+    )
+    event_specs = [
+        ("status", {"status": "running"}, 0.2),
+        ("progress", {"message": "Comparing experiment cohorts"}, 1.0),
+        ("tool_started", {"tool": "query", "tool_call_id": "demo-query", "input": {"purpose": "measure conversion lift"}}, 2.0),
+        ("tool_completed", {"tool": "query", "tool_call_id": "demo-query", "summary": "Experiment cohorts compared"}, 4.0),
+        ("text_delta", {"delta": assistant.content}, 5.0),
+        ("status", {"status": "completed"}, 8.0),
+    ]
+    events = [
+        GatewayChatRunEvent(
+            id=str(uuid.uuid4()), org_id=org_id, user_id=user_id,
+            conversation_id=conversation.id, run_id=run.id, sequence=index,
+            event_type=kind, payload_json=payload,
+            created_at=datetime.fromtimestamp(now + offset, UTC),
+        )
+        for index, (kind, payload, offset) in enumerate(event_specs, start=1)
+    ]
+    store.session.add_all([conversation, user_message, run, assistant, *events])
+    preference = (
+        await store.session.execute(
+            select(GatewayChatUserPreference).where(
+                GatewayChatUserPreference.org_id == org_id,
+                GatewayChatUserPreference.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if preference:
+        preference.default_chat_project_id = project.id
+    else:
+        store.session.add(GatewayChatUserPreference(
+            org_id=org_id, user_id=user_id, default_chat_project_id=project.id
+        ))
+    await store.session.commit()
+    return conversation.id, run.id
+
+
+async def _demo_request_usage(store) -> int:
+    return int(
+        await store.session.scalar(
+            select(func.count(GatewayChatRun.id))
+            .join(GatewayChatConversation, GatewayChatConversation.id == GatewayChatRun.conversation_id)
+            .where(
+                GatewayChatRun.org_id == store._require_org_id(),
+                GatewayChatConversation.origin != "demo_replay",
+            )
+        )
+        or 0
+    )
+
+
+async def _bootstrap_state(store, slug: str, *, created: bool = False) -> DemoBootstrapResponse:
+    cfg = _demo_config()
+    demo = cfg.get(slug)
+    if demo is None:
+        raise HTTPException(status_code=404, detail="Unknown demo catalog")
+    _require_bootstrap_catalog_entry(demo)
+    connection = await store.get_connection(demo.connection_name)
+    projects = list((await store.session.execute(select(GatewayWorkspaceProject).where(
+        GatewayWorkspaceProject.org_id == store._require_org_id(),
+        GatewayWorkspaceProject.status == "active",
+    ))).scalars())
+    project = next((p for p in projects if DEMO_PROJECT_TAG in (p.tags or [])), None)
+    used = await _demo_request_usage(store)
+    base = {
+        "created": created,
+        "connection_name": connection.name if connection else None,
+        "project_id": project.id if project else None,
+        "request_limit": DEMO_REQUEST_LIMIT,
+        "requests_used": used,
+        "requests_remaining": max(0, DEMO_REQUEST_LIMIT - used),
+    }
+    if not connection:
+        return DemoBootstrapResponse(status="provisioning", phase="private_data", **base)
+    if not project:
+        return DemoBootstrapResponse(status="provisioning", phase="project", **base)
+    compiled = await store.session.scalar(select(func.count(GatewayDbtManifest.id)).where(
+        GatewayDbtManifest.org_id == store._require_org_id(),
+        GatewayDbtManifest.project_id == project.id,
+        GatewayDbtManifest.status == "success",
+    ))
+    if not compiled:
+        return DemoBootstrapResponse(status="provisioning", phase="project", **base)
+    conversation_id, run_id = await _seed_demo_replay(store, project)
+    return DemoBootstrapResponse(
+        status="ready", phase="opening", conversation_id=conversation_id,
+        replay_run_id=run_id, **base,
+    )
+
+
+@router.post("/demo/bootstrap", response_model=DemoBootstrapResponse, dependencies=[RequireScope("write")])
+async def bootstrap_demo(
+    body: DemoBootstrapCreate, store: StoreD, _role: OrgAdmin, request: Request, response: Response
+):
+    configured_demo = _demo_config().get(body.catalog_slug)
+    if configured_demo is None:
+        raise HTTPException(status_code=404, detail="Unknown demo catalog")
+    _require_bootstrap_catalog_entry(configured_demo)
+    _info, demo, _branch, connection_created = await _ensure_demo_connection(store, request, body.catalog_slug)
+    _project, project_created = await _demo_project(store, demo)
+    state = await _bootstrap_state(store, body.catalog_slug, created=connection_created or project_created)
+    response.status_code = 200 if state.status == "ready" else 202
+    return state
+
+
+@router.get("/demo/bootstrap", response_model=DemoBootstrapResponse, dependencies=[RequireScope("read")])
+async def get_demo_bootstrap(
+    store: StoreD, response: Response, catalog_slug: str = Query(DEMO_CATALOG_SLUG, pattern="^parallax$")
+):
+    state = await _bootstrap_state(store, catalog_slug)
+    response.status_code = 200 if state.status == "ready" else 202
+    return state
+
+
+@router.get("/demo/replay/{conversation_id}/{run_id}", dependencies=[RequireScope("read")])
+async def authorize_demo_replay(conversation_id: str, run_id: str, store: StoreD):
+    marker = await store.session.scalar(
+        select(GatewayChatMessage.id)
+        .join(GatewayChatRun, GatewayChatRun.user_message_id == GatewayChatMessage.id)
+        .join(GatewayChatConversation, GatewayChatConversation.id == GatewayChatRun.conversation_id)
+        .where(
+            GatewayChatConversation.id == conversation_id,
+            GatewayChatConversation.org_id == store._require_org_id(),
+            GatewayChatConversation.user_id == (store.user_id or "local"),
+            GatewayChatConversation.origin == "demo_replay",
+            GatewayChatRun.id == run_id,
+        )
+    )
+    if marker is None:
+        raise HTTPException(status_code=404, detail="Demo replay not found")
+    message = await store.session.get(GatewayChatMessage, marker)
+    metadata = message.metadata_json if message else {}
+    if not metadata or metadata.get("demo_replay") is not True:
+        raise HTTPException(status_code=404, detail="Demo replay not found")
+    return {"authorized": True, "fixture_version": metadata.get("fixture_version")}
+
+
+async def _delete_demo_branch_strict(store, connection_name: str) -> None:
+    connection = await store.get_connection(connection_name)
+    if connection is None:
+        return
+    extras = await store.get_credential_extras(connection_name) or {}
+    if DEMO_TAG not in (connection.tags or []):
+        return
+    resolved = resolve_xata_extras(extras)
+    branch_name = str(resolved.get("branch") or "")
+    if not branch_name or branch_name.lower() in _PROTECTED_BRANCHES:
+        raise HTTPException(status_code=409, detail="Demo branch identity is invalid; cleanup was aborted")
+    client = XataControlClient(XataControlConfig(
+        api_url=str(resolved.get("xata_api_url") or "https://api.xata.tech"),
+        org=str(resolved.get("xata_organization") or ""),
+        bearer_token=str(resolved.get("xata_api_key") or ""),
+    ))
+    async with client:
+        branches = await client.list_branches(str(resolved.get("xata_project") or ""))
+        branch = next((item for item in branches if item.get("name") == branch_name), None)
+        if branch is not None:
+            await client.delete_branch(str(resolved.get("xata_project") or ""), branch["id"])
+
+
+@router.post("/demo/cleanup", dependencies=[RequireScope("write")])
+async def cleanup_demo_team(store: StoreD, _role: OrgAdmin):
+    """Delete demo-owned project, remote branch, and connection before Clerk org deletion."""
+    connections = await store.list_connections()
+    demo_connections = [connection for connection in connections if DEMO_TAG in (connection.tags or [])]
+    projects = list((await store.session.execute(select(GatewayWorkspaceProject).where(
+        GatewayWorkspaceProject.org_id == store._require_org_id(),
+    ))).scalars())
+    demo_projects = [project for project in projects if DEMO_TAG in (project.tags or [])]
+    if not demo_connections and not demo_projects:
+        return {"demo": False, "cleaned": False}
+    for project in demo_projects:
+        if not await store.delete_workspace_project(project.id):
+            raise HTTPException(status_code=409, detail="Could not remove demo project; retry cleanup")
+    for connection in demo_connections:
+        try:
+            await _delete_demo_branch_strict(store, connection.name)
+        except Exception as exc:
+            logger.warning("demo cleanup aborted before organization deletion: %s", exc)
+            raise HTTPException(status_code=502, detail="Could not remove private demo data; retry cleanup") from exc
+        if not await store.delete_connection(connection.name):
+            raise HTTPException(status_code=409, detail="Could not remove demo connection; retry cleanup")
+    return {"demo": True, "cleaned": True}
 
 
 async def prepare_demo_branch_cleanup(store, name: str) -> Callable[[], Awaitable[None]] | None:

--- a/signalpilot/gateway/gateway/api/deps.py
+++ b/signalpilot/gateway/gateway/api/deps.py
@@ -72,11 +72,11 @@ RequirePlatformStaff = Depends(require_platform_staff)
 
 
 async def require_projects_feature(org_id: OrgID) -> None:
-    """FastAPI dependency: gate the projects/notebooks feature to paid plans.
+    """Gate dbt workspace projects and lineage.
 
     Resolves the org's plan tier and raises 403 if the projects feature is not
-    available (free tier). In local mode the tier resolves to "unlimited", so
-    this is a no-op: local deployments are never gated.
+    available. In local mode the tier resolves to "unlimited", so this is a
+    no-op: local deployments are never gated.
     """
     from ..governance.plan_limits import check_feature, get_org_limits
 
@@ -85,6 +85,17 @@ async def require_projects_feature(org_id: OrgID) -> None:
 
 
 ProjectsGate = Depends(require_projects_feature)
+
+
+async def require_notebook_sessions_feature(org_id: OrgID) -> None:
+    """Gate user-facing notebook storage without affecting Chat's internal runtime."""
+    from ..governance.plan_limits import check_feature, get_org_limits
+
+    limits = await get_org_limits(org_id)
+    check_feature("notebook_sessions", limits)
+
+
+NotebookSessionsGate = Depends(require_notebook_sessions_feature)
 
 # Error sanitization.
 

--- a/signalpilot/gateway/gateway/api/keys.py
+++ b/signalpilot/gateway/gateway/api/keys.py
@@ -110,5 +110,7 @@ async def get_plan_usage(_user: UserID, org_id: OrgID, store: StoreD):
             "sso": plan.sso,
             "budget_controls": plan.budget_controls,
             "audit_export": plan.audit_export,
+            "projects": plan.projects,
+            "notebook_sessions": plan.notebook_sessions,
         },
     }

--- a/signalpilot/gateway/gateway/api/notebook_files.py
+++ b/signalpilot/gateway/gateway/api/notebook_files.py
@@ -26,14 +26,14 @@ import posixpath
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from ..auth import DBSession, OrgID, UserID
 from ..security.scope_guard import RequireScope
 from ..workspace_store import WorkspaceStore
 from ..workspace_store.store import RevisionNotFound, Upsert
-from .deps import ProjectsGate, StoreD
+from .deps import NotebookSessionsGate, StoreD
 from .workspace_files import (
     WorkspaceStoreD,
     _confined,
@@ -41,7 +41,7 @@ from .workspace_files import (
     _valid_branch,
 )
 
-router = APIRouter(prefix="/api", dependencies=[ProjectsGate])
+router = APIRouter(prefix="/api", dependencies=[NotebookSessionsGate])
 
 NOTEBOOK_EXTENSIONS = {".py", ".md", ".qmd"}
 IGNORE_NAMES = {"__pycache__", ".git", "node_modules", ".venv", "target"}

--- a/signalpilot/gateway/gateway/api/notebook_sessions.py
+++ b/signalpilot/gateway/gateway/api/notebook_sessions.py
@@ -11,14 +11,14 @@ from ..notebook_proxy.constants import SESSION_ID_PATTERN_STR
 from ..notebooks import session_service
 from ..runtime.mode import is_cloud_mode
 from ..security.scope_guard import RequireScope
-from .deps import ProjectsGate, StoreD
+from .deps import NotebookSessionsGate, StoreD
 
 # Single source of truth for session_id charset validation (shared with proxy auth).
 _SESSION_ID_PATTERN = re.compile(SESSION_ID_PATTERN_STR)
 
-# Notebook sessions are part of the paid "projects" feature. In local mode the
-# tier resolves to "unlimited", so the gate is a no-op.
-router = APIRouter(prefix="/api/notebook-sessions", dependencies=[ProjectsGate])
+# User-facing notebook compute is paid. Chat's governed internal runtime does
+# not call these routes and remains available independently.
+router = APIRouter(prefix="/api/notebook-sessions", dependencies=[NotebookSessionsGate])
 
 
 @router.post("", status_code=201, response_model=NotebookSessionInfo, dependencies=[RequireScope("write")])
@@ -65,8 +65,7 @@ async def get_session_by_id(session_id: str, store: StoreD):
     Returns 404 on missing, cross-org, OR cross-user (same-org peers cannot
     read each other's sessions: sharing is a future feature).
     """
-    session = await _owned_session_or_404(session_id, store)
-    return session
+    return await _owned_session_or_404(session_id, store)
 
 
 @router.delete("", status_code=204, response_model=None, dependencies=[RequireScope("write")])

--- a/signalpilot/gateway/gateway/api/workspace_projects.py
+++ b/signalpilot/gateway/gateway/api/workspace_projects.py
@@ -23,8 +23,8 @@ from .workspace_files import WorkspaceStoreD, _valid_branch
 
 logger = logging.getLogger(__name__)
 
-# All workspace-project routes require the paid "projects" feature.
-# In local mode the tier resolves to "unlimited", so the gate is a no-op.
+# Workspace projects and lineage are available on every current plan.
+# The gate remains the centralized entitlement boundary for future tiers.
 router = APIRouter(prefix="/api", dependencies=[ProjectsGate])
 
 
@@ -176,6 +176,14 @@ async def update_project(project_id: str, body: WorkspaceProjectUpdate, store: S
     updates = body.model_dump(exclude_none=True)
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
+    existing = await _get_project_or_404(store, project_id)
+    if "sp-demo" in (existing.tags or []) and "tags" in updates:
+        required = [
+            tag
+            for tag in (existing.tags or [])
+            if tag == "sp-demo" or tag.startswith(("demo:", "journey:demo-"))
+        ]
+        updates["tags"] = list(dict.fromkeys([*required, *updates["tags"]]))
     proj = await store.update_workspace_project(project_id, updates)
     if not proj:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/signalpilot/gateway/gateway/governance/plan_limits.py
+++ b/signalpilot/gateway/gateway/governance/plan_limits.py
@@ -44,14 +44,15 @@ class PlanLimits:
     schema_tools: bool  # advanced schema explorer MCP tools
     knowledge_storage_mb: int  # per-org knowledge storage cap in MiB (0 = unlimited)
     knowledge_history_versions: int  # edit history versions kept per doc (0 = unlimited)
-    projects: bool  # workspace projects + notebook sessions (paid feature)
+    projects: bool  # dbt workspace projects and lineage
+    notebook_sessions: bool  # user-facing notebook sessions
 
 
 PLAN_TIERS: dict[str, PlanLimits] = {
     "free": PlanLimits(
         tier="free",
         connections=2,
-        users=1,
+        users=2,
         api_keys=1,
         queries_per_day=200,
         audit_retention_days=7,
@@ -63,7 +64,8 @@ PLAN_TIERS: dict[str, PlanLimits] = {
         schema_tools=True,
         knowledge_storage_mb=50,
         knowledge_history_versions=5,
-        projects=False,
+        projects=True,
+        notebook_sessions=False,
     ),
     "pro": PlanLimits(
         tier="pro",
@@ -81,6 +83,7 @@ PLAN_TIERS: dict[str, PlanLimits] = {
         knowledge_storage_mb=250,
         knowledge_history_versions=5,
         projects=True,
+        notebook_sessions=True,
     ),
     "team": PlanLimits(
         tier="team",
@@ -98,6 +101,7 @@ PLAN_TIERS: dict[str, PlanLimits] = {
         knowledge_storage_mb=1000,
         knowledge_history_versions=25,
         projects=True,
+        notebook_sessions=True,
     ),
     "enterprise": PlanLimits(
         tier="enterprise",
@@ -115,6 +119,7 @@ PLAN_TIERS: dict[str, PlanLimits] = {
         knowledge_storage_mb=5000,
         knowledge_history_versions=50,
         projects=True,
+        notebook_sessions=True,
     ),
     "unlimited": PlanLimits(
         tier="unlimited",
@@ -132,6 +137,7 @@ PLAN_TIERS: dict[str, PlanLimits] = {
         knowledge_storage_mb=0,
         knowledge_history_versions=100,
         projects=True,
+        notebook_sessions=True,
     ),
 }
 
@@ -349,6 +355,7 @@ def check_feature(feature_name: str, limits: PlanLimits) -> None:
         "budget_controls": limits.budget_controls,
         "audit_export": limits.audit_export,
         "projects": limits.projects,
+        "notebook_sessions": limits.notebook_sessions,
     }
     enabled = feature_map.get(feature_name)
     if enabled is None:

--- a/signalpilot/gateway/gateway/main.py
+++ b/signalpilot/gateway/gateway/main.py
@@ -41,6 +41,7 @@ from .http import (
 from .http.log_redaction import install_uvicorn_secret_path_filter, redact_secret_path
 from .models import ConnectionUpdate
 from .runtime.mode import is_cloud_mode
+from .standalone_chat.demo_limits import DemoRequestLimitError
 from .store import Store, configure_byok
 from .store.crypto import _validate_encryption_health
 
@@ -663,6 +664,14 @@ app.add_middleware(
 )
 
 # Global exception handler.
+
+
+@app.exception_handler(DemoRequestLimitError)
+async def _demo_request_limit_handler(
+    _request: Request, exc: DemoRequestLimitError
+) -> JSONResponse:
+    """Keep the documented demo-limit payload at the response top level."""
+    return JSONResponse(status_code=exc.status_code, content=exc.detail)
 
 
 @app.exception_handler(Exception)

--- a/signalpilot/gateway/gateway/models/standalone_chat.py
+++ b/signalpilot/gateway/gateway/models/standalone_chat.py
@@ -86,6 +86,9 @@ class ChatBootstrapResponse(BaseModel):
     available_efforts: list[dict[str, str]] = Field(default_factory=list)
     default_effort: str = "medium"
     enterprise_features: dict[str, bool] = Field(default_factory=dict)
+    demo_request_limit: int | None = None
+    demo_requests_used: int = 0
+    demo_requests_remaining: int | None = None
 
 
 class StandaloneConversationCreate(StrictChatRequest):

--- a/signalpilot/gateway/gateway/standalone_chat/demo_limits.py
+++ b/signalpilot/gateway/gateway/standalone_chat/demo_limits.py
@@ -1,0 +1,56 @@
+"""Atomic live-request allowance for personal demo workspaces."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.db.models import GatewayChatConversation, GatewayChatRun, GatewayConnection
+from gateway.standalone_chat.demo_policy import DEMO_REQUEST_LIMIT, DEMO_TAG
+
+
+class DemoRequestLimitError(HTTPException):
+    def __init__(self, *, limit: int, used: int) -> None:
+        super().__init__(
+            status_code=429,
+            detail={"code": "demo_request_limit", "limit": limit, "used": used},
+        )
+
+
+async def demo_request_usage(
+    db: AsyncSession, *, org_id: str, lock: bool = False
+) -> tuple[int, int] | None:
+    """Return the demo allowance and usage, optionally locking its marker row."""
+    statement = select(GatewayConnection).where(GatewayConnection.org_id == org_id)
+    if lock:
+        statement = statement.with_for_update()
+    connections = list(
+        (await db.execute(statement)).scalars()
+    )
+    demo_connection = next((row for row in connections if DEMO_TAG in (row.tags or [])), None)
+    if demo_connection is None:
+        return None
+
+    used = int(
+        await db.scalar(
+            select(func.count(GatewayChatRun.id))
+            .join(GatewayChatConversation, GatewayChatConversation.id == GatewayChatRun.conversation_id)
+            .where(
+                GatewayChatRun.org_id == org_id,
+                GatewayChatConversation.origin != "demo_replay",
+            )
+        )
+        or 0
+    )
+    return DEMO_REQUEST_LIMIT, used
+
+
+async def enforce_demo_request_limit(db: AsyncSession, *, org_id: str) -> None:
+    """Lock the demo marker before counting so concurrent tabs cannot admit request six."""
+    usage = await demo_request_usage(db, org_id=org_id, lock=True)
+    if usage is None:
+        return
+    limit, used = usage
+    if used >= limit:
+        raise DemoRequestLimitError(limit=limit, used=used)

--- a/signalpilot/gateway/gateway/standalone_chat/demo_policy.py
+++ b/signalpilot/gateway/gateway/standalone_chat/demo_policy.py
@@ -1,0 +1,4 @@
+"""Shared policy constants for the first-run Demo Team."""
+
+DEMO_TAG = "sp-demo"
+DEMO_REQUEST_LIMIT = 5

--- a/signalpilot/gateway/tests/test_demo_connector_isolation.py
+++ b/signalpilot/gateway/tests/test_demo_connector_isolation.py
@@ -298,6 +298,14 @@ def test_pinned_edits_are_restricted_to_cosmetic_fields():
     assert "tags" in _PINNED_EDITABLE_FIELDS
 
 
+def test_demo_policy_tags_survive_cosmetic_tag_edits():
+    from gateway.api.connections.crud import _preserve_pinned_system_tags
+
+    assert _preserve_pinned_system_tags(
+        ["sp-demo", "demo:parallax", "old-label"], ["new-label"]
+    ) == ["sp-demo", "demo:parallax", "new-label"]
+
+
 def test_xata_identity_is_carried_into_edit_revalidation():
     """Xata identity lives in extras, not on ConnectionInfo. If an edit does not
     fold it back in, revalidating the merged record fails ('require region and

--- a/signalpilot/gateway/tests/test_getting_started_policy.py
+++ b/signalpilot/gateway/tests/test_getting_started_policy.py
@@ -1,0 +1,223 @@
+"""Focused policy contracts for Getting Started and Demo Teams."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.api.demo import (
+    Demo,
+    DemoBootstrapCreate,
+    DemoBootstrapResponse,
+    _require_bootstrap_catalog_entry,
+    _seed_demo_replay,
+    authorize_demo_replay,
+    cleanup_demo_team,
+)
+from gateway.db.models import (
+    GatewayBase,
+    GatewayChatMessage,
+    GatewayChatRunEvent,
+    GatewayConnection,
+    GatewayWorkspaceProject,
+)
+from gateway.governance.plan_limits import PLAN_TIERS, check_feature
+from gateway.standalone_chat.demo_limits import demo_request_usage, enforce_demo_request_limit
+from gateway.store import standalone_chat as chat_store
+from gateway.store.store import Store
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(GatewayBase.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+def test_free_tier_splits_projects_from_notebook_sessions() -> None:
+    free = PLAN_TIERS["free"]
+    assert free.projects is True
+    assert free.notebook_sessions is False
+    assert free.users == 2
+    check_feature("projects", free)
+    with pytest.raises(HTTPException) as exc:
+        check_feature("notebook_sessions", free)
+    assert exc.value.status_code == 403
+
+
+def test_demo_bootstrap_only_accepts_the_allowlisted_catalog_slug() -> None:
+    assert DemoBootstrapCreate(catalog_slug="parallax").catalog_slug == "parallax"
+    with pytest.raises(ValueError):
+        DemoBootstrapCreate(catalog_slug="anything-else")
+    with pytest.raises(ValueError):
+        DemoBootstrapCreate.model_validate({"catalog_slug": "parallax", "repo_url": "https://example.com"})
+
+
+def test_bootstrap_catalog_pins_the_xata_project_and_public_repository() -> None:
+    _require_bootstrap_catalog_entry(Demo(
+        slug="parallax",
+        project="prj_7r8eolv5c15q12os2k0m3lt408",
+        title="Parallax",
+        repo_url="https://github.com/kiwi0401/parallax-demo",
+    ))
+    with pytest.raises(HTTPException):
+        _require_bootstrap_catalog_entry(Demo(
+            slug="parallax",
+            project="prj_untrusted",
+            title="Parallax",
+            repo_url="https://github.com/kiwi0401/parallax-demo",
+        ))
+
+
+def test_demo_bootstrap_response_never_has_credentials() -> None:
+    payload = DemoBootstrapResponse(status="ready", phase="opening", created=False).model_dump()
+    assert "xata_key" not in payload
+    assert "credentials" not in payload
+
+
+@pytest.mark.asyncio
+async def test_demo_limit_counts_runs_but_not_seeded_replay(db_session: AsyncSession) -> None:
+    project = GatewayWorkspaceProject(
+        id="project-demo",
+        org_id="org-demo",
+        name="parallax-demo",
+        display_name="Demo project",
+        description="",
+        connection_name="parallax-demo",
+        source="github",
+        status="active",
+        settings={},
+        tags=["sp-demo", "journey:demo-v1"],
+        file_count=1,
+        total_bytes=1,
+        default_branch="main",
+        created_at=1.0,
+        updated_at=1.0,
+    )
+    db_session.add_all([
+        project,
+        GatewayConnection(
+            org_id="org-demo",
+            user_id="user-demo",
+            name="parallax-demo",
+            db_type="xata",
+            status="connected",
+            created_at=1.0,
+            description="",
+            tags=["sp-demo", "demo:parallax"],
+            schema_filter_include=[],
+            schema_filter_exclude=[],
+        ),
+    ])
+    await db_session.commit()
+
+    replay, _ = await chat_store.create_conversation_with_run(
+        db_session,
+        org_id="org-demo",
+        user_id="user-demo",
+        project=project,
+        branch="main",
+        message="seed",
+        commit_sha="a" * 40,
+        origin="demo_replay",
+    )
+    assert replay.origin == "demo_replay"
+    for index in range(5):
+        await chat_store.create_conversation_with_run(
+            db_session,
+            org_id="org-demo",
+            user_id="user-demo",
+            project=project,
+            branch="main",
+            message=f"live request {index}",
+            commit_sha="b" * 40,
+        )
+
+    assert await demo_request_usage(db_session, org_id="org-demo") == (5, 5)
+    with pytest.raises(HTTPException) as exc:
+        await enforce_demo_request_limit(db_session, org_id="org-demo")
+    assert exc.value.status_code == 429
+    assert exc.value.detail == {"code": "demo_request_limit", "limit": 5, "used": 5}
+
+
+@pytest.mark.asyncio
+async def test_non_demo_teams_have_no_demo_allowance(db_session: AsyncSession) -> None:
+    assert await demo_request_usage(db_session, org_id="org-production") is None
+    await enforce_demo_request_limit(db_session, org_id="org-production")
+
+
+@pytest.mark.asyncio
+async def test_seeded_replay_is_versioned_idempotent_and_authorized(db_session: AsyncSession) -> None:
+    project = GatewayWorkspaceProject(
+        id="project-replay",
+        org_id="org-demo",
+        name="parallax-demo",
+        display_name="Demo project",
+        description="",
+        source="github",
+        status="active",
+        settings={},
+        tags=["sp-demo"],
+        file_count=1,
+        total_bytes=1,
+        default_branch="main",
+        created_at=1.0,
+        updated_at=1.0,
+    )
+    db_session.add(project)
+    await db_session.commit()
+    store = Store(db_session, org_id="org-demo", user_id="user-demo")
+
+    first = await _seed_demo_replay(store, project)
+    assert await _seed_demo_replay(store, project) == first
+    marker = (
+        await db_session.execute(
+            select(GatewayChatMessage).where(GatewayChatMessage.content.like("Identify the experiments%"))
+        )
+    ).scalar_one()
+    assert marker.metadata_json == {
+        "surface": "standalone",
+        "demo_replay": True,
+        "fixture_version": "experiments-v1",
+    }
+    events = list((await db_session.execute(select(GatewayChatRunEvent).order_by(GatewayChatRunEvent.sequence))).scalars())
+    assert next(event for event in events if event.event_type == "text_delta").payload_json["delta"]
+    assert await authorize_demo_replay(first[0], first[1], store) == {
+        "authorized": True,
+        "fixture_version": "experiments-v1",
+    }
+    with pytest.raises(HTTPException) as exc:
+        await authorize_demo_replay(first[0], "wrong-run", store)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_demo_team_cleanup_orders_project_branch_then_connection(monkeypatch) -> None:
+    calls: list[str] = []
+    connection = SimpleNamespace(name="parallax-demo", tags=["sp-demo"])
+    project = SimpleNamespace(id="project-demo", tags=["sp-demo"])
+    result = SimpleNamespace(scalars=lambda: [project])
+    store = SimpleNamespace(
+        list_connections=AsyncMock(return_value=[connection]),
+        session=SimpleNamespace(execute=AsyncMock(return_value=result)),
+        _require_org_id=lambda: "org-demo",
+        delete_workspace_project=AsyncMock(side_effect=lambda _id: calls.append("project") or True),
+        delete_connection=AsyncMock(side_effect=lambda _name: calls.append("connection") or True),
+    )
+
+    async def delete_branch(_store, _name):
+        calls.append("branch")
+
+    monkeypatch.setattr("gateway.api.demo._delete_demo_branch_strict", delete_branch)
+    assert await cleanup_demo_team(store, None) == {"demo": True, "cleaned": True}
+    assert calls == ["project", "branch", "connection"]

--- a/signalpilot/web/app/integrations/page.tsx
+++ b/signalpilot/web/app/integrations/page.tsx
@@ -17,7 +17,6 @@ import { useAppAuth } from "~/lib/auth-context";
 import {
   deleteNotionOAuthInstallation,
   deleteSlackOAuthInstallation,
-  getOrgSecrets,
   getWorkspaceProjects,
   getNotionOAuthInstallations,
   getSlackOAuthInstallations,
@@ -25,9 +24,7 @@ import {
   provisionSlackOAuthInstallation,
   startNotionOAuth,
   startSlackOAuth,
-  updateOrgSecrets,
   type NotionOAuthInstallation,
-  type OrgSecretsResponse,
   type SlackOAuthInstallation,
 } from "~/lib/api";
 import type { WorkspaceProjectInfo } from "~/lib/types";
@@ -36,13 +33,9 @@ import { StatusDot } from "~/components/ui/data-viz";
 import { SectionHeader } from "~/components/ui/section-header";
 import { useToast } from "~/components/ui/toast";
 import { ApiKeysSkeleton } from "~/components/ui/skeleton";
-import { NotebooksProjectsPaywall } from "~/components/billing/notebooks-projects-paywall";
 import { NotionIcon } from "~/components/branding/notion-icon";
 import { ThemeEditor } from "~/components/integrations/theme-editor";
-import { useSubscription } from "~/lib/subscription-context";
-
-const IS_CLOUD_MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE === "cloud";
-const PAID_TIERS = ["pro", "team", "enterprise", "unlimited"];
+import { AnthropicKeyForm } from "~/components/integrations/anthropic-key-form";
 
 function oauthStatus(installation: NotionOAuthInstallation): { label: string; tone: "healthy" | "warning" | "error" | "unknown" } {
   if (installation.status === "disconnected") return { label: "disconnected", tone: "error" };
@@ -76,20 +69,9 @@ function projectLabel(project: WorkspaceProjectInfo): string {
   return project.display_name || project.name || project.id;
 }
 
-function formatUpdatedAt(value: number | null): string {
-  if (!value) return "-";
-  return new Date(value * 1000).toLocaleString();
-}
-
 export default function IntegrationsPage() {
   const { isLoaded } = useAppAuth();
-  const { planTier, isLoaded: subLoaded } = useSubscription();
-
-  const isPaid = PAID_TIERS.includes(planTier);
-  const gated = IS_CLOUD_MODE && subLoaded && !isPaid;
-
-  if (!isLoaded || (IS_CLOUD_MODE && !subLoaded)) return <ApiKeysSkeleton />;
-  if (gated) return <NotebooksProjectsPaywall />;
+  if (!isLoaded) return <ApiKeysSkeleton />;
   return <IntegrationsContent />;
 }
 
@@ -109,28 +91,6 @@ function IntegrationsContent() {
   const [provisioningSlackId, setProvisioningSlackId] = useState<string | null>(null);
   const [deletingOauthId, setDeletingOauthId] = useState<string | null>(null);
   const [deletingSlackId, setDeletingSlackId] = useState<string | null>(null);
-  const [orgSecrets, setOrgSecrets] = useState<OrgSecretsResponse | null>(null);
-  const [orgSecretsLoading, setOrgSecretsLoading] = useState(true);
-  const [orgSecretsLoadError, setOrgSecretsLoadError] = useState(false);
-  const [orgSecretsReadOnly, setOrgSecretsReadOnly] = useState(false);
-  const [anthropicKey, setAnthropicKey] = useState("");
-  const [savingAnthropicKey, setSavingAnthropicKey] = useState(false);
-  const [confirmRemoveAnthropicKey, setConfirmRemoveAnthropicKey] = useState(false);
-
-  const fetchOrgSecrets = useCallback(async () => {
-    setOrgSecretsLoading(true);
-    try {
-      const secrets = await getOrgSecrets();
-      setOrgSecrets(secrets);
-      setOrgSecretsLoadError(false);
-    } catch {
-      setOrgSecrets(null);
-      setOrgSecretsLoadError(true);
-    } finally {
-      setOrgSecretsLoading(false);
-    }
-  }, []);
-
   const fetchIntegrations = useCallback(async () => {
     try {
       const [installations, slackInstalls, projectResult] = await Promise.all([
@@ -181,7 +141,6 @@ function IntegrationsContent() {
   }, [toast]);
 
   useEffect(() => { fetchIntegrations(); }, [fetchIntegrations]);
-  useEffect(() => { fetchOrgSecrets(); }, [fetchOrgSecrets]);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -372,49 +331,6 @@ function IntegrationsContent() {
       await fetchIntegrations();
     } catch (e) {
       toast(`failed: ${e}`, "error");
-    }
-  }
-
-  async function handleSaveAnthropicKey() {
-    const key = anthropicKey.trim();
-    if (!key || savingAnthropicKey) return;
-    setSavingAnthropicKey(true);
-    try {
-      const updated = await updateOrgSecrets({ anthropic_api_key: key });
-      setOrgSecrets(updated);
-      setAnthropicKey("");
-      setOrgSecretsReadOnly(false);
-      setOrgSecretsLoadError(false);
-      toast(orgSecrets?.has_key ? "anthropic key rotated" : "anthropic key saved", "success");
-    } catch (e) {
-      if (String(e).includes("403:")) {
-        setOrgSecretsReadOnly(true);
-        toast("you do not have permission to update org secrets", "error");
-      } else {
-        toast(`failed to save key: ${e}`, "error");
-      }
-    } finally {
-      setSavingAnthropicKey(false);
-    }
-  }
-
-  async function handleRemoveAnthropicKey() {
-    setSavingAnthropicKey(true);
-    try {
-      const updated = await updateOrgSecrets({ anthropic_api_key: null });
-      setOrgSecrets(updated);
-      setConfirmRemoveAnthropicKey(false);
-      setOrgSecretsReadOnly(false);
-      toast("anthropic key removed", "success");
-    } catch (e) {
-      if (String(e).includes("403:")) {
-        setOrgSecretsReadOnly(true);
-        toast("you do not have permission to update org secrets", "error");
-      } else {
-        toast(`failed to remove key: ${e}`, "error");
-      }
-    } finally {
-      setSavingAnthropicKey(false);
     }
   }
 
@@ -797,127 +713,9 @@ function IntegrationsContent() {
       </section>
 
       <section className="mb-8">
-        <div className="flex items-center justify-between mb-4">
-          <SectionHeader icon={KeyRound} title="anthropic api key" />
-        </div>
-
-        <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] p-5">
-          {orgSecretsLoading ? (
-            <div className="flex items-center gap-2 text-[12px] text-[var(--color-text-dim)] tracking-wider">
-              <Loader2 className="w-3 h-3 animate-spin" />
-              checking key
-            </div>
-          ) : orgSecretsLoadError ? (
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-center gap-2">
-                <StatusDot status="error" size={4} />
-                <span className="text-[12px] text-[var(--color-text-dim)] tracking-wider">
-                  failed to load
-                </span>
-              </div>
-              <button
-                onClick={fetchOrgSecrets}
-                className="px-4 py-2 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-all tracking-wider uppercase"
-              >
-                retry
-              </button>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <StatusDot status={orgSecrets?.has_key ? "healthy" : "warning"} size={4} />
-                    <span className="text-[13px] text-[var(--color-text)] tracking-wider font-medium">
-                      {orgSecrets?.has_key ? "key set" : "no key"}
-                    </span>
-                  </div>
-                  <div className="space-y-1 text-[11px] text-[var(--color-text-dim)] tracking-wider">
-                    {orgSecrets?.key_preview && (
-                      <p>
-                        preview: <span className="text-[var(--color-text-muted)] font-mono">{orgSecrets.key_preview}</span>
-                      </p>
-                    )}
-                    <p>
-                      updated: <span className="text-[var(--color-text-muted)]">{formatUpdatedAt(orgSecrets?.updated_at ?? null)}</span>
-                    </p>
-                    {orgSecretsReadOnly && (
-                      <p className="text-[var(--color-warning)]">
-                        read-only: write permission required
-                      </p>
-                    )}
-                  </div>
-                </div>
-                {orgSecrets?.has_key && (
-                  <div className="flex items-center gap-1.5">
-                    {confirmRemoveAnthropicKey ? (
-                      <>
-                        <button
-                          onClick={handleRemoveAnthropicKey}
-                          disabled={savingAnthropicKey || orgSecretsReadOnly}
-                          className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-error)] border border-[var(--color-error)]/30 hover:border-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
-                        >
-                          {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
-                          confirm
-                        </button>
-                        <button
-                          onClick={() => setConfirmRemoveAnthropicKey(false)}
-                          className="p-1.5 text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"
-                        >
-                          <X className="w-3 h-3" />
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        onClick={() => setConfirmRemoveAnthropicKey(true)}
-                        disabled={orgSecretsReadOnly}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] hover:border-[var(--color-error)]/50 hover:text-[var(--color-error)] transition-all tracking-wider uppercase disabled:opacity-30"
-                      >
-                        <Trash2 className="w-3 h-3" />
-                        remove
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              <div className="border-t border-[var(--color-border)] pt-4">
-                <label htmlFor="anthropic-api-key" className="sr-only">Anthropic API key</label>
-                <p className="mb-3 text-[12px] leading-5 text-[var(--color-text-dim)] tracking-wider">
-                  Set your{" "}
-                  <a
-                    href="https://platform.claude.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-[var(--color-text)] underline decoration-[var(--color-border-hover)] underline-offset-4 hover:decoration-[var(--color-text)]"
-                  >
-                    Anthropic API key
-                  </a>{" "}
-                  to enable SignalPilot Agents
-                </p>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <input
-                    id="anthropic-api-key"
-                    type="password"
-                    value={anthropicKey}
-                    onChange={(event) => setAnthropicKey(event.target.value)}
-                    onKeyDown={(event) => { if (event.key === "Enter") void handleSaveAnthropicKey(); }}
-                    disabled={savingAnthropicKey || orgSecretsReadOnly}
-                    placeholder="sk-ant-..."
-                    className="min-w-0 flex-1 px-3 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] text-xs font-mono focus:outline-none disabled:opacity-40"
-                  />
-                  <button
-                    onClick={handleSaveAnthropicKey}
-                    disabled={!anthropicKey.trim() || savingAnthropicKey || orgSecretsReadOnly}
-                    className="flex items-center justify-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-[12px] tracking-wider uppercase transition-all hover:opacity-90 disabled:opacity-30"
-                  >
-                    {savingAnthropicKey ? <Loader2 className="w-3 h-3 animate-spin" /> : <KeyRound className="w-3 h-3" />}
-                    {orgSecrets?.has_key ? "rotate" : "save"}
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
+        <div className="mb-4"><SectionHeader icon={KeyRound} title="anthropic api key" /></div>
+        <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)]">
+          <AnthropicKeyForm />
         </div>
       </section>
 

--- a/signalpilot/web/app/knowledge/page.tsx
+++ b/signalpilot/web/app/knowledge/page.tsx
@@ -291,7 +291,7 @@ function KnowledgePage() {
   const list = baseSet.filter(passFilters).sort(sortDocs);
 
   return (
-    <div className="kb-root h-screen flex flex-col p-8 overflow-hidden animate-fade-in">
+    <div data-tour-id="knowledge-area" className="kb-root h-screen flex flex-col p-8 overflow-hidden animate-fade-in">
       {/* Header */}
       <div className="kb-header">
         <div className="kb-logo">

--- a/signalpilot/web/app/layout.tsx
+++ b/signalpilot/web/app/layout.tsx
@@ -27,6 +27,7 @@ import { SWRProvider } from "~/lib/swr";
 import { SubscriptionProvider } from "~/lib/subscription-context";
 import { clerkAppearance } from "~/lib/clerk-theme";
 import TierUpgradeCelebration from "~/components/branding/tier-upgrade-celebration";
+import { GettingStartedMount } from "~/components/getting-started/getting-started-mount";
 
 export const metadata: Metadata = {
   title: "SignalPilot",
@@ -67,6 +68,7 @@ export default async function RootLayout({
               <CommandPalette />
             </MainContent>
             <TierUpgradeCelebration />
+            <GettingStartedMount />
           </SubscriptionProvider>
         </AuthProvider>
       </ConnectionProvider>

--- a/signalpilot/web/app/onboarding/onboarding-cloud.tsx
+++ b/signalpilot/web/app/onboarding/onboarding-cloud.tsx
@@ -15,6 +15,8 @@ import {
   CheckCircle2,
   AlertTriangle,
   Plug,
+  Compass,
+  Database,
 } from "lucide-react";
 import { DashboardSkeleton } from "~/components/ui/skeleton";
 import { useUser, useOrganization, useOrganizationList } from "@clerk/nextjs";
@@ -27,6 +29,7 @@ import { CopyButton } from "~/components/ui/copy-button";
 import { CodeBlock } from "~/components/ui/code-block";
 import { useToast } from "~/components/ui/toast";
 import { TeamStep } from "./team-step";
+import { GETTING_STARTED_EVENT, normalizeGettingStarted } from "~/lib/getting-started";
 
 // ---------------------------------------------------------------------------
 // Re-export the step sub-components that the main page used to define inline.
@@ -585,6 +588,68 @@ function OnboardingWizard({
 // ---------------------------------------------------------------------------
 
 export function CloudOnboardingContent() {
+  const router = useRouter();
+  const { user, isLoaded } = useUser();
+  const { organization, isLoaded: orgLoaded } = useOrganization();
+
+  useEffect(() => {
+    if (isLoaded && !user) router.push("/sign-in");
+  }, [isLoaded, router, user]);
+
+  useEffect(() => {
+    if (!isLoaded || !orgLoaded || !user) return;
+    if (user.unsafeMetadata.onboardingCompleted === true && organization) {
+      router.replace("/dashboard");
+    }
+  }, [isLoaded, orgLoaded, organization, router, user]);
+
+  function launch(journey: "demo" | "setup") {
+    window.dispatchEvent(new CustomEvent(GETTING_STARTED_EVENT, { detail: { journey, expanded: true } }));
+  }
+
+  async function skip() {
+    if (!user) return;
+    await user.update({
+      unsafeMetadata: {
+        ...user.unsafeMetadata,
+        onboardingCompleted: true,
+        signalpilotGettingStarted: normalizeGettingStarted(
+          user.unsafeMetadata.signalpilotGettingStarted,
+        ),
+      },
+    });
+    router.push("/dashboard");
+  }
+
+  if (!isLoaded || !orgLoaded || !user) return <DashboardSkeleton />;
+  return (
+    <div className="flex min-h-screen items-center justify-center px-10 py-16">
+      <div className="w-full max-w-5xl">
+        <p className="text-[11px] uppercase tracking-[0.16em] text-[var(--color-success)]">SignalPilot</p>
+        <h1 className="mt-3 max-w-2xl text-4xl font-semibold tracking-tight text-[var(--color-text)]">Turn governed data into trusted answers.</h1>
+        <p className="mt-4 max-w-xl text-sm leading-6 text-[var(--color-text-dim)]">Start with a private interactive demo, or connect your Team&apos;s dbt project and warehouse.</p>
+        <div className="mt-10 grid grid-cols-2 gap-5">
+          <button type="button" onClick={() => launch("demo")} className="group border border-[var(--color-success)]/50 bg-[var(--color-success)]/5 p-7 text-left hover:border-[var(--color-success)]">
+            <span className="text-[10px] uppercase tracking-[0.12em] text-[var(--color-success)]">Recommended</span>
+            <Compass className="mt-8 h-6 w-6" />
+            <h2 className="mt-4 text-lg font-medium">Explore a demo</h2>
+            <p className="mt-2 text-xs leading-5 text-[var(--color-text-dim)]">Watch the Chat Agent investigate experiment lift, then explore on your own.</p>
+            <span className="mt-6 inline-block bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)]">Show me</span>
+          </button>
+          <button type="button" onClick={() => launch("setup")} className="group border border-[var(--color-border)] p-7 text-left hover:border-[var(--color-text-dim)]">
+            <Database className="mt-5 h-6 w-6" />
+            <h2 className="mt-4 text-lg font-medium">Connect my data</h2>
+            <p className="mt-2 text-xs leading-5 text-[var(--color-text-dim)]">Create a production Team and configure GitHub, your warehouse, and Agent access.</p>
+            <span className="mt-6 inline-block border border-[var(--color-border)] px-4 py-2 text-xs">Set up SignalPilot</span>
+          </button>
+        </div>
+        <button type="button" onClick={() => void skip()} className="mt-6 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]">Skip for now</button>
+      </div>
+    </div>
+  );
+}
+
+function LegacyCloudOnboardingContent() {
   const router = useRouter();
   const { user, isLoaded: userLoaded } = useUser();
 

--- a/signalpilot/web/app/onboarding/page.tsx
+++ b/signalpilot/web/app/onboarding/page.tsx
@@ -4,8 +4,9 @@
  * Onboarding page — entry point.
  *
  * - Local mode: immediate redirect to /dashboard (no onboarding needed).
- * - Cloud mode: renders CloudOnboardingContent which handles the team-creation
- *   step + API key wizard. All @clerk/nextjs hooks live in onboarding-cloud.tsx
+ * - Cloud mode: renders the desktop Getting Started welcome screen. Its
+ *   persistent controller handles Demo, production setup, and Product Tour.
+ *   All @clerk/nextjs hooks live in onboarding-cloud.tsx
  *   to prevent them from being pulled into the SSR bundle in local-mode builds.
  */
 

--- a/signalpilot/web/app/schema/page.tsx
+++ b/signalpilot/web/app/schema/page.tsx
@@ -388,7 +388,7 @@ export default function SchemaExplorerPage() {
   }
 
   return (
-    <main className="schema-page">
+    <main data-tour-id="schema-browser" className="schema-page">
       <header className="schema-titlebar">
         <div>
           <span className="schema-eyebrow">Database catalog</span>

--- a/signalpilot/web/app/settings/team/team-client.tsx
+++ b/signalpilot/web/app/settings/team/team-client.tsx
@@ -54,7 +54,7 @@ export default function TeamClient() {
   const membersCount = organization.membersCount ?? 0;
 
   return (
-    <div className="p-8 max-w-3xl animate-fade-in">
+    <div data-tour-id="team-members" className="p-8 max-w-3xl animate-fade-in">
       <PageHeader
         title="team"
         subtitle="settings"

--- a/signalpilot/web/components/billing/notebooks-projects-paywall.tsx
+++ b/signalpilot/web/components/billing/notebooks-projects-paywall.tsx
@@ -14,11 +14,11 @@ export function NotebooksProjectsPaywall() {
         </div>
         <div className="border border-[var(--color-border)] p-6 space-y-4">
           <p className="text-sm text-[var(--color-text)]">
-            Notebooks &amp; projects are a Pro feature.
+            Interactive notebooks are a Pro feature.
           </p>
           <p className="text-xs text-[var(--color-text-dim)] leading-relaxed">
-            Upgrade to Pro, Team, or Enterprise to create governed notebook
-            workspaces backed by your connections and dbt projects.
+            Free Teams can still import dbt projects, explore lineage, and use
+            Chat Agent. Upgrade for user-managed notebook sessions.
           </p>
           <a
             href="/settings/billing"

--- a/signalpilot/web/components/chat/chat-message.test.tsx
+++ b/signalpilot/web/components/chat/chat-message.test.tsx
@@ -82,6 +82,42 @@ describe("Data Chat dashboard artifact card", () => {
   });
 });
 
+describe("Data Chat authorized replay", () => {
+  it("starts the matching completed run in replay mode", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const message: UiMessage = {
+      id: "assistant-replay",
+      role: "assistant",
+      content: "Demo answer",
+      sequence: 2,
+      created_at: 2,
+      metadata: { run_id: "run-replay", status: "completed" },
+      runId: "run-replay",
+      runStatus: "completed",
+    };
+    const events: StandaloneChatEvent[] = [{
+      run_id: "run-replay",
+      sequence: 1,
+      type: "text_delta",
+      payload: { delta: "Demo answer" },
+      created_at: "2026-01-01T00:00:00Z",
+    }];
+
+    await act(async () => {
+      root.render(
+        <ChatUiContext.Provider value={{ events, conversationId: "conversation-demo", files: [], openArtifact: () => undefined, onStop: async () => undefined, onRetry: async () => undefined, onOpenDashboardPreview: () => undefined }}>
+          <ChatMessage message={message} autoReplayRunId="run-replay" />
+        </ChatUiContext.Provider>,
+      );
+    });
+    expect(container.querySelector('[data-testid="chat-replay"]')).not.toBeNull();
+    await act(async () => root.unmount());
+    container.remove();
+  });
+});
+
 describe("Data Chat live state", () => {
   let container: HTMLDivElement;
   let root: Root;

--- a/signalpilot/web/components/chat/chat-message.tsx
+++ b/signalpilot/web/components/chat/chat-message.tsx
@@ -12,7 +12,7 @@ import {
   Sparkles,
   Wrench,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChatMarkdown } from "~/components/chat/chat-markdown";
 import {
   openStandaloneNotebookArchive,
@@ -464,16 +464,26 @@ function AssistantMessageReplay({
 function ReplayableAssistantMessage({
   message,
   previousMessageAt,
+  autoReplayRunId,
 }: {
   message: UiMessage;
   previousMessageAt?: number;
+  autoReplayRunId?: string | null;
 }) {
   const { events } = useChatUi();
-  const [replaying, setReplaying] = useState(false);
   const runId = messageRunId(message);
+  const [replaying, setReplaying] = useState(
+    () => Boolean(runId && runId === autoReplayRunId),
+  );
+  const autoStarted = useRef(replaying);
   const canReplay =
     Boolean(runId) &&
     events.some((event) => event.run_id === runId && event.type !== "status");
+  useEffect(() => {
+    if (autoStarted.current || !canReplay || runId !== autoReplayRunId) return;
+    autoStarted.current = true;
+    setReplaying(true);
+  }, [autoReplayRunId, canReplay, runId]);
   if (replaying && runId) {
     return (
       <AssistantMessageReplay
@@ -495,9 +505,11 @@ function ReplayableAssistantMessage({
 export function ChatMessage({
   message,
   previousMessageAt,
+  autoReplayRunId,
 }: {
   message: UiMessage;
   previousMessageAt?: number;
+  autoReplayRunId?: string | null;
 }) {
   return message.role === "user" ? (
     <UserMessage message={message} />
@@ -505,6 +517,7 @@ export function ChatMessage({
     <ReplayableAssistantMessage
       message={message}
       previousMessageAt={previousMessageAt}
+      autoReplayRunId={autoReplayRunId}
     />
   );
 }

--- a/signalpilot/web/components/chat/standalone-chat-composer.tsx
+++ b/signalpilot/web/components/chat/standalone-chat-composer.tsx
@@ -106,6 +106,7 @@ export function StandaloneChatComposer({
   return (
     <div
       data-testid="standalone-chat-composer"
+      data-tour-id="chat-composer"
       className="mx-auto w-full max-w-3xl px-6 pb-6 pt-3"
     >
       {/* Plan dock: the run's TodoWrite list, fused to the top of the input

--- a/signalpilot/web/components/chat/standalone-data-chat.tsx
+++ b/signalpilot/web/components/chat/standalone-data-chat.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import {
+  authorizeDemoReplay,
   getSavedChatReport,
   getStandaloneChatBootstrap,
   getStandaloneChatProjectReadiness,
@@ -69,6 +70,7 @@ import { ConnectorsProvider } from "~/components/connectors/connectors-context";
 import { useChatModelSettings } from "~/components/chat/use-chat-model-settings";
 import { useChatBudgetSettings } from "~/components/chat/use-chat-budget-settings";
 import { ChatTelemetryBoundary } from "~/components/chat/chat-telemetry-panel";
+import { GETTING_STARTED_EVENT } from "~/lib/getting-started";
 
 export { ChatUiContext, useChatUi } from "~/components/chat/chat-ui-context";
 export type { UiMessage } from "~/components/chat/chat-ui-context";
@@ -121,6 +123,8 @@ export function StandaloneDataChat({
   const requestedProject = searchParams.get("project");
   const requestedReportId = searchParams.get("report");
   const requestedPrompt = searchParams.get("prompt");
+  const requestedReplayRunId = searchParams.get("replay");
+  const [authorizedReplayRunId, setAuthorizedReplayRunId] = useState<string | null>(null);
   const [selectedReport, setSelectedReport] =
     useState<ChatReportMention | null>(null);
   const attachedReportReference = selectedReport
@@ -176,6 +180,24 @@ export function StandaloneDataChat({
       active = false;
     };
   }, [requestedReportId, selectedReport?.report_id, toast]);
+
+  useEffect(() => {
+    if (!conversationId || !requestedReplayRunId) {
+      setAuthorizedReplayRunId(null);
+      return;
+    }
+    let active = true;
+    void authorizeDemoReplay(conversationId, requestedReplayRunId)
+      .then(() => {
+        if (active) setAuthorizedReplayRunId(requestedReplayRunId);
+      })
+      .catch(() => {
+        if (!active) return;
+        setAuthorizedReplayRunId(null);
+        router.replace(`/chats/${encodeURIComponent(conversationId)}`);
+      });
+    return () => { active = false; };
+  }, [conversationId, requestedReplayRunId, router]);
 
   const { data: readiness } = useSWR(
     selectedProjectId ? `standalone-chat-readiness:${selectedProjectId}` : null,
@@ -296,16 +318,15 @@ export function StandaloneDataChat({
     !selectedProjectId ||
     (readiness?.ready === false && currentRun?.status !== "waiting_for_user") ||
     currentRun?.status === "queued" ||
-    currentRun?.status === "waiting_for_query_approval";
+    currentRun?.status === "waiting_for_query_approval" ||
+    bootstrap?.demo_requests_remaining === 0;
 
   const runIsStreaming =
     currentRun?.status === "queued" || currentRun?.status === "running";
 
-  const disabledReason = composerDisabledReason(
-    selectedProjectId,
-    readiness,
-    currentRun,
-  );
+  const disabledReason = bootstrap?.demo_requests_remaining === 0
+    ? "This Demo Team has used its 5 live requests. Start the Product Tour or set up your own data."
+    : composerDisabledReason(selectedProjectId, readiness, currentRun);
 
   const conversations = historyData?.conversations ?? [];
   const starters =
@@ -514,8 +535,24 @@ export function StandaloneDataChat({
                       key={standaloneMessageKey(conversationId, message)}
                       message={message}
                       previousMessageAt={uiMessages[index - 1]?.created_at}
+                      autoReplayRunId={authorizedReplayRunId}
                     />
                   ))}
+                  {detail?.conversation.origin === "demo_replay" && (
+                    <div className="mx-auto mb-6 w-full max-w-3xl space-y-2 px-6">
+                      {["Which experiments drove the largest conversion lift?", "Which experiment results should we trust, and why?", "Which clients have the biggest data-quality risks?"].map((question) => (
+                        <button key={question} type="button" onClick={() => setDraft(question)} className="block w-full rounded-lg border border-[var(--color-border)] px-3 py-2 text-left text-xs text-[var(--color-text-muted)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]">{question}</button>
+                      ))}
+                      <button type="button" onClick={() => window.dispatchEvent(new CustomEvent(GETTING_STARTED_EVENT, { detail: { journey: "tour", expanded: false } }))} className="mt-2 text-xs text-[var(--color-success)] hover:underline">Start Product Tour</button>
+                    </div>
+                  )}
+                  {bootstrap.demo_requests_remaining === 0 && (
+                    <div className="mx-auto mb-6 flex w-full max-w-3xl items-center gap-3 border border-[var(--color-border)] px-4 py-3 text-xs">
+                      <span className="mr-auto text-[var(--color-text-muted)]">You can keep exploring Demo data and replays.</span>
+                      <button type="button" onClick={() => window.dispatchEvent(new CustomEvent(GETTING_STARTED_EVENT, { detail: { journey: "tour", expanded: false } }))} className="text-[var(--color-success)] hover:underline">Start Product Tour</button>
+                      <button type="button" onClick={() => window.dispatchEvent(new CustomEvent(GETTING_STARTED_EVENT, { detail: { journey: "setup", expanded: true } }))} className="text-[var(--color-text)] hover:underline">Set up my data</button>
+                    </div>
+                  )}
                 </div>
               )}
               {!isEmptyNewChat && (

--- a/signalpilot/web/components/chat/use-standalone-chat-actions.ts
+++ b/signalpilot/web/components/chat/use-standalone-chat-actions.ts
@@ -130,6 +130,7 @@ export function useStandaloneChatActions({
             { revalidate: false },
           );
           router.replace(`/chats/${created.conversation.id}`);
+          void mutateCache("standalone-chat-bootstrap");
           void mutateHistory();
           return;
         }
@@ -216,6 +217,7 @@ export function useStandaloneChatActions({
           { revalidate: false },
         );
         setPendingSubmission(null);
+        void mutateCache("standalone-chat-bootstrap");
         void mutateDetail();
         void mutateHistory();
       } catch (error) {
@@ -235,6 +237,7 @@ export function useStandaloneChatActions({
         }
         setPendingSubmission(null);
         setDraft(text);
+        void mutateCache("standalone-chat-bootstrap");
         toastRequestError(toast, error, "Could not send message");
       } finally {
         setIsSubmitting(false);
@@ -317,12 +320,14 @@ export function useStandaloneChatActions({
           { revalidate: false },
         );
         void mutateDetail();
+        void mutateCache("standalone-chat-bootstrap");
         await mutateHistory();
       } catch (error) {
+        void mutateCache("standalone-chat-bootstrap");
         toastRequestError(toast, error, "Could not retry the run");
       }
     },
-    [mutateDetail, mutateHistory, toast],
+    [mutateCache, mutateDetail, mutateHistory, toast],
   );
 
   const loadConversation = useCallback(

--- a/signalpilot/web/components/connections/connection-list.tsx
+++ b/signalpilot/web/components/connections/connection-list.tsx
@@ -84,7 +84,7 @@ export function ConnectionList({ controller }: ConnectionListProps) {
           }
         />
       ) : (
-        <div className="connection-list">
+        <div className="connection-list" data-tour-id="connection-list">
           <div className="connections-toolbar">
             <label className="connections-search"><Search aria-hidden="true" /><input value={connectionSearch} onChange={(event) => setConnectionSearch(event.target.value)} placeholder="Find a connection" aria-label="Find a connection" /></label>
             {(() => {

--- a/signalpilot/web/components/connections/editor/connection-editor.tsx
+++ b/signalpilot/web/components/connections/editor/connection-editor.tsx
@@ -16,9 +16,10 @@ const IS_CLOUD_MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE === "cloud";
 
 interface ConnectionEditorProps {
   controller: ConnectionsController;
+  primaryAction?: { label: string; onClick: () => void | Promise<void>; pending?: boolean };
 }
 
-export function ConnectionEditor({ controller }: ConnectionEditorProps) {
+export function ConnectionEditor({ controller, primaryAction }: ConnectionEditorProps) {
   const {
     toast, showForm, setShowForm, editingConnection, setEditingConnection,
     form, setForm, selectedVariant,
@@ -550,6 +551,12 @@ export function ConnectionEditor({ controller }: ConnectionEditorProps) {
 
             {/* Action buttons */}
             <div className="flex items-center gap-3 mt-5 pt-4 border-t border-[var(--color-border)]">
+              {primaryAction ? (
+                <button onClick={() => void primaryAction.onClick()} disabled={saving || preTesting || hasFormErrors || primaryAction.pending} className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium rounded-[10px] transition-opacity duration-150 hover:opacity-90 disabled:opacity-30">
+                  {(saving || preTesting || primaryAction.pending) && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                  {primaryAction.label}
+                </button>
+              ) : <>
               <button onClick={handleCreate} disabled={saving || preTesting || hasFormErrors} className="flex items-center gap-2 px-4 py-2 bg-[var(--color-text)] text-[var(--color-bg)] text-xs font-medium rounded-[10px] transition-opacity duration-150 hover:opacity-90 disabled:opacity-30">
                 {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
                 {editingConnection ? "update connection" : "save connection"}
@@ -561,6 +568,7 @@ export function ConnectionEditor({ controller }: ConnectionEditorProps) {
               <button onClick={handleSaveAndTest} disabled={saving || preTesting || hasFormErrors} className="flex items-center gap-2 px-4 py-2 border border-[var(--color-border)] rounded-[10px] text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] hover:border-[var(--color-border-hover)] transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed">
                 {editingConnection ? "update & test" : "save & test"}
               </button>
+              </>}
               <button onClick={() => { setShowForm(false); setEditingConnection(null); setForm({ ...defaultForm }); setServerFieldErrors({}); setShowAdvanced(false); setPreTestResult(null); }} className="px-4 py-2 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors">
                 cancel
               </button>

--- a/signalpilot/web/components/connections/hooks/use-connections-controller.ts
+++ b/signalpilot/web/components/connections/hooks/use-connections-controller.ts
@@ -170,13 +170,14 @@ export function useConnectionsController() {
     setSaving(true);
     try {
       const payload = buildCreatePayload(form);
+      let saved: ConnectionInfo;
       if (editingConnection) {
         // Update existing connection
         const { name: _n, db_type: _d, ...updateFields } = payload;
-        await updateConnection(editingConnection, updateFields);
+        saved = await updateConnection(editingConnection, updateFields);
         toast("connection updated successfully", "success");
       } else {
-        await createConnection(payload);
+        saved = await createConnection(payload);
         toast("connection created successfully", "success");
       }
       setShowForm(false);
@@ -186,6 +187,7 @@ export function useConnectionsController() {
       setServerFieldErrors({});
       setShowAdvanced(false);
       refresh();
+      return saved;
     } catch (e) { handleServerError(e); } finally { setSaving(false); }
   }
 
@@ -383,9 +385,11 @@ export function useConnectionsController() {
         const failedPhase = result.phases?.find((p: { status: string }) => p.status === "error");
         toast(failedPhase?.message || result.message, "error");
       }
+      return result;
     } catch (e) {
       handleServerError(e);
       setPreTestResult({ status: "error", message: _parseError(e), phases: [] });
+      return null;
     } finally {
       setPreTesting(false);
     }

--- a/signalpilot/web/components/getting-started/getting-started-mount.tsx
+++ b/signalpilot/web/components/getting-started/getting-started-mount.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useAppAuth } from "~/lib/auth-context";
+
+const GettingStartedRoot = dynamic(
+  () => import("./getting-started-root").then((module) => module.GettingStartedRoot),
+  { ssr: false },
+);
+
+export function GettingStartedMount() {
+  const { clerkEnabled, isAuthenticated } = useAppAuth();
+  if (!clerkEnabled || !isAuthenticated) return null;
+  return <GettingStartedRoot />;
+}

--- a/signalpilot/web/components/getting-started/getting-started-root.tsx
+++ b/signalpilot/web/components/getting-started/getting-started-root.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import { useOrganization, useOrganizationList, useSession, useUser } from "@clerk/nextjs";
+import { Check, ChevronRight, Loader2, Map, X } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { GitHubImportForm } from "~/components/projects/projects-overview-page";
+import { SetupConnectionForm } from "~/components/getting-started/setup-connection-form";
+import { AnthropicKeyForm } from "~/components/integrations/anthropic-key-form";
+import { TeamInvitationForm } from "~/components/team/team-invitations-section";
+import { ROLE_ADMIN } from "~/lib/team/roles";
+import type { OrganizationResource } from "@clerk/types";
+import {
+  bootstrapDemo,
+  getDemoBootstrap,
+  getConnections,
+  getOrgSecrets,
+  getStandaloneChatProjectReadiness,
+  getWorkspaceProjects,
+  setDefaultStandaloneChatProject,
+  updateWorkspaceProject,
+} from "~/lib/api";
+import type { DemoBootstrapResponse, WorkspaceProjectInfo } from "~/lib/types";
+import {
+  DEFAULT_GETTING_STARTED,
+  GETTING_STARTED_EVENT,
+  TOUR_STEPS,
+  canSelectStep,
+  deriveSetupStep,
+  hiddenForSessionKey,
+  normalizeGettingStarted,
+  routeCompletesTourStep,
+  shouldShowGettingStarted,
+  type GettingStartedJourney,
+  type SignalPilotGettingStarted,
+  type TourStep,
+} from "~/lib/getting-started";
+
+type ControllerEvent = CustomEvent<{ journey?: GettingStartedJourney | null; expanded?: boolean }>;
+
+const SETUP_STEPS = ["Create your Team", "Import your dbt project", "Connect your warehouse", "Add your Anthropic key", "Invite a technical teammate", "Ready"];
+const DEMO_PHASES = ["Creating your demo team", "Preparing your private demo data", "Loading the demo project", "Opening SignalPilot"];
+
+export function GettingStartedRoot() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { user } = useUser();
+  const { session } = useSession();
+  const { organization, invitations, memberships } = useOrganization({
+    invitations: { pageSize: 20, keepPreviousData: true },
+    memberships: { pageSize: 20, keepPreviousData: true },
+  });
+  const { createOrganization, setActive, userMemberships } = useOrganizationList({
+    userMemberships: { infinite: true, pageSize: 50 },
+  });
+  const [state, setState] = useState<SignalPilotGettingStarted>(DEFAULT_GETTING_STARTED);
+  const [open, setOpen] = useState(false);
+  const [hidden, setHidden] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [demo, setDemo] = useState<DemoBootstrapResponse | null>(null);
+  const [teamName, setTeamName] = useState("");
+  const [setupProject, setSetupProject] = useState<WorkspaceProjectInfo | null>(null);
+  const [hasTeamKey, setHasTeamKey] = useState(false);
+  const [ready, setReady] = useState(false);
+  const [spotlight, setSpotlight] = useState<DOMRect | null>(null);
+  const [selectedTourStep, setSelectedTourStep] = useState<TourStep>(0);
+  const [selectedSetupStep, setSelectedSetupStep] = useState(0);
+  const compactRef = useRef<HTMLButtonElement>(null);
+  const demoBusyRef = useRef(false);
+  const metadataHydratedRef = useRef(false);
+
+  useEffect(() => {
+    if (!user || metadataHydratedRef.current) return;
+    metadataHydratedRef.current = true;
+    const normalized = normalizeGettingStarted(user.unsafeMetadata.signalpilotGettingStarted);
+    setState(normalized);
+    if (normalized.activeJourney === "tour") setSelectedTourStep(normalized.tour.step);
+  }, [user]);
+
+  useEffect(() => {
+    if (state.activeJourney === "demo" || state.activeJourney === "setup") setOpen(true);
+  }, [state.activeJourney]);
+
+  const persist = useCallback(async (next: SignalPilotGettingStarted, completeEntry = false) => {
+    setState(next);
+    if (!user) return;
+    await user.update({ unsafeMetadata: {
+      ...user.unsafeMetadata,
+      ...(completeEntry ? { onboardingCompleted: true } : {}),
+      signalpilotGettingStarted: next,
+    } });
+  }, [user]);
+
+  useEffect(() => {
+    if (!session?.id) return;
+    setHidden(sessionStorage.getItem(hiddenForSessionKey(session.id)) === "1");
+  }, [session?.id]);
+
+  useEffect(() => {
+    const handler = (raw: Event) => {
+      const event = raw as ControllerEvent;
+      setHidden(false);
+      setOpen(event.detail?.expanded ?? true);
+      if (event.detail?.journey !== undefined) {
+        const journey = event.detail.journey;
+        if (journey === "tour") setSelectedTourStep(state.tour.status === "active" ? state.tour.step : 0);
+        void persist({
+          ...state,
+          activeJourney: journey,
+          ...(journey === "tour" && state.tour.status !== "active"
+            ? { tour: { status: "active" as const, step: 0 as TourStep } }
+            : {}),
+        });
+      }
+    };
+    window.addEventListener(GETTING_STARTED_EVENT, handler);
+    return () => window.removeEventListener(GETTING_STARTED_EVENT, handler);
+  }, [persist, state]);
+
+  useEffect(() => {
+    const returnTo = sessionStorage.getItem("signalpilot:getting-started:oauth-return");
+    if (!returnTo || !window.location.search.includes("installed=true")) return;
+    sessionStorage.removeItem("signalpilot:getting-started:oauth-return");
+    setOpen(true);
+    router.replace(returnTo);
+  }, [router]);
+
+  useEffect(() => {
+    if (!open) return;
+    const escape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      requestAnimationFrame(() => compactRef.current?.focus());
+    };
+    document.addEventListener("keydown", escape);
+    return () => document.removeEventListener("keydown", escape);
+  }, [open]);
+
+  const switchToTeam = useCallback(async (teamId: string, destination: string) => {
+    if (organization?.id === teamId) return true;
+    const member = userMemberships.data?.some((membership) => membership.organization.id === teamId);
+    if (!member || !setActive) return false;
+    await setActive({ organization: teamId });
+    window.location.href = destination;
+    return false;
+  }, [organization?.id, setActive, userMemberships.data]);
+
+  useEffect(() => {
+    if (state.activeJourney !== "setup" || !state.setup.teamId || organization?.id === state.setup.teamId) return;
+    void switchToTeam(state.setup.teamId, "/dashboard");
+  }, [organization?.id, state.activeJourney, state.setup.teamId, switchToTeam]);
+
+  const startDemo = useCallback(async () => {
+    if (!user || !createOrganization || !setActive || userMemberships.isLoading || demoBusyRef.current) return;
+    demoBusyRef.current = true;
+    setBusy(true); setError(null); setOpen(true);
+    try {
+      if (state.activeJourney !== "demo") await persist({ ...state, activeJourney: "demo" });
+      let teamId = state.demo.teamId;
+      if (teamId && !userMemberships.data?.some((membership) => membership.organization.id === teamId)) {
+        teamId = undefined;
+      }
+      if (teamId && !(await switchToTeam(teamId, "/onboarding?journey=demo"))) return;
+      if (!teamId) {
+        const email = user.primaryEmailAddress?.emailAddress || "My";
+        const demoTeamName = `${email}'s Demo Team`;
+        const existingMembership = userMemberships.data?.find(
+          (membership) => membership.organization.name === demoTeamName,
+        );
+        teamId = existingMembership?.organization.id;
+        if (!teamId) {
+          const org = await createOrganization({ name: demoTeamName });
+          teamId = org.id;
+        }
+        const next = { ...state, activeJourney: "demo" as const, demo: { ...state.demo, teamId } };
+        await persist(next, true);
+        await setActive({ organization: teamId });
+        window.location.href = "/onboarding?journey=demo";
+        return;
+      }
+      const result = await bootstrapDemo();
+      setDemo(result);
+    } catch {
+      setError("We couldn't prepare the demo. Try again.");
+    } finally { demoBusyRef.current = false; setBusy(false); }
+  }, [createOrganization, persist, setActive, state, switchToTeam, user, userMemberships.data, userMemberships.isLoading]);
+
+  useEffect(() => {
+    if (state.activeJourney !== "demo" || busy) return;
+    if (!state.demo.teamId) { void startDemo(); return; }
+    if (organization?.id !== state.demo.teamId) return;
+    if (!demo) void startDemo();
+  }, [busy, demo, organization?.id, startDemo, state.activeJourney, state.demo.teamId]);
+
+  useEffect(() => {
+    if (state.activeJourney !== "demo" || demo?.status !== "provisioning") return;
+    const timer = window.setInterval(() => {
+      void getDemoBootstrap().then((next) => {
+        setDemo(next);
+        if (next.status === "ready" && next.conversation_id && next.replay_run_id) {
+          void persist({ ...state, demo: { ...state.demo, replaySeen: true } });
+          router.push(`/chats/${next.conversation_id}?replay=${next.replay_run_id}`);
+        }
+      }).catch(() => setError("We couldn't prepare the demo. Try again."));
+    }, 2_000);
+    return () => window.clearInterval(timer);
+  }, [demo?.status, persist, router, state]);
+
+  useEffect(() => {
+    if (demo?.status === "ready" && demo.conversation_id && demo.replay_run_id && pathname === "/onboarding") {
+      void persist({ ...state, demo: { ...state.demo, replaySeen: true } });
+      router.push(`/chats/${demo.conversation_id}?replay=${demo.replay_run_id}`);
+    }
+  }, [demo, pathname, persist, router, state]);
+
+  const startSetup = useCallback(async () => {
+    setOpen(true); setError(null);
+    const teamId = state.setup.teamId && userMemberships.data?.some(
+      (membership) => membership.organization.id === state.setup.teamId,
+    ) ? state.setup.teamId : undefined;
+    if (teamId) {
+      if (state.activeJourney !== "setup") await persist({ ...state, activeJourney: "setup" });
+      if (!(await switchToTeam(teamId, "/dashboard"))) return;
+    }
+    if (!teamId && organization) {
+      try {
+        const connections = await getConnections();
+        if (!connections.some((connection) => connection.tags?.includes("sp-demo"))) {
+          await persist({
+            ...state,
+            activeJourney: "setup",
+            setup: { ...state.setup, teamId: organization.id },
+          }, true);
+          return;
+        }
+      } catch { /* keep the dedicated-Team creation path available */ }
+    }
+    await persist({ ...state, activeJourney: "setup" });
+  }, [organization, persist, state, switchToTeam, userMemberships.data]);
+
+  async function createSetupTeam() {
+    if (!teamName.trim() || !createOrganization || !setActive) return;
+    setBusy(true); setError(null);
+    try {
+      const org = await createOrganization({ name: teamName.trim() });
+      const next = { ...state, activeJourney: "setup" as const, setup: { ...state.setup, teamId: org.id } };
+      await persist(next, true);
+      await setActive({ organization: org.id });
+      window.location.href = "/dashboard";
+    } catch (reason) { setError(String(reason)); setBusy(false); }
+  }
+
+  const refreshSetup = useCallback(async () => {
+    if (state.activeJourney !== "setup" || !organization) return;
+    try {
+      const projects = await getWorkspaceProjects("active");
+      const project = projects.projects.find((item) =>
+        (item.tags || []).includes("sp-onboarding") &&
+        (item.tags || []).includes("journey:setup-v2"),
+      ) || null;
+      setSetupProject(project);
+      if (project && state.setup.projectId !== project.id) {
+        void persist({ ...state, setup: { ...state.setup, projectId: project.id, teamId: organization.id } });
+      }
+      const [secret, readiness] = await Promise.all([
+        getOrgSecrets(),
+        project ? getStandaloneChatProjectReadiness(project.id).catch(() => null) : Promise.resolve(null),
+      ]);
+      setHasTeamKey(secret.has_key);
+      setReady(Boolean(readiness?.ready && secret.has_key));
+    } catch { /* incomplete setup remains actionable */ }
+  }, [organization, persist, state]);
+
+  useEffect(() => { void refreshSetup(); }, [refreshSetup]);
+  useEffect(() => {
+    if (state.activeJourney !== "setup" || !setupProject || ready) return;
+    const timer = window.setInterval(() => { void refreshSetup(); }, 5_000);
+    return () => window.clearInterval(timer);
+  }, [ready, refreshSetup, setupProject, state.activeJourney]);
+
+  async function startTour() {
+    const next = { ...state, activeJourney: "tour" as const, tour: { status: "active" as const, step: 0 as TourStep } };
+    await persist(next);
+    setSelectedTourStep(0);
+    setOpen(false);
+    router.push(TOUR_STEPS[0].href);
+  }
+
+  async function handleSetupProjectImported(project?: WorkspaceProjectInfo) {
+    if (!project) return;
+    const tagged = await updateWorkspaceProject(project.id, {
+      tags: Array.from(new Set([...(project.tags || []), "sp-onboarding", "journey:setup-v2"])),
+    });
+    setSetupProject(tagged);
+    await persist({
+      ...state,
+      setup: { ...state.setup, projectId: tagged.id, teamId: organization?.id },
+    });
+  }
+
+  const tourStep = state.tour.step;
+  useEffect(() => {
+    if (state.activeJourney !== "tour" || !routeCompletesTourStep(pathname, selectedTourStep)) return;
+    if (selectedTourStep === 5) {
+      if (state.tour.status !== "complete") void persist({ ...state, tour: { status: "complete", step: 5 } });
+      return;
+    }
+    if (selectedTourStep >= tourStep) {
+      const unlocked = (selectedTourStep + 1) as TourStep;
+      void persist({ ...state, tour: { status: "active", step: unlocked } });
+    }
+  }, [pathname, persist, selectedTourStep, state, tourStep]);
+  useEffect(() => {
+    if (state.activeJourney !== "tour" || hidden) { setSpotlight(null); return; }
+    const update = () => {
+      const target = document.querySelector(`[data-tour-id="${TOUR_STEPS[selectedTourStep].target}"]`);
+      setSpotlight(target?.getBoundingClientRect() ?? null);
+    };
+    const frame = requestAnimationFrame(update);
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [hidden, pathname, selectedTourStep, state.activeJourney]);
+
+  async function nextTourStep() {
+    const current = TOUR_STEPS[selectedTourStep];
+    if (!routeCompletesTourStep(pathname, selectedTourStep)) { router.push(current.href); return; }
+    if (selectedTourStep === 5) {
+      await persist({ ...state, activeJourney: null, tour: { status: "complete", step: 5 } });
+      setOpen(false); setSpotlight(null); return;
+    }
+    const nextStep = (selectedTourStep + 1) as TourStep;
+    setSelectedTourStep(nextStep);
+    if (nextStep > tourStep) await persist({ ...state, tour: { status: "active", step: nextStep } });
+    router.push(TOUR_STEPS[nextStep].href);
+  }
+
+  const setupStep = useMemo(() => {
+    return deriveSetupStep({
+      teamMatches: Boolean(state.setup.teamId && organization?.id === state.setup.teamId),
+      hasProject: Boolean(setupProject),
+      hasLinkedConnection: Boolean(setupProject?.connection_name),
+      hasTeamKey,
+      invitationSkipped: state.setup.invitationSkipped,
+      invitationCount: invitations?.data?.length || 0,
+      memberCount: memberships?.data?.length || 0,
+    });
+  }, [hasTeamKey, invitations?.data?.length, memberships?.data?.length, organization?.id, setupProject, state.setup]);
+  useEffect(() => { setSelectedSetupStep(setupStep); }, [setupStep]);
+
+  if (!user || !shouldShowGettingStarted(hidden, state.activeJourney, open)) return null;
+  const journeyTitle = state.activeJourney === "demo" ? "Explore a demo" : state.activeJourney === "setup" ? "Connect your data" : state.activeJourney === "tour" ? "Product Tour" : "Getting Started";
+  const currentTask = state.activeJourney === "setup" ? SETUP_STEPS[selectedSetupStep] : state.activeJourney === "tour" ? TOUR_STEPS[selectedTourStep].title : state.activeJourney === "demo" ? DEMO_PHASES[demo?.phase === "project" ? 2 : demo?.phase === "opening" ? 3 : state.demo.teamId ? 1 : 0] : "Choose a path";
+  const progress = state.activeJourney === "setup" ? setupStep : state.activeJourney === "tour" ? tourStep : demo?.status === "ready" ? 4 : state.demo.teamId ? 1 : 0;
+  const total = state.activeJourney === "demo" ? 4 : 6;
+  const left = pathname === "/onboarding" ? "1rem" : "calc(14rem + 1rem)";
+
+  return (
+    <>
+      {spotlight && state.activeJourney === "tour" && (
+        <div aria-hidden="true" className="pointer-events-none fixed z-[69] rounded-xl border-2 border-[var(--color-success)] shadow-[0_0_0_6px_rgba(52,211,153,0.12)]" style={{ left: spotlight.left - 6, top: spotlight.top - 6, width: spotlight.width + 12, height: spotlight.height + 12 }} />
+      )}
+      {!open ? (
+        <button ref={compactRef} type="button" onClick={() => setOpen(true)} className="fixed bottom-4 z-[70] w-72 border border-[var(--color-border)] bg-[var(--color-bg-card)] p-3 text-left shadow-2xl" style={{ left }}>
+          <span className="block text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-dim)]">{journeyTitle}</span>
+          <span className="mt-1 flex items-center gap-2 text-xs text-[var(--color-text)]"><span className="truncate">{currentTask}</span><ChevronRight className="ml-auto h-3 w-3" /></span>
+          <span className="mt-2 block h-1 bg-[var(--color-border)]"><span className="block h-full bg-[var(--color-success)]" style={{ width: `${((progress + 1) / total) * 100}%` }} /></span>
+        </button>
+      ) : (
+        <aside aria-label="Getting Started" className="fixed bottom-4 z-[70] flex w-[544px] max-h-[calc(100vh-32px)] flex-col overflow-hidden border border-[var(--color-border)] bg-[var(--color-bg-card)] shadow-2xl" style={{ left }}>
+          <header className="sticky top-0 z-10 flex items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-bg-card)] px-5 py-4">
+            <Map className="h-4 w-4 text-[var(--color-success)]" /><div className="min-w-0 flex-1"><p className="text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-dim)]">Getting Started</p><h2 className="text-sm font-medium">{journeyTitle}</h2></div>
+            <button type="button" onClick={() => setOpen(false)} aria-label="Collapse Getting Started"><X className="h-4 w-4" /></button>
+          </header>
+          <div className="min-h-0 overflow-y-auto p-5">
+            {error && <p role="alert" className="mb-4 border border-[var(--color-error)]/30 p-3 text-xs text-[var(--color-error)]">{error}</p>}
+            {state.activeJourney === null && <JourneyPicker onDemo={() => void startDemo()} onSetup={() => void startSetup()} onTour={() => void startTour()} />}
+            {state.activeJourney === "demo" && <DemoJourney state={state} demo={demo} busy={busy} onStart={() => void startDemo()} onTour={() => void startTour()} onSetup={() => void startSetup()} />}
+            {state.activeJourney === "setup" && (
+              <SetupJourney step={selectedSetupStep} unlockedStep={setupStep} onSelect={setSelectedSetupStep} project={setupProject} ready={ready} teamName={teamName} setTeamName={setTeamName} busy={busy} organization={organization} memberCount={memberships?.data?.length || 0} invitationCount={invitations?.data?.length || 0} onCreateTeam={() => void createSetupTeam()} onImported={handleSetupProjectImported} onLinked={() => void refreshSetup()} onKey={() => { setHasTeamKey(true); void refreshSetup(); }} onInvited={() => void invitations?.revalidate?.()} onSkipInvite={() => void persist({ ...state, setup: { ...state.setup, invitationSkipped: true } })} onReady={async () => { if (!setupProject || !ready) return; await setDefaultStandaloneChatProject(setupProject.id); await startTour(); }} />
+            )}
+            {state.activeJourney === "tour" && <TourJourney step={selectedTourStep} unlockedStep={tourStep} pathname={pathname} spotlight={spotlight} onSelect={setSelectedTourStep} onNext={() => void nextTourStep()} />}
+          </div>
+          <footer className="sticky bottom-0 flex items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-bg-card)] px-5 py-3">
+            <button type="button" onClick={() => { if (session?.id) sessionStorage.setItem(hiddenForSessionKey(session.id), "1"); setHidden(true); }} className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)]">Hide for now</button>
+            {state.activeJourney && <button type="button" onClick={() => void persist({ ...state, activeJourney: null })} className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)]">All journeys</button>}
+          </footer>
+        </aside>
+      )}
+    </>
+  );
+}
+
+function JourneyPicker({ onDemo, onSetup, onTour }: { onDemo: () => void; onSetup: () => void; onTour: () => void }) {
+  return <div className="space-y-3"><button onClick={onDemo} className="w-full border border-[var(--color-success)]/40 p-4 text-left"><span className="text-[10px] uppercase text-[var(--color-success)]">Recommended</span><strong className="mt-1 block text-sm">Explore a demo</strong><span className="text-xs text-[var(--color-text-dim)]">See SignalPilot answer a real analytics question.</span></button><button onClick={onSetup} className="w-full border border-[var(--color-border)] p-4 text-left"><strong className="text-sm">Connect my data</strong><span className="mt-1 block text-xs text-[var(--color-text-dim)]">Set up a production Team and dbt project.</span></button><button onClick={onTour} className="w-full border border-[var(--color-border)] p-4 text-left"><strong className="text-sm">Product Tour</strong></button></div>;
+}
+
+function DemoJourney({ state, demo, busy, onStart, onTour, onSetup }: { state: SignalPilotGettingStarted; demo: DemoBootstrapResponse | null; busy: boolean; onStart: () => void; onTour: () => void; onSetup: () => void }) {
+  if (!state.demo.teamId) return <button onClick={onStart} disabled={busy} className="flex items-center gap-2 bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)]">{busy && <Loader2 className="h-3 w-3 animate-spin" />}Show me</button>;
+  const active = demo?.phase === "project" ? 2 : demo?.phase === "opening" ? 3 : 1;
+  return <div className="space-y-4"><ol className="space-y-3">{DEMO_PHASES.map((label, index) => <li key={label} className={`flex items-center gap-3 text-xs ${index <= active ? "text-[var(--color-text)]" : "text-[var(--color-text-dim)]"}`}>{index < active || demo?.status === "ready" ? <Check className="h-3.5 w-3.5 text-[var(--color-success)]" /> : index === active ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <span className="h-3.5 w-3.5 rounded-full border border-[var(--color-border)]" />}{label}</li>)}</ol>{demo?.status === "ready" && <div className="space-y-2 border-t border-[var(--color-border)] pt-4"><p className="text-xs">{demo.requests_remaining} of {demo.request_limit} live requests remaining.</p><button onClick={onTour} className="mr-2 bg-[var(--color-text)] px-3 py-2 text-xs text-[var(--color-bg)]">Start Product Tour</button><button onClick={onSetup} className="border border-[var(--color-border)] px-3 py-2 text-xs">Set up my data</button></div>}</div>;
+}
+
+function SetupJourney(props: { step: number; unlockedStep: number; onSelect: (step: number) => void; project: WorkspaceProjectInfo | null; ready: boolean; teamName: string; setTeamName: (value: string) => void; busy: boolean; organization: OrganizationResource | null | undefined; memberCount: number; invitationCount: number; onCreateTeam: () => void; onImported: (project?: WorkspaceProjectInfo) => void; onLinked: (name: string) => void; onKey: () => void; onInvited: () => void; onSkipInvite: () => void; onReady: () => void }) {
+  return (
+    <div className="space-y-4">
+      <ol className="grid grid-cols-2 gap-2">
+        {SETUP_STEPS.map((label, index) => (
+          <li key={label}>
+            <button type="button" disabled={index > props.unlockedStep} onClick={() => props.onSelect(index)} className={`w-full text-left text-[11px] disabled:opacity-35 ${index <= props.unlockedStep ? "text-[var(--color-text)]" : "text-[var(--color-text-dim)]"}`}>
+              {index < props.unlockedStep ? "✓ " : `${index + 1}. `}{label}
+            </button>
+          </li>
+        ))}
+      </ol>
+      <div className="border-t border-[var(--color-border)] pt-4">
+        {props.step < props.unlockedStep ? (
+          <p className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]"><Check className="h-3.5 w-3.5 text-[var(--color-success)]" />{SETUP_STEPS[props.step]} is complete.</p>
+        ) : <>
+        {props.step === 0 && (
+          <div className="flex gap-2">
+            <input value={props.teamName} onChange={(event) => props.setTeamName(event.target.value)} placeholder="Team name" className="flex-1 border border-[var(--color-border)] bg-[var(--color-bg-input)] px-3 py-2 text-xs" />
+            <button onClick={props.onCreateTeam} disabled={props.busy || !props.teamName.trim()} className="bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)]">Create Team</button>
+          </div>
+        )}
+        {props.step === 1 && <GitHubImportForm onClose={() => undefined} onImported={props.onImported} oauthReturnTo="/dashboard" />}
+        {props.step === 2 && props.project && <SetupConnectionForm projectId={props.project.id} onLinked={props.onLinked} />}
+        {props.step === 3 && <div className="border border-[var(--color-border)]"><AnthropicKeyForm onSaved={(value) => { if (value.has_key) props.onKey(); }} /></div>}
+        {props.step === 4 && props.organization && (
+          <div>
+            <p className="mb-3 text-xs text-[var(--color-text-dim)]">Free capacity: owner plus one invited Admin. Active and pending invitations count.</p>
+            {props.memberCount + props.invitationCount < 2
+              ? <TeamInvitationForm org={props.organization} defaultRole={ROLE_ADMIN} onInvited={props.onInvited} />
+              : <p className="text-xs">Team capacity is full.</p>}
+            <button onClick={props.onSkipInvite} className="px-3 py-2 text-xs text-[var(--color-text-dim)]">Skip for now</button>
+          </div>
+        )}
+        {props.step === 5 && (
+          <div>
+            <p className="mb-3 text-xs text-[var(--color-text-dim)]">{props.ready ? "Your tagged project, healthy warehouse, compiled dbt metadata, and Team key are ready." : "SignalPilot is waiting for a healthy warehouse connection and compiled dbt metadata."}</p>
+            <button onClick={props.onReady} disabled={!props.project || !props.ready} className="bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)] disabled:opacity-40">Try Agent</button>
+          </div>
+        )}
+        </>}
+      </div>
+    </div>
+  );
+}
+
+function TourJourney({ step, unlockedStep, pathname, spotlight, onSelect, onNext }: { step: TourStep; unlockedStep: TourStep; pathname: string; spotlight: DOMRect | null; onSelect: (step: TourStep) => void; onNext: () => void }) {
+  const current = TOUR_STEPS[step];
+  const onPage = routeCompletesTourStep(pathname, step);
+  return <div><ol className="space-y-1">{TOUR_STEPS.map((item, index) => <li key={item.href}><button type="button" disabled={!canSelectStep(index, unlockedStep)} onClick={() => onSelect(index as TourStep)} className="w-full px-2 py-2 text-left text-xs disabled:opacity-35">{index < unlockedStep ? "✓ " : `${index + 1}. `}{item.title}</button></li>)}</ol><div className="mt-4 border-t border-[var(--color-border)] pt-4"><h3 className="text-sm font-medium">{current.title}</h3><p className="mt-2 text-xs text-[var(--color-text-dim)]">{current.title === "Team" ? "Invite teammates and manage collaboration. Demo Teams are personal; create a production Team to collaborate." : `See how ${current.title.toLowerCase()} fits into the governed analytics workflow.`}</p>{onPage && !spotlight && <p className="mt-2 text-[11px] text-[var(--color-warning)]">This target is unavailable, but you can continue.</p>}<button onClick={onNext} className="mt-4 bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)]">{onPage ? step === 5 ? "Finish tour" : "Next" : `Open ${current.title}`}</button></div></div>;
+}

--- a/signalpilot/web/components/getting-started/setup-connection-form.tsx
+++ b/signalpilot/web/components/getting-started/setup-connection-form.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ConnectionEditor } from "~/components/connections/editor/connection-editor";
+import { useConnectionsController } from "~/components/connections/hooks/use-connections-controller";
+import { updateWorkspaceProject } from "~/lib/api";
+
+export function SetupConnectionForm({ projectId, onLinked }: { projectId: string; onLinked: (name: string) => void }) {
+  const controller = useConnectionsController();
+  const [linking, setLinking] = useState(false);
+  const [pendingConnection, setPendingConnection] = useState<string | null>(null);
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  useEffect(() => {
+    controller.setShowForm(true);
+    controller.setForm((previous) => ({
+      ...previous,
+      tags: Array.from(new Set([...previous.tags, "sp-onboarding", "journey:setup-v2"])),
+    }));
+    // The controller owns the stable setters; this initialization belongs to this mounted step.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const existing = controller.connections.find((connection) =>
+      connection.tags?.includes("sp-onboarding") &&
+      connection.tags?.includes("journey:setup-v2"),
+    );
+    if (existing) setPendingConnection(existing.name);
+  }, [controller.connections]);
+
+  async function linkConnection(connectionName: string) {
+    setLinking(true);
+    setLinkError(null);
+    try {
+      await updateWorkspaceProject(projectId, { connection_name: connectionName });
+      setPendingConnection(null);
+      onLinked(connectionName);
+    } catch (reason) {
+      setPendingConnection(connectionName);
+      setLinkError(reason instanceof Error ? reason.message : "The connection was saved, but linking failed.");
+    } finally {
+      setLinking(false);
+    }
+  }
+
+  async function testAndLink() {
+    const tested = await controller.handlePreTest();
+    if (!tested || tested.status !== "healthy") return;
+    const connection = await controller.handleCreate();
+    if (!connection) return;
+    await linkConnection(connection.name);
+  }
+
+  if (pendingConnection) {
+    return (
+      <div className="space-y-3 border border-[var(--color-border)] p-4">
+        <p className="text-xs text-[var(--color-text)]">Connection “{pendingConnection}” was created successfully.</p>
+        {linkError && <p role="alert" className="text-xs text-[var(--color-error)]">{linkError}</p>}
+        <button type="button" disabled={linking} onClick={() => void linkConnection(pendingConnection)} className="bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)] disabled:opacity-40">
+          {linking ? "Linking…" : "Retry linking"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <ConnectionEditor
+      controller={controller}
+      primaryAction={{ label: "Test and link", onClick: testAndLink, pending: linking }}
+    />
+  );
+}

--- a/signalpilot/web/components/integrations/anthropic-key-form.tsx
+++ b/signalpilot/web/components/integrations/anthropic-key-form.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { KeyRound, Loader2, Trash2, X } from "lucide-react";
+import { useCallback, useEffect, useId, useState } from "react";
+import { getOrgSecrets, updateOrgSecrets, type OrgSecretsResponse } from "~/lib/api";
+import { useToast } from "~/components/ui/toast";
+
+export function AnthropicKeyForm({ onSaved }: { onSaved?: (value: OrgSecretsResponse) => void }) {
+  const { toast } = useToast();
+  const [status, setStatus] = useState<OrgSecretsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [key, setKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+  const [readOnly, setReadOnly] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const inputId = useId();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setStatus(await getOrgSecrets());
+      setLoadError(false);
+    } catch {
+      setStatus(null);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function save() {
+    if (!key.trim()) return;
+    setSaving(true);
+    try {
+      const next = await updateOrgSecrets({ anthropic_api_key: key.trim() });
+      setStatus(next);
+      setKey("");
+      setReadOnly(false);
+      onSaved?.(next);
+      toast(status?.has_key ? "anthropic key rotated" : "anthropic key saved", "success");
+    } catch (error) {
+      if (String(error).includes("403:")) {
+        setReadOnly(true);
+        toast("you do not have permission to update Team secrets", "error");
+      } else toast(`failed to save key: ${error}`, "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove() {
+    setSaving(true);
+    try {
+      const next = await updateOrgSecrets({ anthropic_api_key: null });
+      setStatus(next);
+      setConfirmRemove(false);
+      setReadOnly(false);
+      onSaved?.(next);
+      toast("anthropic key removed", "success");
+    } catch (error) {
+      if (String(error).includes("403:")) {
+        setReadOnly(true);
+        toast("you do not have permission to update Team secrets", "error");
+      } else toast(`failed to remove key: ${error}`, "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <div className="flex items-center gap-2 p-5 text-xs text-[var(--color-text-dim)]"><Loader2 className="h-3 w-3 animate-spin" />checking key</div>;
+  if (loadError) return <div className="flex items-center justify-between gap-3 p-5"><p className="text-xs text-[var(--color-error)]">Failed to load the Team key status.</p><button type="button" onClick={() => void load()} className="border border-[var(--color-border)] px-3 py-2 text-xs">Retry</button></div>;
+  return (
+    <div className="space-y-4 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[13px] font-medium text-[var(--color-text)]">{status?.has_key ? "key set" : "no key"}</p>
+          <p className="mt-1 text-[11px] text-[var(--color-text-dim)]">
+            {status?.has_key ? "Enter a new value only when you want to rotate it. The saved value is never displayed." : "Stored encrypted for this Team and never shown again."}
+          </p>
+          {status?.updated_at && <p className="mt-1 text-[11px] text-[var(--color-text-dim)]">Updated {new Date(status.updated_at * 1000).toLocaleString()}</p>}
+          {readOnly && <p className="mt-1 text-[11px] text-[var(--color-warning)]">Write permission required.</p>}
+        </div>
+        {status?.has_key && (confirmRemove ? (
+          <div className="flex items-center gap-1">
+            <button type="button" onClick={() => void remove()} disabled={saving || readOnly} className="border border-[var(--color-error)]/40 px-3 py-1.5 text-xs text-[var(--color-error)] disabled:opacity-30">Confirm</button>
+            <button type="button" onClick={() => setConfirmRemove(false)} aria-label="Cancel key removal" className="p-1.5 text-[var(--color-text-dim)]"><X className="h-3 w-3" /></button>
+          </div>
+        ) : (
+          <button type="button" onClick={() => setConfirmRemove(true)} disabled={readOnly} className="flex items-center gap-1.5 border border-[var(--color-border)] px-3 py-1.5 text-xs text-[var(--color-text-dim)] disabled:opacity-30"><Trash2 className="h-3 w-3" />Remove</button>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <label htmlFor={inputId} className="sr-only">Anthropic API key</label>
+        <input id={inputId} type="password" value={key} onChange={(event) => setKey(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void save(); }} disabled={saving || readOnly} placeholder="sk-ant-..." autoComplete="off" className="min-w-0 flex-1 border border-[var(--color-border)] bg-[var(--color-bg-input)] px-3 py-2 text-xs font-mono outline-none disabled:opacity-40" />
+        <button type="button" onClick={() => void save()} disabled={saving || readOnly || !key.trim()} className="flex items-center gap-2 bg-[var(--color-text)] px-4 py-2 text-xs text-[var(--color-bg)] disabled:opacity-30">
+          {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <KeyRound className="h-3 w-3" />}
+          {status?.has_key ? "rotate" : "save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/signalpilot/web/components/layout/team-switcher.tsx
+++ b/signalpilot/web/components/layout/team-switcher.tsx
@@ -15,9 +15,10 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useClerk, useUser, useOrganization, useOrganizationList } from "@clerk/nextjs";
 import { Component, type ReactNode } from "react";
-import { LogOut, ChevronDown, Check, Plus } from "lucide-react";
+import { LogOut, ChevronDown, Check, Plus, Map } from "lucide-react";
 import { useCreateTeam } from "~/lib/use-create-team";
 import { PendingButton } from "~/components/ui/pending-button";
+import { GETTING_STARTED_EVENT } from "~/lib/getting-started";
 
 const LIST_MSG_CLASS = "px-3 py-2 text-[10px] text-[var(--color-text-dim)] tracking-wider font-mono";
 
@@ -407,6 +408,18 @@ function TeamSwitcherInner({ displayName }: { displayName: string }) {
             )}
           </div>
           )}
+
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              window.dispatchEvent(new CustomEvent(GETTING_STARTED_EVENT, { detail: { journey: null, expanded: true } }));
+            }}
+            className="w-full flex items-center gap-2 px-3 py-2 text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-hover)] tracking-wider font-mono transition-colors border-t border-[var(--color-border)]"
+          >
+            <Map size={10} aria-hidden="true" />
+            Getting Started
+          </button>
 
           {/* Sign out */}
           <button

--- a/signalpilot/web/components/lineage/dbt-map-page.tsx
+++ b/signalpilot/web/components/lineage/dbt-map-page.tsx
@@ -308,7 +308,7 @@ export function DbtMapPage({
             />
           ))}
 
-        <div className="relative min-w-0 flex-1 bg-[var(--color-bg)]" data-testid="lineage-canvas">
+        <div className="relative min-w-0 flex-1 bg-[var(--color-bg)]" data-testid="lineage-canvas" data-tour-id="lineage-canvas">
           {parsed ? (
             <>
               <ReactFlowProvider>

--- a/signalpilot/web/components/notebook/notebooks-page.tsx
+++ b/signalpilot/web/components/notebook/notebooks-page.tsx
@@ -148,7 +148,7 @@ export default function NotebooksPage() {
   );
 
   const isPaid = PAID_TIERS.includes(planTier);
-  const gated = IS_CLOUD_MODE && subLoaded && !isPaid;
+  const gated = IS_CLOUD_MODE && subLoaded && !isPaid && !pathname?.startsWith("/projects");
 
   const nextSearch = searchParams.toString();
   const effectiveSearchParams = useMemo(

--- a/signalpilot/web/components/projects/projects-overview-page.tsx
+++ b/signalpilot/web/components/projects/projects-overview-page.tsx
@@ -701,12 +701,14 @@ function CreateProjectForm({
   );
 }
 
-function GitHubImportForm({
+export function GitHubImportForm({
   onClose,
   onImported,
+  oauthReturnTo,
 }: {
   onClose: () => void;
-  onImported: () => void | Promise<void>;
+  onImported: (project?: WorkspaceProjectInfo) => void | Promise<void>;
+  oauthReturnTo?: string;
 }) {
   const { toast } = useToast();
   const [installations, setInstallations] = useState<GitHubInstallation[]>([]);
@@ -771,6 +773,9 @@ function GitHubImportForm({
   const connectGitHub = async () => {
     setConnectingGitHub(true);
     try {
+      if (oauthReturnTo) {
+        sessionStorage.setItem("signalpilot:getting-started:oauth-return", oauthReturnTo);
+      }
       const { install_url } = await getGitHubInstallUrl();
       window.location.href = install_url;
     } catch (error) {
@@ -799,7 +804,7 @@ function GitHubImportForm({
           : `${repo.full_name} was already imported`,
         "success",
       );
-      await onImported();
+      await onImported(result.project);
       onClose();
     } catch (error) {
       toast(getErrorMessage(error), "error");

--- a/signalpilot/web/components/team/team-danger-section.tsx
+++ b/signalpilot/web/components/team/team-danger-section.tsx
@@ -24,6 +24,7 @@ import {
 import { isReverificationCancelledError } from "~/lib/security/use-reverify";
 import { formatClerkError } from "~/lib/security/clerk-errors";
 import type { TeamPermissions } from "~/lib/team/use-team-permissions";
+import { cleanupDemoTeam } from "~/lib/api";
 
 interface LeaveOrganizationUser {
   leaveOrganization: (organizationId: string) => Promise<DeletedObjectResource>;
@@ -88,6 +89,9 @@ export function TeamDangerSection({ org, perms, user }: TeamDangerSectionProps) 
     setDeleteError(null);
     setDeleteNotice(null);
     try {
+      // Production Teams receive a no-op response. Demo Teams must finish
+      // project/connection/branch cleanup before Clerk destroys the Team.
+      await cleanupDemoTeam();
       await reverifiedDelete();
       await setActive({ organization: null });
       router.push("/onboarding");

--- a/signalpilot/web/components/team/team-invitations-section.tsx
+++ b/signalpilot/web/components/team/team-invitations-section.tsx
@@ -6,7 +6,7 @@
  * Revoke: per-row via InvitationRow.
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useId, useState } from "react";
 import { Mail } from "lucide-react";
 import { InvitationListSkeleton } from "~/components/ui/list-skeletons";
 import { PendingButton } from "~/components/ui/pending-button";
@@ -26,31 +26,33 @@ import type { TeamPermissions } from "~/lib/team/use-team-permissions";
 import { ROLE_MEMBER, type TeamRole } from "~/lib/team/roles";
 import { RoleSelect } from "./role-select";
 import { InvitationRow } from "./invitation-row";
+import { getConnections } from "~/lib/api";
+import { useSubscription } from "~/lib/subscription-context";
 
 export interface TeamInvitationsSectionProps {
   org: OrganizationResource;
   perms: TeamPermissions;
 }
 
-export function TeamInvitationsSection({ org, perms }: TeamInvitationsSectionProps) {
-  const { invitations } = useOrganization({
-    invitations: { pageSize: 20, keepPreviousData: true },
-  });
-
+export function TeamInvitationForm({
+  org,
+  defaultRole = ROLE_MEMBER,
+  onInvited,
+}: {
+  org: OrganizationResource;
+  defaultRole?: TeamRole;
+  onInvited?: () => void | Promise<void>;
+}) {
   const { toast } = useToast();
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<TeamRole>(ROLE_MEMBER);
+  const [role, setRole] = useState<TeamRole>(defaultRole);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-
+  const emailId = useId();
   const reverifiedInvite = useReverification(
     (params: { emailAddress: string; role: string }) =>
       org.inviteMember({ emailAddress: params.emailAddress, role: params.role }),
-  );
-
-  const reverifiedRevoke = useReverification(
-    (inv: OrganizationInvitationResource) => inv.revoke(),
   );
 
   async function handleInvite(e: React.FormEvent) {
@@ -62,20 +64,59 @@ export function TeamInvitationsSection({ org, perms }: TeamInvitationsSectionPro
     try {
       await reverifiedInvite({ emailAddress: email.trim(), role });
       setEmail("");
-      setRole(ROLE_MEMBER);
+      setRole(defaultRole);
+      await onInvited?.();
       toast("invitation sent", "success");
-      // Revalidate the invitations list
-      invitations?.revalidate?.();
     } catch (err) {
-      if (isReverificationCancelledError(err)) {
-        setNotice("reverification required to send invitation");
-      } else {
-        setError(formatClerkError(err));
-      }
+      if (isReverificationCancelledError(err)) setNotice("reverification required to send invitation");
+      else setError(formatClerkError(err));
     } finally {
       setSending(false);
     }
   }
+
+  return (
+    <form onSubmit={handleInvite} className="p-6 space-y-4">
+      <div className="flex flex-col gap-1">
+        <label htmlFor={emailId} className={LABEL_CLASS}>invite by email</label>
+        <div className="flex gap-2">
+          <input id={emailId} type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="user@example.com" className={`${FIELD_INPUT_CLASS} flex-1`} autoComplete="off" />
+          <RoleSelect value={role} onChange={setRole} disabled={sending} ariaLabel="invited member role" />
+        </div>
+      </div>
+      <div role="alert" aria-live="assertive">{error && <p className={ERROR_CLASS}>{error}</p>}</div>
+      <div role="status" aria-live="polite">{notice && <p className={NEUTRAL_CLASS}>{notice}</p>}</div>
+      <PendingButton type="submit" pending={sending} pendingLabel="sending…" disabled={sending || !email.trim()}>
+        send invitation
+      </PendingButton>
+    </form>
+  );
+}
+
+export function TeamInvitationsSection({ org, perms }: TeamInvitationsSectionProps) {
+  const { planTier } = useSubscription();
+  const { invitations } = useOrganization({
+    invitations: { pageSize: 20, keepPreviousData: true },
+  });
+
+  const { toast } = useToast();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [demoTeam, setDemoTeam] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void getConnections()
+      .then((connections) => {
+        if (active) setDemoTeam(connections.some((connection) => connection.tags?.includes("sp-demo")));
+      })
+      .catch(() => { if (active) setDemoTeam(false); });
+    return () => { active = false; };
+  }, [org.id]);
+
+  const reverifiedRevoke = useReverification(
+    (inv: OrganizationInvitationResource) => inv.revoke(),
+  );
 
   async function handleRevoke(inv: OrganizationInvitationResource) {
     setError(null);
@@ -98,64 +139,37 @@ export function TeamInvitationsSection({ org, perms }: TeamInvitationsSectionPro
   const hasNextPage = invitations?.hasNextPage ?? false;
   // Only show skeleton on initial load, not on background refetches
   const showSkeleton = isLoading && data.length === 0;
+  const freeCapacityFull = planTier === "free" && (org.membersCount ?? 0) + data.length >= 2;
 
   return (
     <section className="mb-8">
       <SectionHeader icon={Mail} title="invitations" />
       <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)]">
         {/* Invite form — admin only */}
-        {perms.canInvite && (
-          <form onSubmit={handleInvite} className="p-6 space-y-4 border-b border-[var(--color-border)]">
-            <div className="flex flex-col gap-1">
-              <label htmlFor="invite-email" className={LABEL_CLASS}>invite by email</label>
-              <div className="flex gap-2">
-                <input
-                  id="invite-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="user@example.com"
-                  className={`${FIELD_INPUT_CLASS} flex-1`}
-                  autoComplete="off"
-                />
-                <RoleSelect
-                  value={role}
-                  onChange={setRole}
-                  disabled={sending}
-                  ariaLabel="invited member role"
-                />
-              </div>
-            </div>
-
-            <div role="alert" aria-live="assertive" aria-atomic="true">
-              {error && <p className={ERROR_CLASS}>{error}</p>}
-            </div>
-            <div role="status" aria-live="polite" aria-atomic="true">
-              {notice && <p className={NEUTRAL_CLASS}>{notice}</p>}
-            </div>
-
-            <PendingButton
-              type="submit"
-              pending={sending}
-              pendingLabel="sending…"
-              disabled={sending || !email.trim()}
-            >
-              send invitation
-            </PendingButton>
-          </form>
+        {perms.canInvite && demoTeam === false && !freeCapacityFull && (
+          <div className="border-b border-[var(--color-border)]">
+            <TeamInvitationForm org={org} onInvited={() => invitations?.revalidate?.()} />
+          </div>
         )}
 
-        {/* Non-admin error/notice */}
-        {!perms.canInvite && (
-          <>
-            <div role="alert" aria-live="assertive" aria-atomic="true" className="px-4">
-              {error && <p className={`${ERROR_CLASS} pt-3`}>{error}</p>}
-            </div>
-            <div role="status" aria-live="polite" aria-atomic="true" className="px-4">
-              {notice && <p className={`${NEUTRAL_CLASS} pt-3`}>{notice}</p>}
-            </div>
-          </>
+        {perms.canInvite && demoTeam === false && freeCapacityFull && (
+          <p className="border-b border-[var(--color-border)] px-6 py-4 text-xs text-[var(--color-text-muted)]">
+            The free plan includes the owner plus one active or pending teammate.
+          </p>
         )}
+
+        {demoTeam && (
+          <p className="border-b border-[var(--color-border)] px-6 py-4 text-xs text-[var(--color-text-muted)]">
+            Demo Teams are personal. Start “Connect my data” from Getting Started to create a Team for collaboration.
+          </p>
+        )}
+
+        <div role="alert" aria-live="assertive" aria-atomic="true" className="px-4">
+          {error && <p className={`${ERROR_CLASS} pt-3`}>{error}</p>}
+        </div>
+        <div role="status" aria-live="polite" aria-atomic="true" className="px-4">
+          {notice && <p className={`${NEUTRAL_CLASS} pt-3`}>{notice}</p>}
+        </div>
 
         {/* Pending invitations list */}
         {showSkeleton ? (

--- a/signalpilot/web/lib/api/client.ts
+++ b/signalpilot/web/lib/api/client.ts
@@ -151,6 +151,14 @@ export function userFacingErrorMessage(
   error: unknown,
   fallback: string,
 ): string | null {
+  if (error instanceof ApiRequestError) {
+    try {
+      const parsed = JSON.parse(error.body) as { code?: string; detail?: { code?: string } };
+      if (parsed.code === "demo_request_limit" || parsed.detail?.code === "demo_request_limit") {
+        return "This Demo Team has used its 5 live requests.";
+      }
+    } catch { /* non-JSON gateway errors use the existing fallback path */ }
+  }
   const raw = error instanceof Error ? error.message : "";
   if (isNotebookSessionAuthError(raw)) return null;
   return raw || fallback;

--- a/signalpilot/web/lib/api/connections.ts
+++ b/signalpilot/web/lib/api/connections.ts
@@ -29,6 +29,21 @@ export const createDemoConnector = (demo: string) =>
     method: "POST",
     body: JSON.stringify({ demo }),
   });
+export const bootstrapDemo = () =>
+  request<import("../types").DemoBootstrapResponse>("/api/demo/bootstrap", {
+    method: "POST",
+    body: JSON.stringify({ catalog_slug: "parallax" }),
+  });
+export const getDemoBootstrap = () =>
+  request<import("../types").DemoBootstrapResponse>(
+    "/api/demo/bootstrap?catalog_slug=parallax",
+  );
+export const authorizeDemoReplay = (conversationId: string, runId: string) =>
+  request<{ authorized: true; fixture_version: string }>(
+    `/api/demo/replay/${encodeURIComponent(conversationId)}/${encodeURIComponent(runId)}`,
+  );
+export const cleanupDemoTeam = () =>
+  request<{ demo: boolean; cleaned: boolean }>("/api/demo/cleanup", { method: "POST" });
 export const refreshConnectionSchema = (name: string) =>
   request<{
     connection_name: string;

--- a/signalpilot/web/lib/api/error-messages.test.ts
+++ b/signalpilot/web/lib/api/error-messages.test.ts
@@ -15,6 +15,16 @@ describe("userFacingErrorMessage", () => {
     expect(userFacingErrorMessage("boom", "fallback")).toBe("fallback");
   });
 
+  it("turns the atomic Demo Team limit into product copy", () => {
+    const error = new ApiRequestError(
+      429,
+      '{"code":"demo_request_limit","limit":5,"used":5}',
+    );
+    expect(userFacingErrorMessage(error, "fallback")).toBe(
+      "This Demo Team has used its 5 live requests.",
+    );
+  });
+
   it("silences the sandbox session-token rejection", () => {
     const error = new ApiRequestError(
       401,

--- a/signalpilot/web/lib/api/platform.ts
+++ b/signalpilot/web/lib/api/platform.ts
@@ -207,6 +207,8 @@ export interface PlanUsage {
     sso: boolean;
     budget_controls: boolean;
     audit_export: boolean;
+    projects: boolean;
+    notebook_sessions: boolean;
   };
 }
 export const getPlan = () => request<PlanUsage>("/api/plan");

--- a/signalpilot/web/lib/api/standalone-chat.ts
+++ b/signalpilot/web/lib/api/standalone-chat.ts
@@ -95,6 +95,9 @@ export type StandaloneChatBootstrap = {
     /** Connectors (external MCP servers) for the chat agent. */
     mcp_connectors?: boolean;
   };
+  demo_request_limit?: number | null;
+  demo_requests_used?: number;
+  demo_requests_remaining?: number | null;
 };
 
 export type StandaloneChatRun = {

--- a/signalpilot/web/lib/getting-started.test.ts
+++ b/signalpilot/web/lib/getting-started.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  canSelectStep,
+  deriveSetupStep,
+  hiddenForSessionKey,
+  normalizeGettingStarted,
+  routeCompletesTourStep,
+  shouldShowGettingStarted,
+} from "~/lib/getting-started";
+
+describe("getting started state", () => {
+  it("upgrades missing and malformed metadata to v2", () => {
+    expect(normalizeGettingStarted(undefined)).toMatchObject({
+      version: 2,
+      activeJourney: null,
+      demo: { replaySeen: false },
+      setup: { invitationSkipped: false },
+      tour: { status: "not_started", step: 0 },
+    });
+    expect(normalizeGettingStarted({ activeJourney: "setup", setup: { teamId: "org_1" }, tour: { step: 99 } }))
+      .toMatchObject({ activeJourney: "setup", setup: { teamId: "org_1" }, tour: { step: 5 } });
+  });
+
+  it("blocks future steps but keeps current and complete steps selectable", () => {
+    expect(canSelectStep(0, 2)).toBe(true);
+    expect(canSelectStep(2, 2)).toBe(true);
+    expect(canSelectStep(3, 2)).toBe(false);
+  });
+
+  it("completes only the expected tour route", () => {
+    expect(routeCompletesTourStep("/connections", 1)).toBe(true);
+    expect(routeCompletesTourStep("/connections/new", 1)).toBe(true);
+    expect(routeCompletesTourStep("/schema", 1)).toBe(false);
+  });
+
+  it("keys hiding to the Clerk session", () => {
+    expect(hiddenForSessionKey("sess_a")).not.toBe(hiddenForSessionKey("sess_b"));
+  });
+
+  it("does not surface an automatic controller for existing users", () => {
+    expect(shouldShowGettingStarted(false, null, false)).toBe(false);
+    expect(shouldShowGettingStarted(false, null, true)).toBe(true);
+    expect(shouldShowGettingStarted(false, "tour", false)).toBe(true);
+    expect(shouldShowGettingStarted(true, "setup", true)).toBe(false);
+  });
+
+  it("derives setup from Team resources instead of metadata counters", () => {
+    expect(deriveSetupStep({ teamMatches: true, hasProject: true, hasLinkedConnection: true, hasTeamKey: true, invitationSkipped: false, invitationCount: 0, memberCount: 1 })).toBe(4);
+    expect(deriveSetupStep({ teamMatches: true, hasProject: true, hasLinkedConnection: true, hasTeamKey: true, invitationSkipped: false, invitationCount: 1, memberCount: 1 })).toBe(5);
+    expect(deriveSetupStep({ teamMatches: true, hasProject: true, hasLinkedConnection: true, hasTeamKey: true, invitationSkipped: false, invitationCount: 0, memberCount: 2 })).toBe(5);
+  });
+});

--- a/signalpilot/web/lib/getting-started.ts
+++ b/signalpilot/web/lib/getting-started.ts
@@ -1,0 +1,100 @@
+export type GettingStartedJourney = "demo" | "setup" | "tour";
+export type TourStep = 0 | 1 | 2 | 3 | 4 | 5;
+
+export type SignalPilotGettingStarted = {
+  version: 2;
+  activeJourney: GettingStartedJourney | null;
+  demo: { teamId?: string; replaySeen: boolean };
+  setup: { teamId?: string; projectId?: string; invitationSkipped: boolean };
+  tour: { status: "not_started" | "active" | "complete"; step: TourStep };
+};
+
+export const DEFAULT_GETTING_STARTED: SignalPilotGettingStarted = {
+  version: 2,
+  activeJourney: null,
+  demo: { replaySeen: false },
+  setup: { invitationSkipped: false },
+  tour: { status: "not_started", step: 0 },
+};
+
+export const TOUR_STEPS = [
+  { title: "Chat Agent", href: "/chats", target: "chat-composer" },
+  { title: "Connections", href: "/connections", target: "connection-list" },
+  { title: "Schema", href: "/schema", target: "schema-browser" },
+  { title: "dbt lineage", href: "/lineage", target: "lineage-canvas" },
+  { title: "Knowledge base", href: "/knowledge", target: "knowledge-area" },
+  { title: "Team", href: "/settings/team", target: "team-members" },
+] as const;
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}
+
+export function normalizeGettingStarted(value: unknown): SignalPilotGettingStarted {
+  const root = record(value);
+  const demo = record(root.demo);
+  const setup = record(root.setup);
+  const tour = record(root.tour);
+  const journey = ["demo", "setup", "tour"].includes(String(root.activeJourney))
+    ? root.activeJourney as GettingStartedJourney
+    : null;
+  const rawStep = Number(tour.step);
+  const step = Math.max(0, Math.min(5, Number.isInteger(rawStep) ? rawStep : 0)) as TourStep;
+  const status = ["not_started", "active", "complete"].includes(String(tour.status))
+    ? tour.status as SignalPilotGettingStarted["tour"]["status"]
+    : "not_started";
+  return {
+    version: 2,
+    activeJourney: journey,
+    demo: {
+      ...(typeof demo.teamId === "string" ? { teamId: demo.teamId } : {}),
+      replaySeen: demo.replaySeen === true,
+    },
+    setup: {
+      ...(typeof setup.teamId === "string" ? { teamId: setup.teamId } : {}),
+      ...(typeof setup.projectId === "string" ? { projectId: setup.projectId } : {}),
+      invitationSkipped: setup.invitationSkipped === true,
+    },
+    tour: { status, step },
+  };
+}
+
+export function canSelectStep(index: number, current: number): boolean {
+  return index >= 0 && index <= current;
+}
+
+export function routeCompletesTourStep(pathname: string, step: TourStep): boolean {
+  const expected = TOUR_STEPS[step].href;
+  return pathname === expected || pathname.startsWith(`${expected}/`);
+}
+
+export function hiddenForSessionKey(sessionId: string): string {
+  return `signalpilot:getting-started:hidden:${sessionId}`;
+}
+
+export function shouldShowGettingStarted(
+  hidden: boolean,
+  activeJourney: GettingStartedJourney | null,
+  open: boolean,
+): boolean {
+  return !hidden && (activeJourney !== null || open);
+}
+
+export function deriveSetupStep(input: {
+  teamMatches: boolean;
+  hasProject: boolean;
+  hasLinkedConnection: boolean;
+  hasTeamKey: boolean;
+  invitationSkipped: boolean;
+  invitationCount: number;
+  memberCount: number;
+}): number {
+  if (!input.teamMatches) return 0;
+  if (!input.hasProject) return 1;
+  if (!input.hasLinkedConnection) return 2;
+  if (!input.hasTeamKey) return 3;
+  if (!input.invitationSkipped && input.invitationCount === 0 && input.memberCount <= 1) return 4;
+  return 5;
+}
+
+export const GETTING_STARTED_EVENT = "signalpilot:getting-started";

--- a/signalpilot/web/lib/types.ts
+++ b/signalpilot/web/lib/types.ts
@@ -235,6 +235,19 @@ export interface DemoConnectorCreated {
   repo_url: string | null;
 }
 
+export interface DemoBootstrapResponse {
+  status: "provisioning" | "ready";
+  phase: "private_data" | "project" | "opening";
+  created: boolean;
+  connection_name?: string;
+  project_id?: string;
+  conversation_id?: string;
+  replay_run_id?: string;
+  request_limit: 5;
+  requests_used: number;
+  requests_remaining: number;
+}
+
 export interface ProjectInfo {
   id: string;
   name: string;


### PR DESCRIPTION
## Outcome

Delivers **Phase 1 — Getting Started foundation and first complete vertical slice** of the onboarding roadmap. A first-time user can choose a private Parallax demo or connect production data, resume the journey from anywhere in the product, and continue into the initial Product Tour.

This branch starts from `main` at `88f11cf7` and contains one focused onboarding commit.

## Full onboarding plan

The product roadmap remains the three-journey flow documented in `plans/onboarding/OVERVIEW.md`:

1. **Entry and choice**
   - Start after authentication with the user's current Team/workspace context.
   - Ask one question: explore SignalPilot with demo data or connect production data.
   - Keep the choice reversible and make incomplete work resumable.

2. **Demo journey**
   - Create a personal Demo Team.
   - Fork the allowlisted Parallax Xata parent into a private writable branch.
   - Import the matching public dbt repository and wait for compiled metadata.
   - Open a versioned saved Chat Agent replay without consuming a live request.
   - Offer suggested live questions, enforce the demo allowance on the server, and route the user to the Product Tour or production setup.
   - Remove the demo project, private Xata branch, and connection before deleting the Demo Team.

3. **Production setup journey**
   - Use the active non-demo Team, or create a production Team when leaving a Demo Team.
   - Import a GitHub/dbt project.
   - Create or choose a warehouse connection, test it, verify compatibility, and link it to the imported project only after a healthy test.
   - Store Team-scoped Anthropic access.
   - Invite one technical teammate or explicitly skip the optional step.
   - Recompute readiness from real project, connection, dbt, and key state; then open Chat Agent with the project selected.

4. **Product Tour journey**
   - Reuse the persistent Getting Started controller across product routes.
   - Guide the user through asking a question, inspecting governed work, exploring schema/lineage and knowledge, and inviting a teammate.
   - Keep setup progress attached to the Team and tour progress attached to the user.
   - Allow collapse, resume, restart, and session-only dismissal.

5. **Acceptance and rollout**
   - Exercise Demo, Setup, fallback/resume, cleanup, and Product Tour in a configured cloud environment.
   - Verify Clerk Team transitions, Xata branch isolation, GitHub/dbt compilation, warehouse test-and-link behavior, Anthropic BYOK, request-limit concurrency, narrow-screen behavior, and deletion cleanup.
   - Configure `SP_DEMO_XATA_ORG` and `SP_DEMO_CATALOG`; keep `XATA_KEY` in deployment secrets only.
   - Resolve the remaining product choices: demo retention, feature surface, exact tour pages, and technical-invite role.

## Phase status

| Phase | Status | Scope |
| --- | --- | --- |
| Phase 0 — Product contract and clickable prototype | Complete on `main` | Three-journey UX, state ownership, warehouse auto-link contract, and shareable mockup. |
| **Phase 1 — Foundation and vertical slice** | **Implemented in this PR** | Persistent controller; Demo Team/bootstrap/replay/limit/cleanup; resumable setup; test-and-link; Team key/invite/readiness; initial tour; free-tier project entitlement split. |
| Phase 2 — Cloud acceptance and hardening | Not yet accepted | Live Clerk/Xata/GitHub/dbt/warehouse/BYOK flows, concurrency and cleanup failure drills, responsive/browser acceptance. |
| Phase 3 — Rollout and product completion | Planned | Deployment configuration, telemetry/operational monitoring, product-choice closure, staged release and production evidence. |

This PR is therefore **at Phase 1**. It provides local automated evidence, but it does not claim staging or production acceptance.

## What changed in this phase

- Added the global compact/drawer Getting Started controller with persisted Demo, Setup, and Tour state.
- Replaced the legacy cloud onboarding entry with the Demo vs Connect choice and added a Team-switcher re-entry point.
- Added an allowlisted, idempotent Parallax demo bootstrap that provisions private Xata data, imports the paired dbt project, and seeds an authorized Chat replay.
- Added an atomic server-side five-live-request Demo Team limit, remaining-usage UI, suggested questions, and upgrade/setup next actions.
- Preserved demo ownership tags and made project/branch/connection cleanup a prerequisite for Demo Team deletion.
- Reused production GitHub import, connection, Anthropic-key, invitation, and readiness surfaces inside the setup journey; the connection is linked only after a successful test.
- Added tour targets across Chat, connections, schema, lineage, knowledge, and Team screens.
- Made dbt projects/lineage available to Free Teams while retaining paid gating for user-managed notebook sessions; Free Teams allow the owner plus one teammate.

## Validation

- `uv run pytest tests/test_getting_started_policy.py tests/test_demo_connector_isolation.py -q` — 34 passed.
- `npm run test:unit -- --run lib/getting-started.test.ts lib/api/error-messages.test.ts components/chat/chat-message.test.tsx` — 20 passed.
- `npm run typecheck` — passed.
- `uv run ruff check <changed Python files>` — passed.
- `git diff --cached --check` — passed before commit.

## Deployment notes

- `XATA_KEY` is server-side only and must come from the deployment secret store.
- The checked-in catalog exposes only Parallax because it has the paired allowlisted dbt repository.
- Live cloud/browser acceptance remains the Phase 2 gate; local tests are not evidence that staging or production is ready.
