### PR TITLE
feat(mcp): OAuth sign-in for the MCP server (Clerk as authorization server)

### DIFF
--- a/signalpilot/gateway/gateway/api/__init__.py
+++ b/signalpilot/gateway/gateway/api/__init__.py
@@ -36,6 +36,7 @@ from .notebook_files import router as notebook_files_router
 from .notebook_sessions import router as notebook_sessions_router
 from .notion import router as notion_router
 from .notion import webhook_router as notion_webhook_router
+from .oauth_metadata import router as oauth_metadata_router
 from .org_secrets import router as org_secrets_router
 from .projects import router as projects_router
 from .query import router as query_router
@@ -60,6 +61,7 @@ def register_routers(app: FastAPI) -> None:
     from .artifact_downloads import router as artifact_download_router
     app.include_router(artifact_download_router)
     app.include_router(health_router)
+    app.include_router(oauth_metadata_router)
     app.include_router(settings_router)
     app.include_router(connections_router)
     app.include_router(demo_router)

--- a/signalpilot/gateway/gateway/api/oauth_metadata.py
+++ b/signalpilot/gateway/gateway/api/oauth_metadata.py
@@ -1,0 +1,102 @@
+"""OAuth discovery documents for the gateway MCP endpoint.
+
+Served publicly (no credentials) so MCP clients can find the authorization
+server after a ``401`` from ``/mcp``:
+
+* ``/.well-known/oauth-protected-resource/mcp`` — RFC 9728 §3.1 path-suffixed
+  document for the ``/mcp`` resource (what the ``WWW-Authenticate`` challenge
+  points at).
+* ``/.well-known/oauth-protected-resource`` — root fallback probed by clients
+  that predate the path-suffixed form.
+* ``/.well-known/oauth-authorization-server`` and
+  ``/.well-known/openid-configuration`` — Clerk's authorization-server
+  metadata mirrored on this origin for clients that look it up on the MCP
+  host instead of following ``authorization_servers``.
+
+All routes answer ``404`` when OAuth is off (local mode / Clerk unset).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import JSONResponse
+
+from ..auth.mcp_oauth import clerk_frontend_api, oauth_enabled, protected_resource_metadata
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["oauth-metadata"])
+
+WELL_KNOWN_PREFIX = "/.well-known/"
+
+_AS_METADATA_TTL_SECONDS = 300.0
+_as_metadata_cache: dict[str, tuple[dict[str, Any], float]] = {}
+
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "mcp-protocol-version, content-type",
+    "Cache-Control": "public, max-age=300",
+}
+
+
+def _require_enabled() -> None:
+    if not oauth_enabled():
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+def _json(payload: dict[str, Any]) -> JSONResponse:
+    return JSONResponse(payload, headers=_CORS_HEADERS)
+
+
+@router.options("/.well-known/{rest:path}", include_in_schema=False)
+async def well_known_preflight(rest: str) -> Response:
+    _require_enabled()
+    return Response(status_code=204, headers=_CORS_HEADERS)
+
+
+@router.get("/.well-known/oauth-protected-resource/mcp", include_in_schema=False)
+@router.get("/.well-known/oauth-protected-resource", include_in_schema=False)
+async def protected_resource() -> JSONResponse:
+    """RFC 9728 protected-resource metadata pointing at Clerk."""
+    _require_enabled()
+    return _json(protected_resource_metadata())
+
+
+async def fetch_authorization_server_metadata(document: str) -> dict[str, Any]:
+    """Fetch (and briefly cache) Clerk's RFC 8414 / OIDC discovery document."""
+    issuer = clerk_frontend_api()
+    if not issuer:
+        raise HTTPException(status_code=404, detail="Not Found")
+    url = f"{issuer}/.well-known/{document}"
+    cached = _as_metadata_cache.get(url)
+    if cached and cached[1] > time.monotonic():
+        return cached[0]
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(url, headers={"Accept": "application/json"})
+    except httpx.HTTPError as exc:
+        logger.error("OAuth metadata: cannot reach %s: %s", url, exc)
+        raise HTTPException(status_code=503, detail="Authorization server metadata unavailable")
+    if resp.status_code != 200:
+        raise HTTPException(status_code=503, detail="Authorization server metadata unavailable")
+    payload = resp.json()
+    _as_metadata_cache[url] = (payload, time.monotonic() + _AS_METADATA_TTL_SECONDS)
+    return payload
+
+
+@router.get("/.well-known/oauth-authorization-server", include_in_schema=False)
+async def authorization_server() -> JSONResponse:
+    _require_enabled()
+    return _json(await fetch_authorization_server_metadata("oauth-authorization-server"))
+
+
+@router.get("/.well-known/openid-configuration", include_in_schema=False)
+async def openid_configuration() -> JSONResponse:
+    _require_enabled()
+    return _json(await fetch_authorization_server_metadata("openid-configuration"))

--- a/signalpilot/gateway/gateway/auth/mcp_api_key.py
+++ b/signalpilot/gateway/gateway/auth/mcp_api_key.py
@@ -239,6 +239,15 @@ class MCPAuthMiddleware:
 
         raw_bearer = _extract_bearer_key(scope)
         if raw_bearer and not raw_bearer.startswith("sp_"):
+            from . import mcp_oauth
+
+            # Clerk-issued OAuth access tokens (Claude.ai, Claude Code, Cursor
+            # signing in through the OAuth flow) take precedence over the
+            # gateway-minted notebook session JWT check below.
+            if mcp_oauth.oauth_enabled() and mcp_oauth.is_oauth_candidate(raw_bearer):
+                await self._authenticate_oauth(scope, receive, send, raw_bearer)
+                return
+
             from ..auth.notebook_jwt import NotebookSessionJWTError, verify_session_jwt
             from ..mcp.context import (
                 mcp_allowed_connection_var,
@@ -457,6 +466,36 @@ class MCPAuthMiddleware:
             await _send_503(send, "Authentication service unavailable. Please try again.")
 
 
+    async def _authenticate_oauth(
+        self, scope: dict[str, Any], receive: Callable, send: Callable, raw_token: str,
+    ) -> None:
+        """Verify a Clerk OAuth access token and run the MCP app as that principal."""
+        from . import mcp_oauth
+
+        try:
+            principal = await mcp_oauth.verify_oauth_token(raw_token)
+        except mcp_oauth.OAuthTokenError as exc:
+            if exc.status == 401:
+                client_ip = _extract_client_ip(scope)
+                if not _check_auth_rate(client_ip or "unknown"):
+                    await _send_429(send, "Too many authentication attempts. Try again later.")
+                    return
+            await mcp_oauth.send_oauth_error(send, exc)
+            return
+
+        from ..http import check_principal_rate_limit
+        from ..mcp import mcp_client_ip_var, mcp_user_agent_var
+
+        rate_error = check_principal_rate_limit(f"oauth:{principal.user_id}", principal.org_id)
+        if rate_error:
+            await _send_429(send, rate_error)
+            return
+        mcp_oauth.apply_principal(scope, principal, raw_token)
+        mcp_client_ip_var.set(_extract_client_ip(scope))
+        mcp_user_agent_var.set(_extract_user_agent(scope))
+        await self._app(scope, receive, send)
+
+
 def _extract_client_ip(scope: dict[str, Any]) -> str | None:
     """Extract the client IP from ASGI scope, respecting reverse-proxy headers."""
     headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
@@ -507,11 +546,24 @@ def _extract_api_key_header(scope: dict[str, Any]) -> str | None:
 
 
 async def _send_401(send: Callable, message: str) -> None:
-    """Send a minimal 401 JSON response through the ASGI send callable."""
-    await _send_json(send, 401, message)
+    """Send a 401 JSON response, with the OAuth discovery challenge when enabled.
+
+    RFC 9728 §5.1: the ``WWW-Authenticate`` header is how an MCP client learns
+    where the protected-resource metadata (and so the authorization server)
+    lives. Without it Claude.ai / Claude Code cannot start the sign-in flow.
+    """
+    from . import mcp_oauth
+
+    extra: list[tuple[bytes, bytes]] = []
+    if mcp_oauth.oauth_enabled():
+        challenge = mcp_oauth.www_authenticate("invalid_token", message)
+        extra.append((b"www-authenticate", challenge.encode()))
+    await _send_json(send, 401, message, extra)
 
 
-async def _send_json(send: Callable, status: int, message: str) -> None:
+async def _send_json(
+    send: Callable, status: int, message: str, extra_headers: list[tuple[bytes, bytes]] | None = None,
+) -> None:
     """Send a minimal ``{"detail": message}`` JSON response with ``status``."""
     body = json.dumps({"detail": message}).encode()
     await send(
@@ -521,6 +573,7 @@ async def _send_json(send: Callable, status: int, message: str) -> None:
             "headers": [
                 (b"content-type", b"application/json"),
                 (b"content-length", str(len(body)).encode()),
+                *(extra_headers or []),
             ],
         }
     )
