### PR TITLE
fix(gateway): commit the ignored tool_projection/dashboard.py (staging worker crash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,8 +98,8 @@ knowledge-base-spec.md
 local-instructions.md
 marimo-ref.md
 security-audit.md
-dashboard_products.py
-dashboard.py
+/dashboard_products.py
+/dashboard.py
 Dockerfile.web.dockerignore
 signalpilot/web/e2e-*.png
 signalpilot/web/e2e-journey-*.png

--- a/docs/docs/product/chat-files.mdx
+++ b/docs/docs/product/chat-files.mdx
@@ -1,0 +1,53 @@
+---
+sidebar_position: 6
+---
+
+# Files and charts in chat
+
+Every file the chat agent saves during a run is a conversation artifact. There
+is no publish step. The agent writes a PNG, a CSV, an HTML report, or a
+markdown document into its working directory, SignalPilot captures it from the
+sandbox, and the file appears in the **Artifacts** panel on the right of the
+chat while the run is still streaming.
+
+## What you see
+
+- **Inline images.** When the answer references a chart the agent saved, the
+  chart renders at that point in the answer with its caption. Click it to open
+  a full-size view, or use the hover actions to open it in the panel or
+  download it.
+- **File cards.** A link to a data file or a report renders as a small card
+  with the file name, its size, and a primary action: preview a CSV as a
+  table, open an HTML report in a sandboxed viewer, or download.
+- **The Files tab.** Every captured file for the conversation, newest change
+  first. A file the agent saves again under the same name replaces the earlier
+  version.
+
+Files that the answer does not reference still get a card under the run so
+nothing the agent produced is hidden.
+
+## How capture works
+
+The agent works in a per-conversation scratch directory inside its sandbox.
+After every tool call that can write to disk, the sandbox compares the
+directory with a snapshot, uploads what changed to SignalPilot, and records
+the change on the run. A final sweep runs when the run ends, so a file written
+by the last step is never lost.
+
+Captured files are stored in the workspace object store under the
+conversation and are removed with it. HTML files are sanitized and served
+with a strict content security policy. SVG files are never opened as a
+document.
+
+Limits, all configurable on the gateway:
+
+| Setting | Default |
+| --- | --- |
+| `SP_CHAT_FILE_MAX_BYTES` | 25 MB per file |
+| `SP_CHAT_CONVERSATION_FILE_QUOTA_BYTES` | 250 MB per conversation |
+| `SP_CHAT_CONVERSATION_FILE_QUOTA_COUNT` | 500 files per conversation |
+
+## Sharing
+
+A shared conversation link shows the same inline images and file cards to the
+reader. Forking a shared conversation copies its files into the fork.

--- a/docs/docs/product/dashboards.mdx
+++ b/docs/docs/product/dashboards.mdx
@@ -1,0 +1,134 @@
+---
+sidebar_position: 7
+---
+
+# Published dashboards
+
+A chat can save a dashboard as `artifacts/<name>.dashboard.json`. The
+**Artifacts** panel renders it in place. **Publish** turns that file into a
+team dashboard that lives on its own, independent of the conversation, and
+can refresh on a schedule.
+
+## A dataset is its SQL
+
+Every dataset in a dashboard file is one of two things:
+
+- **SQL**: `{"connection": "warehouse", "sql": "select ..."}`. The dataset
+  *is* the query. Its rows are whatever that SQL returns, so every
+  derivation lives in the SQL: window functions for trailing sums,
+  `CASE` for groupings, CTEs for shares and ranks. Nothing is shaped outside
+  the query.
+- **Static**: `{"rows": [...]}`. Constants that never change, such as
+  labels or targets. They stay inside the spec and are never refreshed.
+
+In the chat, the agent calls `sp.dashboard_dataset("monthly",
+connection=..., sql=...)` once per SQL dataset. That helper runs the query
+through the governed path and writes the **snapshot** at
+`artifacts/datasets/monthly.csv`. The snapshot is only the cached result of
+the SQL; it is what the Artifacts panel renders, and it is the only way a
+snapshot gets written. The sandbox checks flag a dataset whose snapshot is
+missing (`snapshot_missing`) or whose snapshot was produced by different SQL
+(`snapshot_stale`).
+
+## Publish from a chat
+
+Open the dashboard in the Artifacts panel and click **Publish**. Choose a
+name, who can see it, and a refresh schedule. The dialog lists each dataset
+as **SQL** (with its connection) or **Static**, and whether its snapshot
+was found at `artifacts/datasets/<name>.csv`.
+
+Before anything is stored, publish **verifies that the SQL reproduces the
+dashboard**. For every SQL dataset it runs the recorded query on its
+connection with a one-row limit, through the governed query path, and checks
+that the result has every column the charts and filters read from that
+dataset. This is one small query per dataset, at publish time.
+
+- If a query fails, publish is refused with `sql_failed` and the error text
+  per dataset.
+- If a result lacks a referenced column, publish is refused with
+  `not_repeatable` and the missing columns per dataset. This is the case
+  where a column was derived after the query, for example in pandas, so the
+  SQL alone could not rebuild the snapshot. Move the derivation into the SQL
+  and call `sp.dashboard_dataset` again. A query that returns no rows exposes
+  no columns and is refused the same way.
+
+Static datasets skip the check. When every SQL dataset passes, SignalPilot
+copies the spec and each snapshot into dashboard-owned storage and creates
+**version 1**. Publishing again from the same or another chat, with
+**Update existing** selected, adds a new version to the chosen dashboard.
+
+## The gallery
+
+**Dashboards** in the sidebar lists every dashboard you can see in your
+organization, newest change first. A dashboard is visible to you when its
+visibility is **Team**, or when you published it. Only the
+publisher and organization admins can edit, refresh, archive, or delete it.
+
+| Visibility | Who can open it |
+|---|---|
+| Private | The publisher, and organization admins through the API |
+| Team | Every signed-in member of the organization |
+
+## Versions
+
+Every publish, refresh, and restore creates an immutable version. The live
+version is the one the gallery shows and the one refreshes start from.
+**Restore** on an older version creates a new version with that version's
+content; nothing is ever overwritten. A refresh that fails validation never
+replaces the live version. The version drawer offers each SQL dataset's
+stored snapshot as a `<name>.csv` download.
+
+## Refresh
+
+Refresh is off by default. The schedule has three parts:
+
+- **Interval**: every 15 minutes, every hour, every 2, 4, 8, or 12 hours, or
+  daily.
+- **Aligned to**: a wall-clock time (`HH:MM`). Daily refreshes run at that
+  time. Shorter intervals run at that time plus whole multiples of the
+  interval, so "every 4 hours aligned to 06:00" runs at 02:00, 06:00, 10:00,
+  and so on.
+- **Timezone**: an IANA zone such as `America/New_York`. The schedule follows
+  local time through daylight-saving changes.
+
+The scheduler checks once a minute. If a refresh is still running when the
+next one is due, the new one is recorded as **skipped**. **Refresh now**
+starts one immediately and returns `409` while another is queued or running.
+
+### Refresh modes
+
+**SQL re-run** executes each SQL dataset's `sql` on its `connection`
+through the governed query path, with a 50 000 row limit and a 120 second
+timeout, and stores the rows as CSV. Static datasets are part of the spec
+and need nothing. No agent is involved, so this mode is fast and
+deterministic. Because publish already proved the SQL reproduces the
+columns, this is the normal mode.
+
+**Agent run** starts a chat run in the dashboard's project. The agent calls
+`sp.dashboard_dataset` for every SQL dataset with the exact connection and
+SQL from the spec, writes the dashboard file again unchanged, and checks
+every chart with `dashboard_sample_data`. When the run ends, SignalPilot
+reads the snapshots the run wrote and validates them. The run is refused if
+it changed a chart id, a dataset name, or a dataset's SQL. The run appears in
+the chat list, and the refresh history links to it.
+
+### Validation before swap
+
+In both modes, the new datasets are checked against every chart before they
+go live. The refresh **fails**, and the previous version stays live, when:
+
+- any SQL dataset errored or timed out,
+- any chart would fail to render (a referenced column is missing), or
+- a dataset that had rows before is empty now.
+
+The refresh history shows the outcome per dataset. With **Notify on
+failure** enabled, a failed refresh is written to the gateway log at
+`WARNING` and recorded on the refresh entry.
+
+## Edit in chat
+
+**Edit in chat** opens a new conversation in the dashboard's project. The
+first message carries the current spec. The agent writes it back to
+`artifacts/`, rebuilds each SQL dataset's snapshot with
+`sp.dashboard_dataset`, and iterates with you. Publish the result as a new
+version when you are done.

--- a/signalpilot/gateway/gateway/standalone_chat/tool_projection/dashboard.py
+++ b/signalpilot/gateway/gateway/standalone_chat/tool_projection/dashboard.py
@@ -1,0 +1,168 @@
+"""Projections for the dashboard sandbox tools.
+
+``dashboard_sample_data`` returns one JSON document; ``dashboard_screenshot``
+returns ``[image, text-JSON]`` content, of which only the text part reaches
+the projector. Both projections keep row previews small so the
+``tool_completed`` event stays well under ``PAYLOAD_MAX``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gateway.standalone_chat.tool_projection.base import ProjectedResult, build, text_result
+from gateway.standalone_chat.tool_projection.text import summary_text, try_json
+
+SAMPLE_ROWS_MAX = 5
+SAMPLE_COLUMNS_MAX = 40
+ISSUES_MAX = 10
+ISSUE_MESSAGE_MAX = 300
+CHART_IDS_MAX = 50
+
+
+def _payload(text: str) -> dict[str, Any] | None:
+    """Return the tool's JSON document, unwrapping a content-block list if present."""
+    parsed = try_json(text)
+    if isinstance(parsed, list):
+        for block in parsed:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                inner = try_json(block["text"])
+                if isinstance(inner, dict):
+                    return inner
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _dashboard_status(parsed: dict[str, Any]) -> tuple[bool, list[str]]:
+    dashboard = parsed.get("dashboard")
+    if not isinstance(dashboard, dict):
+        return True, []
+    errors = dashboard.get("errors")
+    errors_out = [str(error)[:ISSUE_MESSAGE_MAX] for error in errors[:ISSUES_MAX]] if isinstance(errors, list) else []
+    return bool(dashboard.get("valid", True)), errors_out
+
+
+def _issues(raw: Any) -> list[dict[str, str]]:
+    if not isinstance(raw, list):
+        return []
+    issues: list[dict[str, str]] = []
+    for issue in raw[:ISSUES_MAX]:
+        if isinstance(issue, dict):
+            issues.append(
+                {
+                    "code": str(issue.get("code") or "issue"),
+                    "message": str(issue.get("message") or "")[:ISSUE_MESSAGE_MAX],
+                }
+            )
+    return issues
+
+
+def _column_names(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    names: list[str] = []
+    for column in raw[:SAMPLE_COLUMNS_MAX]:
+        if isinstance(column, dict) and column.get("name") is not None:
+            names.append(str(column["name"]))
+        elif isinstance(column, str):
+            names.append(column)
+    return names
+
+
+def _plural(count: int, noun: str) -> str:
+    return f"{count} {noun}{'' if count == 1 else 's'}"
+
+
+def project_dashboard_sample(content: str, tool_input: dict[str, Any] | None) -> ProjectedResult:
+    text = content or ""
+    parsed = _payload(text)
+    if parsed is None:
+        return text_result(text, summary=summary_text(text, "Dashboard data"))
+    valid, errors = _dashboard_status(parsed)
+    charts_out: list[dict[str, Any]] = []
+    issue_total = 0
+    for chart in parsed.get("charts") or []:
+        if not isinstance(chart, dict):
+            continue
+        issues = _issues(chart.get("issues"))
+        raw_issue_count = chart.get("issues")
+        issue_count = len(raw_issue_count) if isinstance(raw_issue_count, list) else len(issues)
+        issue_total += issue_count
+        rows = chart.get("rows")
+        row_count = chart.get("row_count")
+        entry: dict[str, Any] = {
+            "id": str(chart.get("id") or ""),
+            "type": str(chart.get("type") or ""),
+            "row_count": row_count if isinstance(row_count, int) else 0,
+            "issue_count": issue_count,
+            "columns": _column_names(chart.get("columns")),
+            "rows": [row for row in rows[:SAMPLE_ROWS_MAX] if isinstance(row, dict)] if isinstance(rows, list) else [],
+            "issues": issues,
+        }
+        charts_out.append(entry)
+    result: dict[str, Any] = {
+        "kind": "dashboard_sample",
+        "dashboard_valid": valid,
+        "charts": charts_out,
+    }
+    if tool_input and isinstance(tool_input.get("path"), str):
+        result["path"] = tool_input["path"]
+    if errors:
+        result["errors"] = errors
+    if not valid:
+        summary = f"Dashboard spec invalid · {_plural(len(errors), 'error')}" if errors else "Dashboard spec invalid"
+    else:
+        issue_text = _plural(issue_total, "issue") if issue_total else "no issues"
+        summary = f"{_plural(len(charts_out), 'chart')} checked, {issue_text}"
+    return build(result, summary=summary, text=text)
+
+
+def project_dashboard_screenshot(content: str, tool_input: dict[str, Any] | None) -> ProjectedResult:
+    text = content or ""
+    parsed = _payload(text)
+    if parsed is None:
+        return text_result(text, summary=summary_text(text, "Dashboard screenshot"))
+    valid, errors = _dashboard_status(parsed)
+    rendered_raw = parsed.get("rendered")
+    rendered = [str(item) for item in rendered_raw[:CHART_IDS_MAX]] if isinstance(rendered_raw, list) else []
+    failed_raw = parsed.get("failed")
+    failed: list[dict[str, str]] = []
+    if isinstance(failed_raw, list):
+        for item in failed_raw[:CHART_IDS_MAX]:
+            if isinstance(item, dict):
+                failed.append(
+                    {
+                        "id": str(item.get("id") or ""),
+                        "code": str(item.get("code") or "failed"),
+                        "message": str(item.get("message") or "")[:ISSUE_MESSAGE_MAX],
+                    }
+                )
+            else:
+                failed.append({"id": str(item), "code": "failed", "message": ""})
+    result: dict[str, Any] = {
+        "kind": "dashboard_screenshot",
+        "dashboard_valid": valid,
+        "rendered": rendered,
+        "failed": failed,
+    }
+    for key in ("width", "height"):
+        value = parsed.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            result[key] = value
+    if isinstance(parsed.get("preview_path"), str):
+        result["preview_path"] = parsed["preview_path"]
+    if tool_input and isinstance(tool_input.get("path"), str):
+        result["path"] = tool_input["path"]
+    if errors:
+        result["errors"] = errors
+    error = parsed.get("error")
+    if isinstance(error, str) and error:
+        result["error"] = error[:ISSUE_MESSAGE_MAX]
+        summary = "Dashboard renderer unavailable" if error == "renderer_unavailable" else f"Dashboard render error · {error}"
+    elif not valid:
+        summary = f"Dashboard spec invalid · {_plural(len(errors), 'error')}" if errors else "Dashboard spec invalid"
+    else:
+        summary = f"Rendered {_plural(len(rendered), 'chart')}"
+        if failed:
+            summary += f", {len(failed)} failed"
+    return build(result, summary=summary, text=text)


### PR DESCRIPTION
The deployed staging chat worker exits 1 at import: `cannot import name 'dashboard' from partially initialized module gateway.standalone_chat.tool_projection`. Cause: a bare `dashboard.py` line in .gitignore matched `tool_projection/dashboard.py`, so PR #344 never carried the file. Every staging run since 21:47 UTC has stayed queued.

This adds the file, anchors the scratch patterns to the repo root, and adds the two product docs pages the sidebar references but the root `/docs/` rule hid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfZZecsk7TeJvfaLxD2d3g