@@ -535,43 +588,9 @@ async def _send_json(send: Callable, status: int, message: str) -> None:
 
 async def _send_429(send: Callable, message: str) -> None:
     """Send a minimal 429 JSON response through the ASGI send callable."""
-    body = json.dumps({"detail": message}).encode()
-    await send(
-        {
-            "type": "http.response.start",
-            "status": 429,
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"content-length", str(len(body)).encode()),
-            ],
-        }
-    )
-    await send(
-        {
-            "type": "http.response.body",
-            "body": body,
-            "more_body": False,
-        }
-    )
+    await _send_json(send, 429, message)
 
 
 async def _send_503(send: Callable, message: str) -> None:
     """Send a minimal 503 JSON response through the ASGI send callable."""
-    body = json.dumps({"detail": message}).encode()
-    await send(
-        {
-            "type": "http.response.start",
-            "status": 503,
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"content-length", str(len(body)).encode()),
-            ],
-        }
-    )
-    await send(
-        {
-            "type": "http.response.body",
-            "body": body,
-            "more_body": False,
-        }
-    )
+    await _send_json(send, 503, message)

--- a/signalpilot/gateway/gateway/auth/mcp_oauth.py
+++ b/signalpilot/gateway/gateway/auth/mcp_oauth.py
@@ -1,0 +1,405 @@
+"""OAuth 2.1 resource-server support for the gateway MCP endpoint.
+
+The gateway never issues tokens. Clerk is the authorization server; the
+gateway only (1) advertises RFC 9728 protected-resource metadata that points
+at Clerk, (2) answers unauthenticated ``/mcp`` requests with a
+``WWW-Authenticate`` challenge so MCP clients (Claude.ai, Claude Code,
+Cursor, MCP Inspector) can discover the authorization server, and
+(3) verifies the Clerk-issued access token on each request.
+
+Token verification order:
+
+* JWT access tokens (Clerk default): RS256 against the instance JWKS, issuer
+  pinned to the Clerk Frontend API, ``exp``/``iat``/``sub`` required, and the
+  ``aud`` claim checked against the canonical MCP resource URL (RFC 8707).
+* Opaque access tokens: introspected through the Clerk Backend API with the
+  instance secret key.
+
+Organization context comes from the ``org_id`` claim (granted by the
+``user:org:read`` scope, chosen on Clerk's consent screen). The caller's role
+inside that organization is resolved through the Clerk Backend API and mapped
+to gateway scopes, so an OAuth caller gets exactly what an API key minted by
+the same person would get.
+
+The inbound Clerk token is never forwarded anywhere (MCP token-passthrough
+prohibition); tools keep minting their own internal credentials.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import jwt
+
+from ..config import get_mcp_settings
+from ..config.gateway import get_gateway_settings
+from ..models.api_keys import VALID_API_KEY_SCOPES
+from ..runtime.mode import is_cloud_mode
+
+logger = logging.getLogger(__name__)
+
+CLERK_API_BASE = "https://api.clerk.com/v1"
+
+# Scopes the gateway asks Clerk for. ``user:org:read`` is what makes Clerk show
+# the organization selector on consent and stamp ``org_id`` into the token.
+OAUTH_SCOPES: tuple[str, ...] = ("openid", "profile", "email", "user:org:read")
+
+# Gateway scopes granted to an OAuth caller by organization role.
+MEMBER_SCOPES: tuple[str, ...] = tuple(sorted(VALID_API_KEY_SCOPES - {"admin"}))
+ADMIN_SCOPES: tuple[str, ...] = tuple(sorted(VALID_API_KEY_SCOPES))
+
+_MEMBERSHIP_CACHE_TTL_SECONDS = 300.0
+_INTROSPECTION_CACHE_TTL_SECONDS = 60.0
+
+
+class OAuthTokenError(Exception):
+    """A bearer token that must be answered with an RFC 6750 challenge."""
+
+    def __init__(
+        self,
+        error: str,
+        description: str,
+        *,
+        status: int = 401,
+        scope: str | None = None,
+    ) -> None:
+        super().__init__(description)
+        self.error = error
+        self.description = description
+        self.status = status
+        self.scope = scope
+
+
+@dataclass
+class OAuthPrincipal:
+    """The identity a verified Clerk OAuth access token represents."""
+
+    user_id: str
+    org_id: str
+    org_role: str
+    scopes: list[str]
+    client_id: str | None
+    expires_at: int | None
+    claims: dict[str, Any] = field(default_factory=dict)
+
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+
+def clerk_frontend_api() -> str | None:
+    """Return the Clerk Frontend API origin derived from the publishable key."""
+    pk = os.environ.get("CLERK_PUBLISHABLE_KEY", "")
+    for prefix in ("pk_test_", "pk_live_"):
+        if pk.startswith(prefix):
+            encoded = pk[len(prefix):]
+            padded = encoded + "=" * (-len(encoded) % 4)
+            try:
+                domain = base64.b64decode(padded).decode("utf-8").rstrip("$")
+            except (ValueError, UnicodeDecodeError):
+                return None
+            return f"https://{domain}" if domain else None
+    return None
+
+
+def oauth_enabled() -> bool:
+    """OAuth is on in cloud mode whenever Clerk is configured and not disabled."""
+    if not is_cloud_mode():
+        return False
+    if get_mcp_settings().sp_mcp_oauth_disabled:
+        return False
+    return clerk_frontend_api() is not None
+
+
+def resource_url() -> str:
+    """Canonical MCP resource identifier (RFC 8707): the public ``/mcp`` URL."""
+    override = get_mcp_settings().sp_mcp_oauth_resource_url.strip()
+    if override:
+        return override.rstrip("/")
+    return get_gateway_settings().sp_public_gateway_url.rstrip("/") + "/mcp"
+
+
+def _resource_origin_and_path() -> tuple[str, str]:
+    url = resource_url()
+    scheme, _, rest = url.partition("://")
+    host, slash, path = rest.partition("/")
+    return f"{scheme}://{host}", (slash + path if path else "")
+
+
+def resource_metadata_url() -> str:
+    """RFC 9728 §3.1 path-suffixed metadata URL for the MCP resource."""
+    origin, path = _resource_origin_and_path()
+    return f"{origin}/.well-known/oauth-protected-resource{path}"
+
+
+def protected_resource_metadata() -> dict[str, Any]:
+    """The RFC 9728 document served under ``/.well-known/oauth-protected-resource``."""
+    issuer = clerk_frontend_api() or ""
+    return {
+        "resource": resource_url(),
+        "authorization_servers": [issuer] if issuer else [],
+        "scopes_supported": list(OAUTH_SCOPES),
+        "bearer_methods_supported": ["header"],
+        "resource_name": "SignalPilot MCP",
+    }
+
+
+def www_authenticate(
+    error: str = "invalid_token",
+    description: str = "Authentication required",
+    scope: str | None = None,
+) -> str:
+    """Build the RFC 6750 / RFC 9728 ``WWW-Authenticate`` challenge value."""
+    parts = [f'error="{error}"', f'error_description="{_quote(description)}"']
+    parts.append(f'resource_metadata="{resource_metadata_url()}"')
+    parts.append(f'scope="{scope or " ".join(OAUTH_SCOPES)}"')
+    return "Bearer " + ", ".join(parts)
+
+
+def _quote(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', "'")
+
+
+# ─── Token classification ───────────────────────────────────────────────────
+
+
+def is_oauth_candidate(token: str) -> bool:
+    """Decide whether a non-``sp_`` bearer token should take the OAuth path.
+
+    A JWT whose unverified ``iss`` is the Clerk Frontend API is a Clerk OAuth
+    (or session) token. Anything that is not a JWT at all is treated as an
+    opaque Clerk access token. Gateway-minted notebook session JWTs carry
+    their own issuer and are left to the notebook verifier.
+    """
+    issuer = clerk_frontend_api()
+    if not issuer:
+        return False
+    if token.count(".") != 2:
+        return True
+    try:
+        claims = jwt.decode(token, options={"verify_signature": False})
+    except jwt.InvalidTokenError:
+        return False
+    return claims.get("iss") == issuer
+
+
+# ─── Verification ────────────────────────────────────────────────────────────
+
+
+def _audience_matches(aud: Any) -> bool:
+    if aud is None:
+        return False
+    values = aud if isinstance(aud, list) else [aud]
+    target = resource_url()
+    return any(isinstance(v, str) and v.rstrip("/") == target for v in values)
+
+
+def _org_id_from_claims(claims: dict[str, Any]) -> str | None:
+    org_id = claims.get("org_id")
+    if org_id:
+        return str(org_id)
+    o_claim = claims.get("o")
+    if isinstance(o_claim, dict):
+        return o_claim.get("id") or None
+    if isinstance(o_claim, str):
+        return o_claim or None
+    return None
+
+
+def _decode_jwt(token: str) -> dict[str, Any]:
+    from .user import _get_jwks_client
+
+    issuer = clerk_frontend_api()
+    client = _get_jwks_client()
+    if client is None or issuer is None:
+        raise OAuthTokenError("invalid_token", "OAuth is not configured", status=503)
+    try:
+        signing_key = client.get_signing_key_from_jwt(token)
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            issuer=issuer,
+            leeway=30,
+            options={"require": ["exp", "iat", "sub"], "verify_aud": False},
+        )
+    except jwt.PyJWKClientError as exc:
+        logger.error("MCP OAuth: JWKS unavailable: %s", exc)
+        raise OAuthTokenError("invalid_token", "Authentication service unavailable", status=503)
+    except jwt.ExpiredSignatureError:
+        raise OAuthTokenError("invalid_token", "The access token has expired")
+    except jwt.InvalidTokenError as exc:
+        logger.warning("MCP OAuth: JWT rejected: %s", exc)
+        raise OAuthTokenError("invalid_token", "The access token is invalid")
+
+
+_introspection_cache: dict[str, tuple[dict[str, Any], float]] = {}
+
+
+async def _introspect_opaque(token: str) -> dict[str, Any]:
+    """Verify an opaque Clerk access token through the Backend API."""
+    cached = _introspection_cache.get(token)
+    if cached and cached[1] > time.monotonic():
+        return cached[0]
+    secret = os.environ.get("CLERK_SECRET_KEY", "")
+    if not secret:
+        raise OAuthTokenError("invalid_token", "Opaque tokens are not supported", status=503)
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{CLERK_API_BASE}/oauth_applications/access_tokens/verify",
+                headers={"Authorization": f"Bearer {secret}"},
+                json={"access_token": token},
+            )
+    except httpx.HTTPError as exc:
+        logger.error("MCP OAuth: introspection failed: %s", exc)
+        raise OAuthTokenError("invalid_token", "Authentication service unavailable", status=503)
+    if resp.status_code != 200:
+        raise OAuthTokenError("invalid_token", "The access token is invalid")
+    data = resp.json()
+    if data.get("active") is False or data.get("revoked") or not data.get("subject") and not data.get("sub"):
+        raise OAuthTokenError("invalid_token", "The access token is invalid")
+    claims = {
+        "sub": data.get("subject") or data.get("sub"),
+        "scope": " ".join(data.get("scopes") or []) if isinstance(data.get("scopes"), list) else data.get("scope", ""),
+        "exp": data.get("expires_at") or data.get("exp"),
+        "org_id": data.get("org_id") or data.get("organization_id"),
+        "azp": data.get("client_id"),
+        "iss": clerk_frontend_api(),
+    }
+    _introspection_cache[token] = (claims, time.monotonic() + _INTROSPECTION_CACHE_TTL_SECONDS)
+    if len(_introspection_cache) > 512:
+        _introspection_cache.pop(next(iter(_introspection_cache)))
+    return claims
+
+
+_membership_cache: dict[tuple[str, str], tuple[str, float]] = {}
+
+
+async def resolve_org_role(user_id: str, org_id: str) -> str:
+    """Look up the caller's role in ``org_id`` via the Clerk Backend API."""
+    key = (user_id, org_id)
+    cached = _membership_cache.get(key)
+    if cached and cached[1] > time.monotonic():
+        return cached[0]
+    secret = os.environ.get("CLERK_SECRET_KEY", "")
+    if not secret:
+        raise OAuthTokenError("invalid_token", "Organization lookup is not configured", status=503)
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{CLERK_API_BASE}/organizations/{org_id}/memberships",
+                headers={"Authorization": f"Bearer {secret}"},
+                params={"user_id": user_id, "limit": 1},
+            )
+    except httpx.HTTPError as exc:
+        logger.error("MCP OAuth: membership lookup failed: %s", exc)
+        raise OAuthTokenError("invalid_token", "Authentication service unavailable", status=503)
+    if resp.status_code != 200:
+        logger.warning("MCP OAuth: membership lookup HTTP %s for org %s", resp.status_code, org_id)
+        raise OAuthTokenError("insufficient_scope", "You are not a member of this organization", status=403)
+    rows = resp.json().get("data") or []
+    row = next((r for r in rows if (r.get("public_user_data") or {}).get("user_id") == user_id), None)
+    if row is None:
+        raise OAuthTokenError("insufficient_scope", "You are not a member of this organization", status=403)
+    role = str(row.get("role") or "org:member")
+    _membership_cache[key] = (role, time.monotonic() + _MEMBERSHIP_CACHE_TTL_SECONDS)
+    if len(_membership_cache) > 4096:
+        _membership_cache.pop(next(iter(_membership_cache)))
+    return role
+
+
+def scopes_for_role(role: str) -> list[str]:
+    return list(ADMIN_SCOPES if role in ("admin", "org:admin") else MEMBER_SCOPES)
+
+
+async def verify_oauth_token(token: str) -> OAuthPrincipal:
+    """Verify a Clerk OAuth access token and resolve its organization principal."""
+    claims = _decode_jwt(token) if token.count(".") == 2 else await _introspect_opaque(token)
+
+    user_id = claims.get("sub")
+    if not user_id:
+        raise OAuthTokenError("invalid_token", "The access token has no subject")
+
+    aud = claims.get("aud")
+    if aud is not None and not _audience_matches(aud):
+        logger.warning("MCP OAuth: audience %r does not match %s", aud, resource_url())
+        raise OAuthTokenError("invalid_token", "The access token was issued for another resource")
+    if aud is None and get_mcp_settings().sp_mcp_oauth_require_audience:
+        raise OAuthTokenError("invalid_token", "The access token has no audience")
+
+    org_id = _org_id_from_claims(claims)
+    if not org_id:
+        raise OAuthTokenError(
+            "insufficient_scope",
+            "Select an organization when you authorize SignalPilot",
+            status=403,
+            scope="user:org:read",
+        )
+
+    role = await resolve_org_role(str(user_id), org_id)
+    exp = claims.get("exp")
+    return OAuthPrincipal(
+        user_id=str(user_id),
+        org_id=org_id,
+        org_role=role,
+        scopes=scopes_for_role(role),
+        client_id=claims.get("azp") or claims.get("client_id"),
+        expires_at=int(exp) if isinstance(exp, (int, float)) else None,
+        claims=dict(claims),
+    )
+
+
+# ─── ASGI helpers used by MCPAuthMiddleware ──────────────────────────────────
+
+
+def apply_principal(scope: dict[str, Any], principal: OAuthPrincipal, raw_token: str) -> None:
+    """Populate ``scope["state"]["auth"]`` and the MCP context variables."""
+    from ..mcp import context as ctx
+
+    if "state" not in scope:
+        scope["state"] = {}
+    scope["state"]["auth"] = {
+        "auth_method": "oauth",
+        "user_id": principal.user_id,
+        "org_id": principal.org_id,
+        "org_role": principal.org_role,
+        "client_id": principal.client_id,
+        "scopes": list(principal.scopes),
+    }
+    ctx.mcp_user_id_var.set(principal.user_id)
+    ctx.mcp_org_id_var.set(principal.org_id)
+    ctx.mcp_raw_key_var.set(raw_token)
+    ctx.mcp_scopes_var.set(list(principal.scopes))
+    for var in (
+        ctx.mcp_allowed_connection_var,
+        ctx.mcp_capabilities_var,
+        ctx.mcp_execution_identity_var,
+        ctx.mcp_project_id_var,
+        ctx.mcp_branch_var,
+        ctx.mcp_eval_doc_ids_var,
+        ctx.mcp_eval_connection_var,
+        ctx.mcp_eval_run_var,
+        ctx.mcp_eval_task_var,
+    ):
+        var.set(None)
+
+
+async def send_oauth_error(send: Callable, exc: OAuthTokenError) -> None:
+    """Send an RFC 6750 error response with the discovery challenge attached."""
+    body = json.dumps({"error": exc.error, "error_description": exc.description, "detail": exc.description}).encode()
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    if exc.status in (401, 403):
+        headers.append((b"www-authenticate", www_authenticate(exc.error, exc.description, exc.scope).encode()))
+    await send({"type": "http.response.start", "status": exc.status, "headers": headers})
+    await send({"type": "http.response.body", "body": body, "more_body": False})

--- a/signalpilot/gateway/gateway/config/mcp.py
+++ b/signalpilot/gateway/gateway/config/mcp.py
@@ -4,7 +4,8 @@ Cached because no test monkeypatches these vars after import.
 If you add an env var here, audit tests/ for monkeypatch.setenv("YOUR_VAR")
 before adding — if any test touches it, keep it as os.getenv (Class B).
 
-Class A vars managed here: SP_MCP_ALLOWED_HOSTS
+Class A vars managed here: SP_MCP_ALLOWED_HOSTS, SP_MCP_OAUTH_DISABLED,
+SP_MCP_OAUTH_RESOURCE_URL, SP_MCP_OAUTH_REQUIRE_AUDIENCE
 
 Note: sp_mcp_allowed_hosts is a raw CSV string. The downstream parse in mcp/server.py
 does the split/strip/extend — this module does not duplicate that logic, so the
@@ -24,6 +25,15 @@ class McpSettings(_GatewaySettingsBase):
     """Typed MCP configuration read from process environment at instantiation."""
 
     sp_mcp_allowed_hosts: str = Field("", alias="SP_MCP_ALLOWED_HOSTS")
+    # OAuth resource-server behaviour for /mcp (cloud mode, Clerk as the AS).
+    # Set SP_MCP_OAUTH_DISABLED=true to fall back to API-key-only auth.
+    sp_mcp_oauth_disabled: bool = Field(False, alias="SP_MCP_OAUTH_DISABLED")
+    # Canonical RFC 8707 resource identifier. Defaults to
+    # ``{SP_PUBLIC_GATEWAY_URL}/mcp``; override when the MCP host differs.
+    sp_mcp_oauth_resource_url: str = Field("", alias="SP_MCP_OAUTH_RESOURCE_URL")
+    # Reject access tokens that carry no ``aud`` claim at all. Tokens with an
+    # ``aud`` are always checked against the resource URL.
+    sp_mcp_oauth_require_audience: bool = Field(True, alias="SP_MCP_OAUTH_REQUIRE_AUDIENCE")
 
 
 @lru_cache(maxsize=1)

--- a/signalpilot/gateway/gateway/http/middleware/auth.py
+++ b/signalpilot/gateway/gateway/http/middleware/auth.py
@@ -82,6 +82,11 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
         if request.url.path in PUBLIC_PATHS:
             return await call_next(request)
 
+        # OAuth discovery documents (RFC 9728 / RFC 8414) must be readable
+        # before a client has any credential.
+        if request.url.path.startswith("/.well-known/"):
+            return await call_next(request)
+
         # MCP endpoints have their own auth (MCPAuthMiddleware): skip
         if request.url.path.startswith("/mcp"):
             return await call_next(request)

--- a/signalpilot/gateway/tests/test_mcp_oauth.py
+++ b/signalpilot/gateway/tests/test_mcp_oauth.py
@@ -1,0 +1,414 @@
+"""Tests for the Clerk OAuth resource-server path on /mcp.
+
+Covers: discovery documents, the WWW-Authenticate challenge, JWT verification
+(issuer / audience / expiry / org), role→scope mapping, and the middleware
+branch that runs the MCP app as the OAuth principal.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from gateway.auth import mcp_oauth
+from gateway.auth.mcp_api_key import MCPAuthMiddleware
+
+FRONTEND_DOMAIN = "endless-fly-19.clerk.accounts.dev"
+ISSUER = f"https://{FRONTEND_DOMAIN}"
+PUBLIC_URL = "https://gw.example.test"
+RESOURCE = f"{PUBLIC_URL}/mcp"
+
+
+def _publishable_key() -> str:
+    return "pk_test_" + base64.b64encode(f"{FRONTEND_DOMAIN}$".encode()).decode().rstrip("=")
+
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PUBLIC_PEM = _PRIVATE_KEY.public_key().public_bytes(
+    serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+)
+
+
+def _mint(**overrides: Any) -> str:
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "iss": ISSUER,
+        "sub": "user_123",
+        "aud": RESOURCE,
+        "exp": now + 3600,
+        "iat": now,
+        "azp": "client_abc",
+        "scope": "openid profile email user:org:read",
+        "org_id": "org_456",
+    }
+    for key, value in overrides.items():
+        if value is None:
+            claims.pop(key, None)
+        else:
+            claims[key] = value
+    return jwt.encode(claims, _PRIVATE_KEY, algorithm="RS256", headers={"kid": "k1"})
+
+
+@pytest.fixture
+def oauth_env(monkeypatch):
+    monkeypatch.setenv("SP_DEPLOYMENT_MODE", "cloud")
+    monkeypatch.setenv("CLERK_PUBLISHABLE_KEY", _publishable_key())
+    monkeypatch.setenv("CLERK_SECRET_KEY", "sk_test_dummy")
+    monkeypatch.setenv("SP_SESSION_JWT_SECRET", "unit-test-session-secret-unit-test-session-secret")
+    monkeypatch.setenv("SP_PUBLIC_GATEWAY_URL", PUBLIC_URL)
+    monkeypatch.delenv("SP_MCP_OAUTH_RESOURCE_URL", raising=False)
+    monkeypatch.delenv("SP_MCP_OAUTH_DISABLED", raising=False)
+    from gateway.config import get_mcp_settings
+    from gateway.config.gateway import get_gateway_settings
+
+    get_mcp_settings.cache_clear()
+    get_gateway_settings.cache_clear()
+    mcp_oauth._membership_cache.clear()
+    mcp_oauth._introspection_cache.clear()
+
+    signing_key = MagicMock()
+    signing_key.key = _PUBLIC_PEM
+    jwks_client = MagicMock()
+    jwks_client.get_signing_key_from_jwt.return_value = signing_key
+    with patch("gateway.auth.user._get_jwks_client", return_value=jwks_client):
+        yield
+    get_mcp_settings.cache_clear()
+    get_gateway_settings.cache_clear()
+
+
+def _membership_response(role: str = "org:member", user_id: str = "user_123") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"data": [{"role": role, "public_user_data": {"user_id": user_id}}]}
+    return resp
+
+
+def _patch_clerk_get(resp: MagicMock):
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return patch("gateway.auth.mcp_oauth.httpx.AsyncClient", return_value=client)
+
+
+# ─── Configuration / discovery ───────────────────────────────────────────────
+
+
+class TestDiscovery:
+    def test_enabled_only_in_cloud_mode_with_clerk(self, oauth_env, monkeypatch):
+        assert mcp_oauth.oauth_enabled() is True
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        assert mcp_oauth.oauth_enabled() is False
+
+    def test_disabled_flag_turns_oauth_off(self, oauth_env, monkeypatch):
+        from gateway.config import get_mcp_settings
+
+        monkeypatch.setenv("SP_MCP_OAUTH_DISABLED", "true")
+        get_mcp_settings.cache_clear()
+        assert mcp_oauth.oauth_enabled() is False
+
+    def test_resource_and_metadata_urls_follow_public_gateway_url(self, oauth_env):
+        assert mcp_oauth.resource_url() == RESOURCE
+        assert mcp_oauth.resource_metadata_url() == f"{PUBLIC_URL}/.well-known/oauth-protected-resource/mcp"
+
+    def test_resource_url_override(self, oauth_env, monkeypatch):
+        from gateway.config import get_mcp_settings
+
+        monkeypatch.setenv("SP_MCP_OAUTH_RESOURCE_URL", "https://mcp.other.test/mcp/")
+        get_mcp_settings.cache_clear()
+        assert mcp_oauth.resource_url() == "https://mcp.other.test/mcp"
+
+    def test_protected_resource_metadata_points_at_clerk(self, oauth_env):
+        doc = mcp_oauth.protected_resource_metadata()
+        assert doc["resource"] == RESOURCE
+        assert doc["authorization_servers"] == [ISSUER]
+        assert "user:org:read" in doc["scopes_supported"]
+        assert doc["bearer_methods_supported"] == ["header"]
+
+    def test_www_authenticate_has_resource_metadata_and_scope(self, oauth_env):
+        header = mcp_oauth.www_authenticate("invalid_token", 'Bad "token"')
+        assert header.startswith("Bearer ")
+        assert 'error="invalid_token"' in header
+        assert f'resource_metadata="{PUBLIC_URL}/.well-known/oauth-protected-resource/mcp"' in header
+        assert 'scope="openid profile email user:org:read"' in header
+        assert '"token"' not in header  # quotes inside the description are neutralised
+
+    def test_well_known_routes(self, oauth_env):
+        from gateway.api.oauth_metadata import router
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        for path in ("/.well-known/oauth-protected-resource/mcp", "/.well-known/oauth-protected-resource"):
+            resp = client.get(path)
+            assert resp.status_code == 200, path
+            assert resp.json()["resource"] == RESOURCE
+            assert resp.headers["access-control-allow-origin"] == "*"
+
+        as_doc = {"issuer": ISSUER, "authorization_endpoint": f"{ISSUER}/oauth/authorize"}
+        with patch(
+            "gateway.api.oauth_metadata.fetch_authorization_server_metadata",
+            new=AsyncMock(return_value=as_doc),
+        ):
+            resp = client.get("/.well-known/oauth-authorization-server")
+        assert resp.status_code == 200
+        assert resp.json()["issuer"] == ISSUER
+
+        assert client.options("/.well-known/oauth-protected-resource").status_code == 204
+
+    def test_well_known_routes_404_when_disabled(self, oauth_env, monkeypatch):
+        from gateway.api.oauth_metadata import router
+
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+        app = FastAPI()
+        app.include_router(router)
+        assert TestClient(app).get("/.well-known/oauth-protected-resource").status_code == 404
+
+
+# ─── Token classification ───────────────────────────────────────────────────
+
+
+class TestCandidate:
+    def test_clerk_jwt_is_candidate(self, oauth_env):
+        assert mcp_oauth.is_oauth_candidate(_mint()) is True
+
+    def test_notebook_session_jwt_is_not_candidate(self, oauth_env):
+        token = jwt.encode({"iss": "signalpilot-notebook-session", "sub": "u"}, "secret", algorithm="HS256")
+        assert mcp_oauth.is_oauth_candidate(token) is False
+
+    def test_opaque_token_is_candidate(self, oauth_env):
+        assert mcp_oauth.is_oauth_candidate("oat_abcdef0123456789") is True
+
+    def test_garbage_jwt_is_not_candidate(self, oauth_env):
+        assert mcp_oauth.is_oauth_candidate("a.b.c") is False
+
+
+# ─── Verification ────────────────────────────────────────────────────────────
+
+
+class TestVerify:
+    @pytest.mark.asyncio
+    async def test_valid_member_token(self, oauth_env):
+        with _patch_clerk_get(_membership_response("org:member")):
+            principal = await mcp_oauth.verify_oauth_token(_mint())
+        assert principal.user_id == "user_123"
+        assert principal.org_id == "org_456"
+        assert principal.org_role == "org:member"
+        assert principal.client_id == "client_abc"
+        assert "admin" not in principal.scopes
+        assert {"read", "query", "execute", "write"} <= set(principal.scopes)
+
+    @pytest.mark.asyncio
+    async def test_admin_role_gets_admin_scope(self, oauth_env):
+        with _patch_clerk_get(_membership_response("org:admin")):
+            principal = await mcp_oauth.verify_oauth_token(_mint())
+        assert "admin" in principal.scopes
+
+    @pytest.mark.asyncio
+    async def test_membership_is_cached(self, oauth_env):
+        patcher = _patch_clerk_get(_membership_response())
+        with patcher as client_cls:
+            await mcp_oauth.verify_oauth_token(_mint())
+            await mcp_oauth.verify_oauth_token(_mint())
+        assert client_cls.return_value.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_wrong_audience_rejected(self, oauth_env):
+        with pytest.raises(mcp_oauth.OAuthTokenError) as exc:
+            await mcp_oauth.verify_oauth_token(_mint(aud="https://evil.test/mcp"))
+        assert exc.value.status == 401
+        assert exc.value.error == "invalid_token"
+
+    @pytest.mark.asyncio
+    async def test_audience_list_and_trailing_slash_accepted(self, oauth_env):
+        with _patch_clerk_get(_membership_response()):
+            principal = await mcp_oauth.verify_oauth_token(_mint(aud=["other", RESOURCE + "/"]))
+        assert principal.org_id == "org_456"
+
+    @pytest.mark.asyncio
+    async def test_missing_audience_rejected_by_default(self, oauth_env):
+        with pytest.raises(mcp_oauth.OAuthTokenError):
+            await mcp_oauth.verify_oauth_token(_mint(aud=None))
+
+    @pytest.mark.asyncio
+    async def test_missing_audience_allowed_when_configured(self, oauth_env, monkeypatch):
+        from gateway.config import get_mcp_settings
+
+        monkeypatch.setenv("SP_MCP_OAUTH_REQUIRE_AUDIENCE", "false")
+        get_mcp_settings.cache_clear()
+        with _patch_clerk_get(_membership_response()):
+            principal = await mcp_oauth.verify_oauth_token(_mint(aud=None))
+        assert principal.user_id == "user_123"
+
+    @pytest.mark.asyncio
+    async def test_wrong_issuer_rejected(self, oauth_env):
+        with pytest.raises(mcp_oauth.OAuthTokenError):
+            await mcp_oauth.verify_oauth_token(_mint(iss="https://other.clerk.accounts.dev"))
+
+    @pytest.mark.asyncio
+    async def test_expired_rejected(self, oauth_env):
+        with pytest.raises(mcp_oauth.OAuthTokenError) as exc:
+            await mcp_oauth.verify_oauth_token(_mint(exp=int(time.time()) - 600))
+        assert "expired" in exc.value.description
+
+    @pytest.mark.asyncio
+    async def test_missing_org_is_insufficient_scope_403(self, oauth_env):
+        with pytest.raises(mcp_oauth.OAuthTokenError) as exc:
+            await mcp_oauth.verify_oauth_token(_mint(org_id=None))
+        assert exc.value.status == 403
+        assert exc.value.error == "insufficient_scope"
+        assert exc.value.scope == "user:org:read"
+
+    @pytest.mark.asyncio
+    async def test_prod_short_org_claim_supported(self, oauth_env):
+        with _patch_clerk_get(_membership_response()):
+            principal = await mcp_oauth.verify_oauth_token(_mint(org_id=None, o={"id": "org_456", "rol": "admin"}))
+        assert principal.org_id == "org_456"
+
+    @pytest.mark.asyncio
+    async def test_non_member_rejected(self, oauth_env):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": []}
+        with _patch_clerk_get(resp), pytest.raises(mcp_oauth.OAuthTokenError) as exc:
+            await mcp_oauth.verify_oauth_token(_mint())
+        assert exc.value.status == 403
+
+    @pytest.mark.asyncio
+    async def test_hs256_token_rejected(self, oauth_env):
+        token = jwt.encode(
+            {"iss": ISSUER, "sub": "u", "aud": RESOURCE, "exp": int(time.time()) + 60, "iat": int(time.time())},
+            "secret",
+            algorithm="HS256",
+        )
+        with pytest.raises(mcp_oauth.OAuthTokenError):
+            await mcp_oauth.verify_oauth_token(token)
+
+
+# ─── Middleware integration ─────────────────────────────────────────────────
+
+
+def _scope(headers: list[tuple[bytes, bytes]] | None = None) -> dict[str, Any]:
+    return {"type": "http", "method": "POST", "path": "/mcp", "headers": headers or []}
+
+
+async def _run(middleware: MCPAuthMiddleware, scope: dict) -> dict:
+    events: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event: dict):
+        events.append(event)
+
+    await middleware(scope, receive, send)
+    start = next(e for e in events if e["type"] == "http.response.start")
+    body = next((e for e in events if e["type"] == "http.response.body"), None)
+    headers = {k.decode().lower(): v.decode() for k, v in start.get("headers", [])}
+    return {
+        "status": start["status"],
+        "headers": headers,
+        "body": json.loads(body["body"]) if body and body.get("body") else None,
+    }
+
+
+class TestMiddleware:
+    @pytest.mark.asyncio
+    async def test_oauth_token_runs_app_as_principal(self, oauth_env):
+        captured: dict = {}
+
+        async def app(scope, receive, send):
+            from gateway.mcp import context as ctx
+
+            captured["auth"] = scope["state"]["auth"]
+            captured["org"] = ctx.mcp_org_id_var.get()
+            captured["scopes"] = ctx.mcp_scopes_var.get()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"{}", "more_body": False})
+
+        with _patch_clerk_get(_membership_response("org:admin")):
+            result = await _run(MCPAuthMiddleware(app), _scope([(b"authorization", f"Bearer {_mint()}".encode())]))
+
+        assert result["status"] == 200
+        assert captured["auth"]["auth_method"] == "oauth"
+        assert captured["auth"]["user_id"] == "user_123"
+        assert captured["org"] == "org_456"
+        assert "admin" in captured["scopes"]
+
+    @pytest.mark.asyncio
+    async def test_bad_oauth_token_gets_challenge(self, oauth_env):
+        async def app(scope, receive, send):
+            pytest.fail("must not reach the MCP app")
+
+        token = _mint(aud="https://evil.test/mcp")
+        result = await _run(MCPAuthMiddleware(app), _scope([(b"authorization", f"Bearer {token}".encode())]))
+        assert result["status"] == 401
+        assert "resource_metadata=" in result["headers"]["www-authenticate"]
+        assert result["body"]["error"] == "invalid_token"
+
+    @pytest.mark.asyncio
+    async def test_missing_org_gets_403_step_up(self, oauth_env):
+        async def app(scope, receive, send):
+            pytest.fail("must not reach the MCP app")
+
+        token = _mint(org_id=None)
+        result = await _run(MCPAuthMiddleware(app), _scope([(b"authorization", f"Bearer {token}".encode())]))
+        assert result["status"] == 403
+        assert 'error="insufficient_scope"' in result["headers"]["www-authenticate"]
+        assert 'scope="user:org:read"' in result["headers"]["www-authenticate"]
+
+    @pytest.mark.asyncio
+    async def test_no_credential_401_carries_challenge(self, oauth_env):
+        """The very first unauthenticated POST is how clients discover OAuth."""
+
+        async def app(scope, receive, send):
+            pytest.fail("must not reach the MCP app")
+
+        store = MagicMock()
+        store.list_api_keys = AsyncMock(return_value=[MagicMock()])
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        factory = MagicMock(return_value=session)
+        with (
+            patch("gateway.db.engine.get_session_factory", return_value=factory),
+            patch("gateway.store.Store", return_value=store),
+        ):
+            result = await _run(MCPAuthMiddleware(app), _scope())
+        assert result["status"] == 401
+        www = result["headers"]["www-authenticate"]
+        assert www.startswith("Bearer ")
+        assert f'resource_metadata="{PUBLIC_URL}/.well-known/oauth-protected-resource/mcp"' in www
+
+    @pytest.mark.asyncio
+    async def test_notebook_jwt_still_takes_notebook_path(self, oauth_env):
+        async def app(scope, receive, send):
+            pytest.fail("must not reach the MCP app")
+
+        token = jwt.encode({"iss": "signalpilot-notebook-session", "sub": "u"}, "secret", algorithm="HS256")
+        result = await _run(MCPAuthMiddleware(app), _scope([(b"authorization", f"Bearer {token}".encode())]))
+        assert result["status"] == 401
+        assert result["body"]["detail"] == "Invalid notebook session token."
+
+    @pytest.mark.asyncio
+    async def test_local_mode_ignores_oauth(self, oauth_env, monkeypatch):
+        monkeypatch.setenv("SP_DEPLOYMENT_MODE", "local")
+
+        async def app(scope, receive, send):
+            pytest.fail("must not reach the MCP app")
+
+        result = await _run(MCPAuthMiddleware(app), _scope([(b"authorization", f"Bearer {_mint()}".encode())]))
+        # Falls through to the notebook-session verifier, no OAuth challenge.
+        assert result["status"] == 401
+        assert "www-authenticate" not in result["headers"]

--- a/signalpilot/web/app/settings/mcp-connect/page.tsx
+++ b/signalpilot/web/app/settings/mcp-connect/page.tsx
@@ -21,6 +21,7 @@ import { SectionHeader } from "~/components/ui/section-header";
 import { useToast } from "~/components/ui/toast";
 import { ApiKeysSkeleton } from "~/components/ui/skeleton";
 import { McpAgentDefaultsSettings } from "~/components/settings/mcp-agent-defaults";
+import { McpOAuthConnect } from "~/components/settings/mcp-oauth-connect";
 
 // ---------------------------------------------------------------------------
 // MCP URL derivation
@@ -197,7 +198,7 @@ function McpConnectContent() {
       <PageHeader
         title="mcp connect"
         subtitle="integration"
-        description="connect mcp clients to signalpilot using your api key"
+        description="connect mcp clients to signalpilot by signing in, or with an api key"
       />
 
       <TerminalBar
@@ -216,10 +217,13 @@ function McpConnectContent() {
         </div>
       </TerminalBar>
 
-      {/* ── Section 1: Endpoint (hidden if no keys) ── */}
+      {/* ── Section 0: OAuth sign-in (needs no api key) ── */}
+      <McpOAuthConnect mcpUrl={mcpUrl} />
+
+      {/* ── Section 1: Endpoint with api-key auth (hidden if no keys) ── */}
       <McpAgentDefaultsSettings />
       {!hasKeys ? null : <section className="mb-8">
-        <SectionHeader icon={Plug} title="endpoint" />
+        <SectionHeader icon={Plug} title="endpoint (api key)" />
         <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] rounded-[14px] p-5 space-y-4">
           {/* URL row */}
           <div>
@@ -252,9 +256,9 @@ function McpConnectContent() {
         </div>
       </section>}
 
-      {/* ── Section 2: API Key ── */}
+      {/* ── Section 2: API Key (alternative for headless / ci clients) ── */}
       <section className="mb-8">
-        <SectionHeader icon={Key} title="api key" />
+        <SectionHeader icon={Key} title="api key (alternative)" />
         {keysError ? (
           <div className="border border-[var(--color-error)]/20 bg-[var(--color-error)]/5 rounded-[14px] p-4 flex items-start gap-3">
             <Info
@@ -314,11 +318,11 @@ function McpConnectContent() {
                 strokeWidth={1.5}
               />
               <div className="flex-1">
-                <p className="text-[12px] text-[var(--color-warning)] leading-relaxed mb-1 font-medium">
-                  an api key is required to connect mcp clients.
+                <p className="text-[12px] text-[var(--color-text-muted)] leading-relaxed mb-1 font-medium">
+                  no api key yet — that is fine for interactive clients.
                 </p>
                 <p className="text-[11px] text-[var(--color-text-dim)] leading-relaxed mb-3">
-                  create an api key first — without one, no mcp client (Claude Code, Cursor, etc.) can authenticate with SignalPilot.
+                  claude.ai, claude code and cursor sign in through oauth above. create an api key only for headless or ci clients that cannot open a browser.
                 </p>
                 <Link
                   href="/settings/api-keys"
@@ -333,9 +337,9 @@ function McpConnectContent() {
         )}
       </section>
 
-      {/* ── Section 3: Client Configuration (hidden if no keys) ── */}
+      {/* ── Section 3: API-key client configuration (hidden if no keys) ── */}
       {!hasKeys ? null : <section className="mb-8">
-        <SectionHeader icon={Terminal} title="client configuration" />
+        <SectionHeader icon={Terminal} title="client configuration (api key)" />
 
         {/* Tab selector */}
         <div role="tablist" className="flex items-center gap-0 mb-4 border border-[var(--color-border)] bg-[var(--color-bg-card)] rounded-[10px] overflow-hidden">

--- a/signalpilot/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/signalpilot/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { useSignIn, useAuth, useClerk } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
 import { AuthShell } from "~/components/auth/auth-shell";
+import { currentPostSignInRedirect } from "~/lib/auth/post-sign-in-redirect";
 import { Loader2 } from "lucide-react";
 
 const INPUT_CLASS =
@@ -41,7 +41,6 @@ export default function SignInPage() {
   const { isLoaded, signIn, setActive } = useSignIn();
   const { isSignedIn, orgId } = useAuth();
   const clerk = useClerk();
-  const router = useRouter();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -69,12 +68,13 @@ export default function SignInPage() {
     const activeSession = sessions.find((s: { status: string }) => s.status === "active");
 
     if (activeSession) {
-      // Fully active session — redirect based on org
+      // Fully active session — redirect based on org. A `redirect_url` from
+      // Clerk (OAuth consent for MCP clients) wins over the dashboard.
       setRedirecting(true);
       if (!orgId) {
         window.location.href = "/onboarding";
       } else {
-        window.location.href = "/dashboard";
+        window.location.href = clerk.buildUrlWithAuth(currentPostSignInRedirect());
       }
       return;
     }
@@ -110,7 +110,7 @@ export default function SignInPage() {
       await signIn!.authenticateWithRedirect({
         strategy,
         redirectUrl: "/sign-in/sso-callback",
-        redirectUrlComplete: "/dashboard",
+        redirectUrlComplete: currentPostSignInRedirect(),
       });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Social sign-in failed";
@@ -172,7 +172,7 @@ export default function SignInPage() {
 
       if (result.status === "complete") {
         await setActive!({ session: result.createdSessionId });
-        router.push("/dashboard");
+        window.location.href = clerk.buildUrlWithAuth(currentPostSignInRedirect());
       } else if (result.status === "needs_second_factor") {
         setStep("totp");
       } else {
@@ -200,7 +200,7 @@ export default function SignInPage() {
 
       if (result.status === "complete") {
         await setActive!({ session: result.createdSessionId });
-        router.push("/dashboard");
+        window.location.href = clerk.buildUrlWithAuth(currentPostSignInRedirect());
       } else {
         setError("Verification failed");
       }

--- a/signalpilot/web/components/settings/mcp-oauth-connect.tsx
+++ b/signalpilot/web/components/settings/mcp-oauth-connect.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, CheckCircle2, Info, LogIn, Terminal } from "lucide-react";
+import { SectionHeader } from "~/components/ui/section-header";
+import { CodeBlock } from "~/components/ui/code-block";
+
+/**
+ * "Sign in with SignalPilot" connection instructions for MCP clients.
+ *
+ * In cloud mode the gateway is an OAuth 2.1 resource server with Clerk as
+ * the authorization server. An MCP client only needs the server URL: its
+ * first request gets a 401 with a `WWW-Authenticate` challenge, it discovers
+ * Clerk from `/.well-known/oauth-protected-resource/mcp`, registers itself
+ * (dynamic client registration) and opens the Clerk sign-in + consent screen.
+ * No API key is involved.
+ */
+
+function CopyButton({ text, label = "copy" }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-[var(--color-text-dim)] border border-[var(--color-border)] rounded-[10px] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)] transition-colors duration-150 flex-shrink-0"
+      title={label}
+    >
+      {copied ? (
+        <>
+          <CheckCircle2 className="w-3 h-3 text-[var(--color-success)]" />
+          <span className="text-[var(--color-success)]">copied</span>
+        </>
+      ) : (
+        <>
+          <Copy className="w-3 h-3" />
+          {label}
+        </>
+      )}
+    </button>
+  );
+}
+
+export function claudeCodeAddCommand(mcpUrl: string): string {
+  return `claude mcp add --transport http signalpilot ${mcpUrl}`;
+}
+
+export function oauthClientConfig(mcpUrl: string): string {
+  return JSON.stringify({ mcpServers: { signalpilot: { type: "http", url: mcpUrl } } }, null, 2);
+}
+
+export function McpOAuthConnect({ mcpUrl }: { mcpUrl: string }) {
+  const addCommand = claudeCodeAddCommand(mcpUrl);
+
+  return (
+    <section className="mb-8">
+      <SectionHeader icon={LogIn} title="sign in with signalpilot (oauth)" />
+      <div className="border border-[var(--color-border)] bg-[var(--color-bg-card)] rounded-[14px] p-5 space-y-5">
+        <div>
+          <p className="text-[11px] text-[var(--color-text-dim)] uppercase tracking-[0.08em] mb-2">
+            mcp server url
+          </p>
+          <div className="flex items-center gap-3">
+            <code className="flex-1 px-3 py-2.5 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-[10px] text-[13px] text-[var(--color-success)] font-mono break-all">
+              {mcpUrl}
+            </code>
+            <CopyButton text={mcpUrl} label="copy url" />
+          </div>
+          <p className="text-[12px] text-[var(--color-text-dim)] leading-relaxed mt-3">
+            paste this url into any mcp client. the client opens the signalpilot sign-in page,
+            you pick your organization, and the connection is authorized as you. no api key needed.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="border border-[var(--color-border)] rounded-[10px] p-4">
+            <p className="text-[11px] text-[var(--color-text-dim)] uppercase tracking-[0.08em] mb-2">
+              claude.ai / claude desktop
+            </p>
+            <ol className="text-[12px] text-[var(--color-text-muted)] leading-relaxed list-decimal pl-4 space-y-1">
+              <li>settings → connectors → add custom connector</li>
+              <li>paste the mcp server url above</li>
+              <li>click connect and sign in with your signalpilot account</li>
+            </ol>
+          </div>
+          <div className="border border-[var(--color-border)] rounded-[10px] p-4">
+            <p className="text-[11px] text-[var(--color-text-dim)] uppercase tracking-[0.08em] mb-2">
+              claude code
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 px-2.5 py-2 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-[8px] text-[11px] text-[var(--color-text)] font-mono break-all">
+                {addCommand}
+              </code>
+              <CopyButton text={addCommand} />
+            </div>
+            <p className="text-[11px] text-[var(--color-text-dim)] leading-relaxed mt-2">
+              then run <code className="text-[var(--color-text-muted)]">/mcp</code> inside claude code to sign in.
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center gap-2 mb-2">
+            <Terminal className="w-3.5 h-3.5 text-[var(--color-text-dim)]" strokeWidth={1.5} />
+            <span className="text-[11px] text-[var(--color-text-dim)] tracking-wider uppercase">
+              cursor / other clients (.mcp.json)
+            </span>
+          </div>
+          <CodeBlock code={oauthClientConfig(mcpUrl)} language="json" maxHeight="12rem" showLineNumbers={false} />
+        </div>
+
+        <div className="flex items-start gap-2 p-3 border border-[var(--color-border)] bg-[var(--color-bg)] rounded-[10px]">
+          <Info className="w-3.5 h-3.5 text-[var(--color-text-dim)] mt-0.5 flex-shrink-0" strokeWidth={1.5} />
+          <p className="text-[12px] text-[var(--color-text-dim)] leading-relaxed">
+            your access follows your organization role: admins get the full tool set, members get
+            everything except admin-only tools. api keys below remain available for headless or
+            ci usage.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/signalpilot/web/lib/auth/post-sign-in-redirect.test.ts
+++ b/signalpilot/web/lib/auth/post-sign-in-redirect.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { clerkFrontendApiOrigin, clerkTrustedOrigins, resolvePostSignInRedirect } from "./post-sign-in-redirect";
+
+// "endless-fly-19.clerk.accounts.dev$" base64-encoded, the way Clerk builds publishable keys.
+const PK = "pk_test_" + Buffer.from("endless-fly-19.clerk.accounts.dev$").toString("base64").replace(/=+$/, "");
+const CLERK = "https://endless-fly-19.clerk.accounts.dev";
+
+describe("clerkFrontendApiOrigin", () => {
+  it("derives the frontend api origin from the publishable key", () => {
+    expect(clerkFrontendApiOrigin(PK)).toBe(CLERK);
+  });
+  it("returns null for junk", () => {
+    expect(clerkFrontendApiOrigin(undefined)).toBeNull();
+    expect(clerkFrontendApiOrigin("sk_test_nope")).toBeNull();
+    expect(clerkFrontendApiOrigin("pk_test_%%%")).toBeNull();
+  });
+});
+
+describe("clerkTrustedOrigins", () => {
+  it("includes the account portal for dev instances", () => {
+    expect(clerkTrustedOrigins(PK)).toEqual([CLERK, "https://endless-fly-19.accounts.dev"]);
+  });
+  it("includes the account portal for production instances", () => {
+    const prod = "pk_live_" + Buffer.from("clerk.signalpilot.ai$").toString("base64").replace(/=+$/, "");
+    expect(clerkTrustedOrigins(prod)).toEqual(["https://clerk.signalpilot.ai", "https://accounts.signalpilot.ai"]);
+  });
+});
+
+describe("resolvePostSignInRedirect", () => {
+  it("allows the account portal consent page", () => {
+    const target = "https://endless-fly-19.accounts.dev/oauth-consent?__clerk_db_jwt=dvb_x&scope=openid";
+    expect(resolvePostSignInRedirect(`?redirect_url=${encodeURIComponent(target)}`, { publishableKey: PK })).toBe(target);
+  });
+
+  it("falls back to the dashboard without a redirect_url", () => {
+    expect(resolvePostSignInRedirect("")).toBe("/dashboard");
+    expect(resolvePostSignInRedirect("?foo=bar", { fallback: "/onboarding" })).toBe("/onboarding");
+  });
+
+  it("allows same-origin paths", () => {
+    expect(resolvePostSignInRedirect("?redirect_url=%2Fprojects%2F1")).toBe("/projects/1");
+  });
+
+  it("rejects protocol-relative and foreign absolute urls", () => {
+    expect(resolvePostSignInRedirect("?redirect_url=//evil.test/x", { publishableKey: PK })).toBe("/dashboard");
+    expect(resolvePostSignInRedirect("?redirect_url=https://evil.test/x", { publishableKey: PK })).toBe("/dashboard");
+    expect(resolvePostSignInRedirect("?redirect_url=javascript:alert(1)", { publishableKey: PK })).toBe("/dashboard");
+  });
+
+  it("allows the Clerk authorize continuation url so OAuth consent can finish", () => {
+    const target = `${CLERK}/oauth/authorize-with-immediate-redirect?client_id=abc&state=1`;
+    const search = `?redirect_url=${encodeURIComponent(target)}`;
+    expect(resolvePostSignInRedirect(search, { publishableKey: PK })).toBe(target);
+  });
+
+  it("does not trust Clerk urls when the publishable key is unknown", () => {
+    const target = `${CLERK}/oauth/authorize`;
+    expect(resolvePostSignInRedirect(`?redirect_url=${encodeURIComponent(target)}`)).toBe("/dashboard");
+  });
+});

--- a/signalpilot/web/lib/auth/post-sign-in-redirect.ts
+++ b/signalpilot/web/lib/auth/post-sign-in-redirect.ts
@@ -1,0 +1,84 @@
+/**
+ * Where to send a user after they sign in.
+ *
+ * Clerk redirects OAuth authorization requests from signed-out users to our
+ * sign-in page with `?redirect_url=<Clerk authorize URL>`. Once the session
+ * exists we must send the browser back there so the OAuth consent flow (MCP
+ * clients signing in with SignalPilot) can finish. Only two destinations are
+ * honoured, everything else falls back, so this can never be an open redirect:
+ *
+ * - a same-origin path (`/projects/123`)
+ * - an absolute URL on a Clerk-hosted origin derived from the publishable key:
+ *   the Frontend API (`https://clerk.example.com`, `https://x.clerk.accounts.dev`)
+ *   or the Account Portal that serves the OAuth consent screen
+ *   (`https://accounts.example.com`, `https://x.accounts.dev`)
+ */
+
+export const DEFAULT_POST_SIGN_IN_PATH = "/dashboard";
+
+export function clerkFrontendApiOrigin(publishableKey: string | undefined): string | null {
+  if (!publishableKey) return null;
+  const match = /^pk_(?:test|live)_(.+)$/.exec(publishableKey.trim());
+  if (!match) return null;
+  try {
+    const decoded = atob(match[1].padEnd(match[1].length + ((4 - (match[1].length % 4)) % 4), "="));
+    const domain = decoded.replace(/\$$/, "");
+    if (!/^[a-z0-9.-]+$/i.test(domain)) return null;
+    return `https://${domain}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Clerk-hosted origins a post-sign-in redirect may target. */
+export function clerkTrustedOrigins(publishableKey: string | undefined): string[] {
+  const fapi = clerkFrontendApiOrigin(publishableKey);
+  if (!fapi) return [];
+  const host = fapi.slice("https://".length);
+  const origins = [fapi];
+  if (host.endsWith(".clerk.accounts.dev")) {
+    origins.push(`https://${host.replace(".clerk.accounts.dev", ".accounts.dev")}`);
+  } else if (host.startsWith("clerk.")) {
+    origins.push(`https://accounts.${host.slice("clerk.".length)}`);
+  }
+  return origins;
+}
+
+export function resolvePostSignInRedirect(
+  search: string,
+  options: { publishableKey?: string; fallback?: string } = {},
+): string {
+  const fallback = options.fallback ?? DEFAULT_POST_SIGN_IN_PATH;
+  let target: string | null;
+  try {
+    target = new URLSearchParams(search).get("redirect_url");
+  } catch {
+    return fallback;
+  }
+  if (!target) return fallback;
+  target = target.trim();
+
+  // Same-origin path: "/x" but not protocol-relative "//evil".
+  if (target.startsWith("/") && !target.startsWith("//") && !target.startsWith("/\\")) {
+    return target;
+  }
+
+  const trusted = clerkTrustedOrigins(options.publishableKey).map((o) => o.toLowerCase());
+  if (!trusted.length) return fallback;
+  try {
+    const url = new URL(target);
+    if (url.protocol === "https:" && trusted.includes(url.origin.toLowerCase())) return url.toString();
+  } catch {
+    // not an absolute URL
+  }
+  return fallback;
+}
+
+/** Browser convenience: resolve from the current location. */
+export function currentPostSignInRedirect(fallback?: string): string {
+  if (typeof window === "undefined") return fallback ?? DEFAULT_POST_SIGN_IN_PATH;
+  return resolvePostSignInRedirect(window.location.search, {
+    publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    fallback,
+  });
+}


### PR DESCRIPTION
## Summary

`/mcp` becomes an OAuth 2.1 **resource server** with Clerk as the authorization server. MCP clients (Claude.ai, Claude Code, Cursor) now connect with just the server URL and sign in with their SignalPilot account — no API key. API keys and notebook session JWTs keep working unchanged; local mode has no OAuth.

**Gateway**
- `gateway/auth/mcp_oauth.py` — RFC 9728 metadata, `WWW-Authenticate` challenge, Clerk JWT verification (RS256 via JWKS, issuer pinned, `aud` must equal the canonical `/mcp` URL), opaque-token introspection fallback, org role lookup via Clerk Backend API → gateway scopes (`org:admin` → all scopes; member → all but `admin`).
- `gateway/api/oauth_metadata.py` — public `/.well-known/oauth-protected-resource[/mcp]`, `/.well-known/oauth-authorization-server`, `/.well-known/openid-configuration` (Clerk metadata mirrored). 404 when OAuth is off.
- `MCPAuthMiddleware` — Clerk bearer branch; every `/mcp` 401 carries the discovery challenge; missing `org_id` → 403 `insufficient_scope` step-up with `scope="user:org:read"`.
- Config: `SP_MCP_OAUTH_DISABLED`, `SP_MCP_OAUTH_RESOURCE_URL` (default `{SP_PUBLIC_GATEWAY_URL}/mcp`), `SP_MCP_OAUTH_REQUIRE_AUDIENCE` (default true).

**Web**
- Sign-in page honours Clerk's `redirect_url` (same-origin paths or Clerk-hosted origins derived from the publishable key only) so the consent flow can finish after login.
- `/settings/mcp-connect`: OAuth is the primary connection method; API keys are the alternative for headless/CI clients.

## Clerk configuration required per instance

Done on the **staging** instance via Backend API: dynamic client registration on, JWT access tokens on, `aud` claim on, PKCE required, default scopes `openid profile email user:org:read`; pre-registered public app "SignalPilot MCP (Claude)" with the claude.ai / claude.com callbacks; instance sign-in URL fixed to the staging web. **Prod needs the same before a prod deploy.**

## Test plan

- [x] `tests/test_mcp_oauth.py` — 31 tests (discovery docs, challenge header, issuer/audience/expiry/org checks, role→scope mapping, middleware branch, local mode unaffected)
- [x] `lib/auth/post-sign-in-redirect.test.ts` — 10 tests (open-redirect protection)
- [x] Live on the local staging stack behind ngrok: Clerk sign-in → consent → PKCE code exchange → JWT with `aud=<mcp url>`, `org_id`, `client_id` → gateway `initialize` / `tools/list` 200; unauthenticated POST → 401 + challenge; DCR against Clerk works; bogus `sp_` keys still get "Invalid API key"
- [x] Pre-existing failures in `test_mcp_auth.py` / `test_auth_enforcement.py` / `test_security_hardening.py` are identical on untouched HEAD (checked in a temp worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq2dHd6xxU4vZvpovGf8Xy
